### PR TITLE
Nix: Add `perf` to the shell dependencies.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -139,7 +139,11 @@
             pkgs.skopeo
             pkgs.nodePackages.prettier
             rustToolchain
-          ];
+          ] ++ (
+            pkgs.lib.optionals
+              pkgs.stdenv.isLinux
+              [ pkgs.linuxPackages_latest.perf ]
+          );
         };
       });
 }


### PR DESCRIPTION
### What

`cargo-flamegraph` depends on access to the `perf` utility on Linux.

This adds it to the dependencies.

### How

Trivially.
