### PR TITLE
Shorten the "slow" timeout for cargo-nextest.

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,7 @@
+# This is extended configuration for the `cargo nextest` test runner.
+# It will not be applied when using `cargo test`.
+
+[profile.default]
+# Mark any test that takes longer than 15 seconds as "slow",
+# and terminate and fail the test after 60 seconds.
+slow-timeout = { period = "15s", terminate-after = 4 }


### PR DESCRIPTION
### What

This reduces the "slow" timeout from 1 minute to 15 seconds, and the "termination" timeout from 10 minutes to 1 minute.

It does nothing for `cargo test`, which does not support timing out test cases.

### How

I added some configuration to _.config/nextest.toml_.