### PR TITLE
Wrap configuration and state in `Arc`.

### DIFF
--- a/crates/connectors/ndc-postgres/src/configuration.rs
+++ b/crates/connectors/ndc-postgres/src/configuration.rs
@@ -50,7 +50,7 @@ impl<'a> version1::Configuration {
 }
 
 /// State for our connector.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct State {
     pub pool: PgPool,
     pub metrics: metrics::Metrics,

--- a/crates/connectors/ndc-postgres/src/connector.rs
+++ b/crates/connectors/ndc-postgres/src/connector.rs
@@ -5,6 +5,8 @@
 //! The relevant types for configuration and state are defined in
 //! `super::configuration`.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use tracing::{info_span, Instrument};
 
@@ -21,23 +23,24 @@ pub struct Postgres {}
 #[async_trait]
 impl connector::Connector for Postgres {
     /// RawConfiguration is what the user specifies as JSON
-    type RawConfiguration = configuration::RawConfiguration;
+    type RawConfiguration = Arc<configuration::RawConfiguration>;
     /// The type of validated configuration
-    type Configuration = configuration::Configuration;
+    type Configuration = Arc<configuration::Configuration>;
     /// The type of unserializable state
-    type State = configuration::State;
+    type State = Arc<configuration::State>;
 
     fn make_empty_configuration() -> Self::RawConfiguration {
-        configuration::RawConfiguration::empty()
+        Arc::new(configuration::RawConfiguration::empty())
     }
 
     /// Configure a configuration maybe?
     async fn update_configuration(
         args: &Self::RawConfiguration,
-    ) -> Result<configuration::RawConfiguration, connector::UpdateConfigurationError> {
+    ) -> Result<Self::RawConfiguration, connector::UpdateConfigurationError> {
         configuration::configure(args, CONFIGURATION_QUERY)
             .instrument(info_span!("Update configuration"))
             .await
+            .map(Arc::new)
     }
 
     /// Validate the raw configuration provided by the user,
@@ -48,6 +51,7 @@ impl connector::Connector for Postgres {
         configuration::validate_raw_configuration(configuration)
             .instrument(info_span!("Validate raw configuration"))
             .await
+            .map(Arc::new)
     }
 
     /// Initialize the connector's in-memory state.
@@ -64,6 +68,7 @@ impl connector::Connector for Postgres {
         configuration::create_state(configuration, metrics)
             .instrument(info_span!("Initialise state"))
             .await
+            .map(Arc::new)
             .map_err(|err| connector::InitializationError::Other(err.into()))
     }
 
@@ -75,8 +80,8 @@ impl connector::Connector for Postgres {
     /// the number of idle connections in a connection pool
     /// can be polled but not updated directly.
     fn fetch_metrics(
-        _configuration: &configuration::Configuration,
-        state: &configuration::State,
+        _configuration: &Self::Configuration,
+        state: &Self::State,
     ) -> Result<(), connector::FetchMetricsError> {
         state.metrics.update_pool_metrics(&state.pool);
         Ok(())


### PR DESCRIPTION
### What

This wraps configuration and state in `Arc`, because they are cloned by axum per request. [axum encourages this in its documentation.](https://docs.rs/axum/latest/axum/index.html#sharing-state-with-handlers)

This seems to have a pretty decent impact on benchmark results.

### How

We wrap the raw configuration, configuration, and state in `Arc<...>`, and fix the code to match. As we treat this data as read-only, that's really all there is to it.