### PR TITLE
chore: export configuration types

### DIFF
--- a/crates/connectors/ndc-postgres/src/configuration.rs
+++ b/crates/connectors/ndc-postgres/src/configuration.rs
@@ -17,9 +17,12 @@ pub use version1::{
     validate_raw_configuration,
     Configuration,
     ConfigurationError,
+    ConnectionUri,
     ConnectionUris,
+    HasuraRegionName,
     PoolSettings,
     RawConfiguration,
+    RegionName,
 };
 
 pub const CURRENT_VERSION: u32 = 1;


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

`v3-metadata-build-service` needs to use our `ConnectionUri` and other types, but they are not exported.

### How

Export them.