### PR TITLE
chore: Add OpenTelemetry env vars when running engine

### DIFF
--- a/justfile
+++ b/justfile
@@ -225,7 +225,9 @@ run-engine: start-dependencies
   @echo "http://localhost:4002/ for jaeger console"
   # Run graphql-engine using static Chinook metadata
   # we expect the `v3-engine` repo to live next door to this one
-  RUST_LOG=DEBUG cargo run --release \
+  RUST_LOG=DEBUG \
+  OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4317 \
+    cargo run --release \
     --manifest-path ../v3-engine/Cargo.toml \
     --bin engine -- \
     --metadata-path ./static/chinook-metadata.json


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

Quality of life change - when running engine for testing, ensure we tell it where Jaeger etc live so that we can test tracing too.

### How

Pass `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4317` when running `just run-engine`.