### PR TITLE
Add `order_by` clauses absolutely everywhere.

### DIFF
--- a/crates/connectors/ndc-citus/tests/explain_tests.rs
+++ b/crates/connectors/ndc-citus/tests/explain_tests.rs
@@ -21,7 +21,13 @@ async fn select_where_variable() {
 #[tokio::test]
 async fn select_where_name_nilike() {
     let result = run_explain(create_router().await, "select_where_name_nilike").await;
-    let keywords = vec!["Aggregate", "Subquery Scan", "Limit", "Seq Scan", "Filter"];
+    let keywords = vec![
+        "Aggregate",
+        "Subquery Scan",
+        "Limit",
+        "Index Scan",
+        "Filter",
+    ];
     is_contained_in_lines(keywords, result.details.plan);
     insta::assert_snapshot!(result.details.query);
 }

--- a/crates/connectors/ndc-citus/tests/snapshots/explain_tests__select_where_name_nilike.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/explain_tests__select_where_name_nilike.snap
@@ -24,6 +24,8 @@ FROM
                 true
                 AND ("%0_Album"."Title" NOT ILIKE cast($1 as varchar))
               )
+            ORDER BY
+              "%0_Album"."AlbumId" ASC
             LIMIT
               5
           ) AS "%2_rows"

--- a/crates/connectors/ndc-citus/tests/snapshots/explain_tests__select_where_variable.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/explain_tests__select_where_variable.snap
@@ -21,6 +21,8 @@ FROM
               "public"."Album" AS "%0_Album"
             WHERE
               ("%0_Album"."Title" LIKE $1)
+            ORDER BY
+              "%0_Album"."AlbumId" ASC
           ) AS "%2_rows"
       ) AS "%2_rows"
   ) AS "%1_universe"

--- a/crates/connectors/ndc-cockroach/tests/snapshots/explain_tests__select_where_name_nilike.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/explain_tests__select_where_name_nilike.snap
@@ -24,6 +24,8 @@ FROM
                 true
                 AND ("%0_Album"."Title" NOT ILIKE cast($1 as varchar))
               )
+            ORDER BY
+              "%0_Album"."AlbumId" ASC
             LIMIT
               5
           ) AS "%2_rows"

--- a/crates/connectors/ndc-cockroach/tests/snapshots/explain_tests__select_where_variable.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/explain_tests__select_where_variable.snap
@@ -21,6 +21,8 @@ FROM
               "public"."Album" AS "%0_Album"
             WHERE
               ("%0_Album"."Title" LIKE $1)
+            ORDER BY
+              "%0_Album"."AlbumId" ASC
           ) AS "%2_rows"
       ) AS "%2_rows"
   ) AS "%1_universe"

--- a/crates/connectors/ndc-postgres/tests/explain_tests.rs
+++ b/crates/connectors/ndc-postgres/tests/explain_tests.rs
@@ -21,7 +21,13 @@ async fn select_where_variable() {
 #[tokio::test]
 async fn select_where_name_nilike() {
     let result = run_explain(create_router().await, "select_where_name_nilike").await;
-    let keywords = vec!["Aggregate", "Subquery Scan", "Limit", "Seq Scan", "Filter"];
+    let keywords = vec![
+        "Aggregate",
+        "Subquery Scan",
+        "Limit",
+        "Index Scan",
+        "Filter",
+    ];
     is_contained_in_lines(keywords, result.details.plan);
     insta::assert_snapshot!(result.details.query);
 }

--- a/crates/connectors/ndc-postgres/tests/snapshots/explain_tests__select_where_name_nilike.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/explain_tests__select_where_name_nilike.snap
@@ -24,6 +24,8 @@ FROM
                 true
                 AND ("%0_Album"."Title" NOT ILIKE cast($1 as varchar))
               )
+            ORDER BY
+              "%0_Album"."AlbumId" ASC
             LIMIT
               5
           ) AS "%2_rows"

--- a/crates/connectors/ndc-postgres/tests/snapshots/explain_tests__select_where_variable.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/explain_tests__select_where_variable.snap
@@ -21,6 +21,8 @@ FROM
               "public"."Album" AS "%0_Album"
             WHERE
               ("%0_Album"."Title" LIKE $1)
+            ORDER BY
+              "%0_Album"."AlbumId" ASC
           ) AS "%2_rows"
       ) AS "%2_rows"
   ) AS "%1_universe"

--- a/crates/query-engine/translation/tests/goldenfiles/native_queries/select_artist_with_album_by_title/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/native_queries/select_artist_with_album_by_title/request.json
@@ -26,6 +26,18 @@
         }
       }
     },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "ArtistId",
+            "path": []
+          }
+        }
+      ]
+    },
     "limit": 5
   },
   "arguments": {},

--- a/crates/query-engine/translation/tests/goldenfiles/native_queries/select_artist_with_album_by_title_relationship_arguments/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/native_queries/select_artist_with_album_by_title_relationship_arguments/request.json
@@ -22,9 +22,33 @@
               "type": "column",
               "column": "Title"
             }
+          },
+          "order_by": {
+            "elements": [
+              {
+                "order_direction": "asc",
+                "target": {
+                  "type": "column",
+                  "name": "AlbumId",
+                  "path": []
+                }
+              }
+            ]
           }
         }
       }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "ArtistId",
+            "path": []
+          }
+        }
+      ]
     },
     "limit": 5
   },

--- a/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_with_album_by_title.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_with_album_by_title.snap
@@ -61,6 +61,8 @@ FROM
                       ) AS "%5_rows"
                   ) AS "%2_RELATIONSHIP_Albums"
               ) AS "%2_RELATIONSHIP_Albums" ON ('true')
+            ORDER BY
+              "%0_artist"."ArtistId" ASC
             LIMIT
               5
           ) AS "%8_rows"

--- a/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_with_album_by_title_relationship_arguments.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_with_album_by_title_relationship_arguments.snap
@@ -58,10 +58,14 @@ FROM
                                   "%0_artist"."ArtistId" = "%3_album_by_title"."ArtistId"
                                 )
                               )
+                            ORDER BY
+                              "%3_album_by_title"."AlbumId" ASC
                           ) AS "%5_rows"
                       ) AS "%5_rows"
                   ) AS "%2_RELATIONSHIP_Albums"
               ) AS "%2_RELATIONSHIP_Albums" ON ('true')
+            ORDER BY
+              "%0_artist"."ArtistId" ASC
             LIMIT
               5
           ) AS "%8_rows"

--- a/crates/tests/tests-common/goldenfiles/aggregate_count_albums_plus_field.json
+++ b/crates/tests/tests-common/goldenfiles/aggregate_count_albums_plus_field.json
@@ -8,6 +8,18 @@
         "arguments": {}
       }
     },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
+    },
     "limit": 5,
     "offset": 3,
     "aggregates": {

--- a/crates/tests/tests-common/goldenfiles/aggregate_count_artist_albums.json
+++ b/crates/tests/tests-common/goldenfiles/aggregate_count_artist_albums.json
@@ -20,6 +20,18 @@
         }
       }
     },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "ArtistId",
+            "path": []
+          }
+        }
+      ]
+    },
     "limit": 5,
     "offset": 1
   },

--- a/crates/tests/tests-common/goldenfiles/aggregate_count_artist_albums_plus_field.json
+++ b/crates/tests/tests-common/goldenfiles/aggregate_count_artist_albums_plus_field.json
@@ -19,6 +19,18 @@
               "arguments": {}
             }
           },
+          "order_by": {
+            "elements": [
+              {
+                "order_direction": "asc",
+                "target": {
+                  "type": "column",
+                  "name": "AlbumId",
+                  "path": []
+                }
+              }
+            ]
+          },
           "aggregates": {
             "how_many_albums": {
               "type": "star_count"
@@ -26,6 +38,18 @@
           }
         }
       }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "ArtistId",
+            "path": []
+          }
+        }
+      ]
     },
     "limit": 5,
     "offset": 1

--- a/crates/tests/tests-common/goldenfiles/dup_array_relationship.json
+++ b/crates/tests/tests-common/goldenfiles/dup_array_relationship.json
@@ -13,6 +13,18 @@
               "column": "Title",
               "arguments": {}
             }
+          },
+          "order_by": {
+            "elements": [
+              {
+                "order_direction": "asc",
+                "target": {
+                  "type": "column",
+                  "name": "AlbumId",
+                  "path": []
+                }
+              }
+            ]
           }
         }
       },
@@ -27,9 +39,33 @@
               "column": "Title",
               "arguments": {}
             }
+          },
+          "order_by": {
+            "elements": [
+              {
+                "order_direction": "asc",
+                "target": {
+                  "type": "column",
+                  "name": "AlbumId",
+                  "path": []
+                }
+              }
+            ]
           }
         }
       }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "ArtistId",
+            "path": []
+          }
+        }
+      ]
     },
     "limit": 3
   },

--- a/crates/tests/tests-common/goldenfiles/native_queries/select_artist_with_album_by_title_relationship_arguments.json
+++ b/crates/tests/tests-common/goldenfiles/native_queries/select_artist_with_album_by_title_relationship_arguments.json
@@ -22,9 +22,33 @@
               "type": "column",
               "column": "Title"
             }
+          },
+          "order_by": {
+            "elements": [
+              {
+                "order_direction": "asc",
+                "target": {
+                  "type": "column",
+                  "name": "AlbumId",
+                  "path": []
+                }
+              }
+            ]
           }
         }
       }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "ArtistId",
+            "path": []
+          }
+        }
+      ]
     },
     "limit": 7,
     "offset": 140

--- a/crates/tests/tests-common/goldenfiles/select_5.json
+++ b/crates/tests/tests-common/goldenfiles/select_5.json
@@ -8,6 +8,18 @@
         "arguments": {}
       }
     },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
+    },
     "limit": 5,
     "offset": 3
   },

--- a/crates/tests/tests-common/goldenfiles/select_where_album_id_greater_than.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_album_id_greater_than.json
@@ -28,6 +28,18 @@
         "type": "scalar",
         "value": 340
       }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
     }
   },
   "arguments": {},

--- a/crates/tests/tests-common/goldenfiles/select_where_album_id_greater_than_or_equal_to.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_album_id_greater_than_or_equal_to.json
@@ -28,6 +28,18 @@
         "type": "scalar",
         "value": 340
       }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
     }
   },
   "arguments": {},

--- a/crates/tests/tests-common/goldenfiles/select_where_album_id_is_not_null.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_album_id_is_not_null.json
@@ -21,6 +21,18 @@
           "path": []
         }
       }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
     }
   },
   "arguments": {},

--- a/crates/tests/tests-common/goldenfiles/select_where_album_id_less_than.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_album_id_less_than.json
@@ -28,6 +28,18 @@
         "type": "scalar",
         "value": 1
       }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
     }
   },
   "arguments": {},

--- a/crates/tests/tests-common/goldenfiles/select_where_album_id_less_than_or_equal_to.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_album_id_less_than_or_equal_to.json
@@ -28,6 +28,18 @@
         "type": "scalar",
         "value": 1
       }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
     }
   },
   "arguments": {},

--- a/crates/tests/tests-common/goldenfiles/select_where_name_ilike.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_name_ilike.json
@@ -28,6 +28,18 @@
         "type": "scalar",
         "value": "%rock%"
       }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
     }
   },
   "arguments": {},

--- a/crates/tests/tests-common/goldenfiles/select_where_name_iregex.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_name_iregex.json
@@ -29,6 +29,18 @@
         "type": "scalar",
         "value": "[j]agged little pill"
       }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
     }
   },
   "arguments": {},

--- a/crates/tests/tests-common/goldenfiles/select_where_name_like.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_name_like.json
@@ -28,6 +28,18 @@
         "type": "scalar",
         "value": "%Rock%"
       }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
     }
   },
   "arguments": {},

--- a/crates/tests/tests-common/goldenfiles/select_where_name_nilike.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_name_nilike.json
@@ -29,6 +29,18 @@
           }
         }
       ]
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
     }
   },
   "arguments": {},

--- a/crates/tests/tests-common/goldenfiles/select_where_name_niregex.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_name_niregex.json
@@ -29,6 +29,18 @@
         "type": "scalar",
         "value": "[j]agged little pill"
       }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
     }
   },
   "arguments": {},

--- a/crates/tests/tests-common/goldenfiles/select_where_name_not_in.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_name_not_in.json
@@ -35,6 +35,18 @@
           }
         ]
       }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
     }
   },
   "arguments": {},

--- a/crates/tests/tests-common/goldenfiles/select_where_name_not_like.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_name_not_like.json
@@ -32,6 +32,18 @@
           "value": "%Rock%"
         }
       }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
     }
   },
   "arguments": {},

--- a/crates/tests/tests-common/goldenfiles/select_where_name_nregex.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_name_nregex.json
@@ -29,6 +29,18 @@
         "type": "scalar",
         "value": "[J]agged Little Pill"
       }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
     }
   },
   "arguments": {},

--- a/crates/tests/tests-common/goldenfiles/select_where_name_nsimilar.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_name_nsimilar.json
@@ -1,7 +1,6 @@
 {
   "collection": "Album",
   "query": {
-    "limit": 5,
     "fields": {
       "AlbumId": {
         "type": "column",
@@ -29,7 +28,20 @@
         "type": "scalar",
         "value": "(R|B)%"
       }
-    }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
+    },
+    "limit": 5
   },
   "arguments": {},
   "collection_relationships": {}

--- a/crates/tests/tests-common/goldenfiles/select_where_name_regex.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_name_regex.json
@@ -29,6 +29,18 @@
         "type": "scalar",
         "value": "[J]agged Little Pill"
       }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
     }
   },
   "arguments": {},

--- a/crates/tests/tests-common/goldenfiles/select_where_name_similar.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_name_similar.json
@@ -29,6 +29,18 @@
         "type": "scalar",
         "value": "(R|B)%"
       }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
     }
   },
   "arguments": {},

--- a/crates/tests/tests-common/goldenfiles/select_where_or.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_or.json
@@ -33,6 +33,18 @@
           ]
         }
       ]
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
     }
   },
   "arguments": {},

--- a/crates/tests/tests-common/goldenfiles/select_where_related_exists.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_related_exists.json
@@ -18,6 +18,18 @@
               "column": "Title",
               "arguments": {}
             }
+          },
+          "order_by": {
+            "elements": [
+              {
+                "order_direction": "asc",
+                "target": {
+                  "type": "column",
+                  "name": "AlbumId",
+                  "path": []
+                }
+              }
+            ]
           }
         }
       }
@@ -45,6 +57,18 @@
           "value": "Supernatural"
         }
       }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "ArtistId",
+            "path": []
+          }
+        }
+      ]
     }
   },
   "arguments": {},

--- a/crates/tests/tests-common/goldenfiles/select_where_unrelated_exists.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_unrelated_exists.json
@@ -53,6 +53,18 @@
           }
         ]
       }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
     }
   },
   "arguments": {},

--- a/crates/tests/tests-common/goldenfiles/select_where_variable.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_variable.json
@@ -23,6 +23,18 @@
         "type": "variable",
         "name": "search"
       }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
     }
   },
   "arguments": {},

--- a/crates/tests/tests-common/src/assert.rs
+++ b/crates/tests/tests-common/src/assert.rs
@@ -5,6 +5,11 @@
 /// snapshot testing because small details (like cost) can change from
 /// run to run rendering the output unstable.
 pub fn is_contained_in_lines(keywords: Vec<&str>, lines: String) {
-    tracing::info!("expected keywords: {:?}\nlines: {}", keywords, lines,);
-    assert!(keywords.iter().all(|&s| lines.contains(s)));
+    tracing::info!("expected keywords: {:?}\nlines:\n{}", keywords, lines);
+    assert!(
+        keywords.iter().all(|&s| lines.contains(s)),
+        "expected keywords: {:?}\nlines:\n{}",
+        keywords,
+        lines
+    );
 }


### PR DESCRIPTION
### What

We can't have deterministic snapshots without `ORDER BY`. PostgreSQL is generous and generally orders by the primary key for small datasets, but Yugabyte and other databases are not so forgiving.

### How

I have added `order_by` clauses to the goldenfiles pretty much wherever we expect multiple results.

The `EXPLAIN` snapshots needed to be updated, but none others.