### PR TITLE
chore: fix trace propagation with new `ndc-hub`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,17 +1466,19 @@ dependencies = [
 [[package]]
 name = "ndc-sdk"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-hub.git?rev=662b9b7#662b9b7d058e06bd431988fa7017212589fd96c2"
+source = "git+https://github.com/hasura/ndc-hub.git?rev=3248df5#3248df5c1ab4a26ad4cbe860015ef6f31b3ec7a1"
 dependencies = [
  "async-trait",
  "axum",
  "axum-macros",
  "clap",
  "gdc_rust_types",
+ "http",
  "indexmap 1.9.3",
  "ndc-client",
  "ndc-test",
  "opentelemetry",
+ "opentelemetry-http",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_api",

--- a/crates/connectors/ndc-citus/Cargo.toml
+++ b/crates/connectors/ndc-citus/Cargo.toml
@@ -14,7 +14,7 @@ name = "ndc-citus"
 path = "bin/main.rs"
 
 [dependencies]
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "662b9b7", package = "ndc-sdk" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "3248df5", package = "ndc-sdk" }
 ndc-postgres = { path = "../ndc-postgres" }
 
 async-trait = "0.1.73"

--- a/crates/connectors/ndc-cockroach/Cargo.toml
+++ b/crates/connectors/ndc-cockroach/Cargo.toml
@@ -14,7 +14,7 @@ name = "ndc-cockroach"
 path = "bin/main.rs"
 
 [dependencies]
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "662b9b7", package = "ndc-sdk" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "3248df5", package = "ndc-sdk" }
 ndc-postgres = { path = "../ndc-postgres" }
 
 async-trait = "0.1.73"

--- a/crates/connectors/ndc-postgres/Cargo.toml
+++ b/crates/connectors/ndc-postgres/Cargo.toml
@@ -15,7 +15,7 @@ path = "bin/main.rs"
 
 [dependencies]
 
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "662b9b7", package = "ndc-sdk" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "3248df5", package = "ndc-sdk" }
 query-engine-execution = { path = "../../query-engine/execution" }
 query-engine-metadata = { path = "../../query-engine/metadata" }
 query-engine-sql = { path = "../../query-engine/sql" }

--- a/crates/query-engine/execution/Cargo.toml
+++ b/crates/query-engine/execution/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "662b9b7", package = "ndc-sdk" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "3248df5", package = "ndc-sdk" }
 
 query-engine-sql = { path = "../sql" }
 

--- a/crates/query-engine/translation/Cargo.toml
+++ b/crates/query-engine/translation/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 [dependencies]
 
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "662b9b7", package = "ndc-sdk" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "3248df5", package = "ndc-sdk" }
 
 query-engine-metadata = { path = "../metadata" }
 query-engine-sql = { path = "../sql" }

--- a/crates/tests/other-db-tests/Cargo.toml
+++ b/crates/tests/other-db-tests/Cargo.toml
@@ -12,7 +12,7 @@ aurora = []
 [dependencies]
 
 tests-common = { path = "../tests-common" }
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "662b9b7", package = "ndc-sdk" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "3248df5", package = "ndc-sdk" }
 ndc-postgres = { path = "../../connectors/ndc-postgres" }
 
 axum = "0.6.19"

--- a/crates/tests/tests-common/Cargo.toml
+++ b/crates/tests/tests-common/Cargo.toml
@@ -8,7 +8,7 @@ name = "tests_common"
 path = "src/lib.rs"
 
 [dependencies]
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "662b9b7", package = "ndc-sdk" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "3248df5", package = "ndc-sdk" }
 
 axum = "0.6.19"
 axum-test-helper = "0.3.0"


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

`ndc-multitenant` had trace propagation, but single tenant connectors didn't. Added it to `ndc-hub` so we could use it here. This is helpful for performance work.

<img width="1758" alt="Screenshot 2023-10-03 at 16 28 35" src="https://github.com/hasura/ndc-postgres/assets/4729125/3549f612-61a3-4253-a390-68ba2ab0c6a9">

### How

Use new `ndc-hub` commit.
