### PR TITLE
Avoid cloning metadata for `Env`.

### DIFF
--- a/crates/query-engine/translation/src/translation/query/helpers.rs
+++ b/crates/query-engine/translation/src/translation/query/helpers.rs
@@ -10,8 +10,8 @@ use query_engine_sql::sql;
 
 #[derive(Debug)]
 /// Static information from the query and metadata.
-pub struct Env {
-    metadata: metadata::Metadata,
+pub struct Env<'a> {
+    metadata: &'a metadata::Metadata,
     relationships: BTreeMap<String, models::Relationship>,
 }
 
@@ -86,10 +86,10 @@ pub enum CollectionInfo {
     },
 }
 
-impl Env {
+impl<'a> Env<'a> {
     /// Create a new Env by supplying the metadata and relationships.
     pub fn new(
-        metadata: metadata::Metadata,
+        metadata: &'a metadata::Metadata,
         relationships: BTreeMap<String, models::Relationship>,
     ) -> Env {
         Env {

--- a/crates/query-engine/translation/src/translation/query/mod.rs
+++ b/crates/query-engine/translation/src/translation/query/mod.rs
@@ -24,7 +24,7 @@ pub fn translate(
     metadata: &metadata::Metadata,
     query_request: models::QueryRequest,
 ) -> Result<sql::execution_plan::ExecutionPlan, Error> {
-    let env = Env::new(metadata.clone(), query_request.collection_relationships);
+    let env = Env::new(metadata, query_request.collection_relationships);
     let mut state = State::new();
     let (current_table, from_clause) = root::make_from_clause_and_reference(
         &query_request.collection,


### PR DESCRIPTION
### What

The `Env` struct captures the metadata, but it doesn't need to own it as it's pretty transient.

By capturing a reference instead, we can avoid cloning the metadata, which is a fairly expensive operation.

On my machine, this has a noticeable impact on benchmark results.

### How

Judicious use of the `&` operator.

Yes, there are lifetimes.