### PR TITLE
Move aggregate functions into metadata

### DIFF
--- a/crates/connectors/ndc-postgres/src/configuration.rs
+++ b/crates/connectors/ndc-postgres/src/configuration.rs
@@ -36,14 +36,12 @@ pub const CURRENT_VERSION: u32 = 1;
 #[derive(Debug)]
 pub struct RuntimeConfiguration<'a> {
     pub metadata: &'a metadata::Metadata,
-    pub aggregate_functions: &'a metadata::AggregateFunctions,
 }
 
 impl<'a> version1::Configuration {
     /// Apply the common interpretations on the Configuration API type into an RuntimeConfiguration.
     pub fn as_runtime_configuration(self: &'a Configuration) -> RuntimeConfiguration<'a> {
         RuntimeConfiguration {
-            aggregate_functions: &self.config.aggregate_functions,
             metadata: &self.config.metadata,
         }
     }

--- a/crates/connectors/ndc-postgres/src/configuration/version1.rs
+++ b/crates/connectors/ndc-postgres/src/configuration/version1.rs
@@ -25,8 +25,6 @@ pub struct RawConfiguration {
     pub pool_settings: PoolSettings,
     #[serde(default)]
     pub metadata: metadata::Metadata,
-    #[serde(default)]
-    pub aggregate_functions: metadata::AggregateFunctions,
     /// Schemas which are excluded from introspection. The default setting will exclude the
     /// internal schemas of Postgres, Citus, Cockroach, and the PostGIS extension.
     #[serde(default = "default_excluded_schemas")]
@@ -112,7 +110,6 @@ impl RawConfiguration {
             connection_uris: ConnectionUris(SingleOrList::List(vec![])),
             pool_settings: PoolSettings::default(),
             metadata: metadata::Metadata::default(),
-            aggregate_functions: metadata::AggregateFunctions::default(),
             excluded_schemas: default_excluded_schemas(),
         }
     }
@@ -256,8 +253,8 @@ pub async fn configure(
         metadata: metadata::Metadata {
             tables,
             native_queries: args.metadata.native_queries,
+            aggregate_functions,
         },
-        aggregate_functions,
         excluded_schemas: args.excluded_schemas,
     })
 }

--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -37,7 +37,7 @@ fn occurring_scalar_types(
         .values()
         .flat_map(|v| v.arguments.values().map(|c| c.r#type.clone()));
 
-    let aggregate_types = config.aggregate_functions.0.keys().cloned();
+    let aggregate_types = config.metadata.aggregate_functions.0.keys().cloned();
 
     tables_column_types
         .chain(native_queries_column_types)
@@ -53,18 +53,15 @@ fn occurring_scalar_types(
 pub async fn get_schema(
     configuration::Configuration { config, .. }: &configuration::Configuration,
 ) -> Result<models::SchemaResponse, connector::SchemaError> {
-    let configuration::RawConfiguration {
-        metadata,
-        aggregate_functions,
-        ..
-    } = config;
+    let configuration::RawConfiguration { metadata, .. } = config;
     let scalar_types: BTreeMap<String, models::ScalarType> = occurring_scalar_types(config)
         .iter()
         .map(|scalar_type| {
             (
                 scalar_type.0.clone(),
                 models::ScalarType {
-                    aggregate_functions: aggregate_functions
+                    aggregate_functions: metadata
+                        .aggregate_functions
                         .0
                         .get(scalar_type)
                         .unwrap_or(&BTreeMap::new())

--- a/crates/connectors/ndc-postgres/tests/snapshots/configuration_tests__get_configuration_schema.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/configuration_tests__get_configuration_schema.snap
@@ -38,19 +38,12 @@ expression: schema
         "metadata": {
           "default": {
             "tables": {},
-            "native_queries": {}
+            "native_queries": {},
+            "aggregate_functions": {}
           },
           "allOf": [
             {
               "$ref": "#/definitions/Metadata"
-            }
-          ]
-        },
-        "aggregate_functions": {
-          "default": {},
-          "allOf": [
-            {
-              "$ref": "#/definitions/AggregateFunctions"
             }
           ]
         },
@@ -148,6 +141,14 @@ expression: schema
           "allOf": [
             {
               "$ref": "#/definitions/NativeQueries"
+            }
+          ]
+        },
+        "aggregate_functions": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/AggregateFunctions"
             }
           ]
         }

--- a/crates/connectors/ndc-postgres/tests/snapshots/configuration_tests__get_rawconfiguration_schema.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/configuration_tests__get_rawconfiguration_schema.snap
@@ -26,19 +26,12 @@ expression: schema
     "metadata": {
       "default": {
         "tables": {},
-        "native_queries": {}
+        "native_queries": {},
+        "aggregate_functions": {}
       },
       "allOf": [
         {
           "$ref": "#/definitions/Metadata"
-        }
-      ]
-    },
-    "aggregate_functions": {
-      "default": {},
-      "allOf": [
-        {
-          "$ref": "#/definitions/AggregateFunctions"
         }
       ]
     },
@@ -136,6 +129,14 @@ expression: schema
           "allOf": [
             {
               "$ref": "#/definitions/NativeQueries"
+            }
+          ]
+        },
+        "aggregate_functions": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/AggregateFunctions"
             }
           ]
         }

--- a/crates/query-engine/metadata/src/metadata/mod.rs
+++ b/crates/query-engine/metadata/src/metadata/mod.rs
@@ -17,4 +17,6 @@ pub struct Metadata {
     pub tables: TablesInfo,
     #[serde(default)]
     pub native_queries: NativeQueries,
+    #[serde(default)]
+    pub aggregate_functions: AggregateFunctions,
 }

--- a/static/aurora/chinook-deployment-template.json
+++ b/static/aurora/chinook-deployment-template.json
@@ -777,374 +777,374 @@
           }
         }
       }
-    }
-  },
-  "aggregate_functions": {
-    "bit": {
-      "bit_and": {
-        "return_type": "bit"
-      },
-      "bit_or": {
-        "return_type": "bit"
-      },
-      "bit_xor": {
-        "return_type": "bit"
-      }
     },
-    "bool": {
-      "bool_and": {
-        "return_type": "bool"
-      },
-      "bool_or": {
-        "return_type": "bool"
-      },
-      "every": {
-        "return_type": "bool"
-      }
-    },
-    "bpchar": {
-      "max": {
-        "return_type": "bpchar"
-      },
-      "min": {
-        "return_type": "bpchar"
-      }
-    },
-    "date": {
-      "max": {
-        "return_type": "date"
-      },
-      "min": {
-        "return_type": "date"
-      }
-    },
-    "float4": {
-      "avg": {
-        "return_type": "float8"
-      },
-      "max": {
-        "return_type": "float4"
-      },
-      "min": {
-        "return_type": "float4"
-      },
-      "stddev": {
-        "return_type": "float8"
-      },
-      "stddev_pop": {
-        "return_type": "float8"
-      },
-      "stddev_samp": {
-        "return_type": "float8"
-      },
-      "sum": {
-        "return_type": "float4"
-      },
-      "var_pop": {
-        "return_type": "float8"
-      },
-      "var_samp": {
-        "return_type": "float8"
-      },
-      "variance": {
-        "return_type": "float8"
-      }
-    },
-    "float8": {
-      "avg": {
-        "return_type": "float8"
-      },
-      "max": {
-        "return_type": "float8"
-      },
-      "min": {
-        "return_type": "float8"
-      },
-      "stddev": {
-        "return_type": "float8"
-      },
-      "stddev_pop": {
-        "return_type": "float8"
-      },
-      "stddev_samp": {
-        "return_type": "float8"
-      },
-      "sum": {
-        "return_type": "float8"
-      },
-      "var_pop": {
-        "return_type": "float8"
-      },
-      "var_samp": {
-        "return_type": "float8"
-      },
-      "variance": {
-        "return_type": "float8"
-      }
-    },
-    "inet": {
-      "max": {
-        "return_type": "inet"
-      },
-      "min": {
-        "return_type": "inet"
-      }
-    },
-    "int2": {
-      "avg": {
-        "return_type": "numeric"
-      },
-      "bit_and": {
-        "return_type": "int2"
-      },
-      "bit_or": {
-        "return_type": "int2"
-      },
-      "bit_xor": {
-        "return_type": "int2"
-      },
-      "max": {
-        "return_type": "int2"
-      },
-      "min": {
-        "return_type": "int2"
-      },
-      "stddev": {
-        "return_type": "numeric"
-      },
-      "stddev_pop": {
-        "return_type": "numeric"
-      },
-      "stddev_samp": {
-        "return_type": "numeric"
-      },
-      "sum": {
-        "return_type": "int8"
-      },
-      "var_pop": {
-        "return_type": "numeric"
-      },
-      "var_samp": {
-        "return_type": "numeric"
-      },
-      "variance": {
-        "return_type": "numeric"
-      }
-    },
-    "int4": {
-      "avg": {
-        "return_type": "numeric"
-      },
-      "bit_and": {
-        "return_type": "int4"
-      },
-      "bit_or": {
-        "return_type": "int4"
-      },
-      "bit_xor": {
-        "return_type": "int4"
-      },
-      "max": {
-        "return_type": "int4"
-      },
-      "min": {
-        "return_type": "int4"
-      },
-      "stddev": {
-        "return_type": "numeric"
-      },
-      "stddev_pop": {
-        "return_type": "numeric"
-      },
-      "stddev_samp": {
-        "return_type": "numeric"
-      },
-      "sum": {
-        "return_type": "int8"
-      },
-      "var_pop": {
-        "return_type": "numeric"
-      },
-      "var_samp": {
-        "return_type": "numeric"
-      },
-      "variance": {
-        "return_type": "numeric"
-      }
-    },
-    "int8": {
-      "avg": {
-        "return_type": "numeric"
-      },
-      "bit_and": {
-        "return_type": "int8"
-      },
-      "bit_or": {
-        "return_type": "int8"
-      },
-      "bit_xor": {
-        "return_type": "int8"
-      },
-      "max": {
-        "return_type": "int8"
-      },
-      "min": {
-        "return_type": "int8"
-      },
-      "stddev": {
-        "return_type": "numeric"
-      },
-      "stddev_pop": {
-        "return_type": "numeric"
-      },
-      "stddev_samp": {
-        "return_type": "numeric"
-      },
-      "sum": {
-        "return_type": "numeric"
-      },
-      "var_pop": {
-        "return_type": "numeric"
-      },
-      "var_samp": {
-        "return_type": "numeric"
-      },
-      "variance": {
-        "return_type": "numeric"
-      }
-    },
-    "interval": {
-      "avg": {
-        "return_type": "interval"
-      },
-      "max": {
-        "return_type": "interval"
-      },
-      "min": {
-        "return_type": "interval"
-      },
-      "sum": {
-        "return_type": "interval"
-      }
-    },
-    "money": {
-      "max": {
-        "return_type": "money"
-      },
-      "min": {
-        "return_type": "money"
-      },
-      "sum": {
-        "return_type": "money"
-      }
-    },
-    "numeric": {
-      "avg": {
-        "return_type": "numeric"
-      },
-      "max": {
-        "return_type": "numeric"
-      },
-      "min": {
-        "return_type": "numeric"
-      },
-      "stddev": {
-        "return_type": "numeric"
-      },
-      "stddev_pop": {
-        "return_type": "numeric"
-      },
-      "stddev_samp": {
-        "return_type": "numeric"
-      },
-      "sum": {
-        "return_type": "numeric"
-      },
-      "var_pop": {
-        "return_type": "numeric"
-      },
-      "var_samp": {
-        "return_type": "numeric"
-      },
-      "variance": {
-        "return_type": "numeric"
-      }
-    },
-    "oid": {
-      "max": {
-        "return_type": "oid"
-      },
-      "min": {
-        "return_type": "oid"
-      }
-    },
-    "pg_lsn": {
-      "max": {
-        "return_type": "pg_lsn"
-      },
-      "min": {
-        "return_type": "pg_lsn"
-      }
-    },
-    "text": {
-      "max": {
-        "return_type": "text"
-      },
-      "min": {
-        "return_type": "text"
-      }
-    },
-    "tid": {
-      "max": {
-        "return_type": "tid"
-      },
-      "min": {
-        "return_type": "tid"
-      }
-    },
-    "time": {
-      "max": {
-        "return_type": "time"
-      },
-      "min": {
-        "return_type": "time"
-      }
-    },
-    "timestamp": {
-      "max": {
-        "return_type": "timestamp"
-      },
-      "min": {
-        "return_type": "timestamp"
-      }
-    },
-    "timestamptz": {
-      "max": {
-        "return_type": "timestamptz"
-      },
-      "min": {
-        "return_type": "timestamptz"
-      }
-    },
-    "timetz": {
-      "max": {
-        "return_type": "timetz"
-      },
-      "min": {
-        "return_type": "timetz"
-      }
-    },
-    "xid8": {
-      "max": {
-        "return_type": "xid8"
-      },
-      "min": {
-        "return_type": "xid8"
-      }
-    },
-    "xml": {
-      "xmlagg": {
-        "return_type": "xml"
+    "aggregate_functions": {
+      "bit": {
+        "bit_and": {
+          "return_type": "bit"
+        },
+        "bit_or": {
+          "return_type": "bit"
+        },
+        "bit_xor": {
+          "return_type": "bit"
+        }
+      },
+      "bool": {
+        "bool_and": {
+          "return_type": "bool"
+        },
+        "bool_or": {
+          "return_type": "bool"
+        },
+        "every": {
+          "return_type": "bool"
+        }
+      },
+      "bpchar": {
+        "max": {
+          "return_type": "bpchar"
+        },
+        "min": {
+          "return_type": "bpchar"
+        }
+      },
+      "date": {
+        "max": {
+          "return_type": "date"
+        },
+        "min": {
+          "return_type": "date"
+        }
+      },
+      "float4": {
+        "avg": {
+          "return_type": "float8"
+        },
+        "max": {
+          "return_type": "float4"
+        },
+        "min": {
+          "return_type": "float4"
+        },
+        "stddev": {
+          "return_type": "float8"
+        },
+        "stddev_pop": {
+          "return_type": "float8"
+        },
+        "stddev_samp": {
+          "return_type": "float8"
+        },
+        "sum": {
+          "return_type": "float4"
+        },
+        "var_pop": {
+          "return_type": "float8"
+        },
+        "var_samp": {
+          "return_type": "float8"
+        },
+        "variance": {
+          "return_type": "float8"
+        }
+      },
+      "float8": {
+        "avg": {
+          "return_type": "float8"
+        },
+        "max": {
+          "return_type": "float8"
+        },
+        "min": {
+          "return_type": "float8"
+        },
+        "stddev": {
+          "return_type": "float8"
+        },
+        "stddev_pop": {
+          "return_type": "float8"
+        },
+        "stddev_samp": {
+          "return_type": "float8"
+        },
+        "sum": {
+          "return_type": "float8"
+        },
+        "var_pop": {
+          "return_type": "float8"
+        },
+        "var_samp": {
+          "return_type": "float8"
+        },
+        "variance": {
+          "return_type": "float8"
+        }
+      },
+      "inet": {
+        "max": {
+          "return_type": "inet"
+        },
+        "min": {
+          "return_type": "inet"
+        }
+      },
+      "int2": {
+        "avg": {
+          "return_type": "numeric"
+        },
+        "bit_and": {
+          "return_type": "int2"
+        },
+        "bit_or": {
+          "return_type": "int2"
+        },
+        "bit_xor": {
+          "return_type": "int2"
+        },
+        "max": {
+          "return_type": "int2"
+        },
+        "min": {
+          "return_type": "int2"
+        },
+        "stddev": {
+          "return_type": "numeric"
+        },
+        "stddev_pop": {
+          "return_type": "numeric"
+        },
+        "stddev_samp": {
+          "return_type": "numeric"
+        },
+        "sum": {
+          "return_type": "int8"
+        },
+        "var_pop": {
+          "return_type": "numeric"
+        },
+        "var_samp": {
+          "return_type": "numeric"
+        },
+        "variance": {
+          "return_type": "numeric"
+        }
+      },
+      "int4": {
+        "avg": {
+          "return_type": "numeric"
+        },
+        "bit_and": {
+          "return_type": "int4"
+        },
+        "bit_or": {
+          "return_type": "int4"
+        },
+        "bit_xor": {
+          "return_type": "int4"
+        },
+        "max": {
+          "return_type": "int4"
+        },
+        "min": {
+          "return_type": "int4"
+        },
+        "stddev": {
+          "return_type": "numeric"
+        },
+        "stddev_pop": {
+          "return_type": "numeric"
+        },
+        "stddev_samp": {
+          "return_type": "numeric"
+        },
+        "sum": {
+          "return_type": "int8"
+        },
+        "var_pop": {
+          "return_type": "numeric"
+        },
+        "var_samp": {
+          "return_type": "numeric"
+        },
+        "variance": {
+          "return_type": "numeric"
+        }
+      },
+      "int8": {
+        "avg": {
+          "return_type": "numeric"
+        },
+        "bit_and": {
+          "return_type": "int8"
+        },
+        "bit_or": {
+          "return_type": "int8"
+        },
+        "bit_xor": {
+          "return_type": "int8"
+        },
+        "max": {
+          "return_type": "int8"
+        },
+        "min": {
+          "return_type": "int8"
+        },
+        "stddev": {
+          "return_type": "numeric"
+        },
+        "stddev_pop": {
+          "return_type": "numeric"
+        },
+        "stddev_samp": {
+          "return_type": "numeric"
+        },
+        "sum": {
+          "return_type": "numeric"
+        },
+        "var_pop": {
+          "return_type": "numeric"
+        },
+        "var_samp": {
+          "return_type": "numeric"
+        },
+        "variance": {
+          "return_type": "numeric"
+        }
+      },
+      "interval": {
+        "avg": {
+          "return_type": "interval"
+        },
+        "max": {
+          "return_type": "interval"
+        },
+        "min": {
+          "return_type": "interval"
+        },
+        "sum": {
+          "return_type": "interval"
+        }
+      },
+      "money": {
+        "max": {
+          "return_type": "money"
+        },
+        "min": {
+          "return_type": "money"
+        },
+        "sum": {
+          "return_type": "money"
+        }
+      },
+      "numeric": {
+        "avg": {
+          "return_type": "numeric"
+        },
+        "max": {
+          "return_type": "numeric"
+        },
+        "min": {
+          "return_type": "numeric"
+        },
+        "stddev": {
+          "return_type": "numeric"
+        },
+        "stddev_pop": {
+          "return_type": "numeric"
+        },
+        "stddev_samp": {
+          "return_type": "numeric"
+        },
+        "sum": {
+          "return_type": "numeric"
+        },
+        "var_pop": {
+          "return_type": "numeric"
+        },
+        "var_samp": {
+          "return_type": "numeric"
+        },
+        "variance": {
+          "return_type": "numeric"
+        }
+      },
+      "oid": {
+        "max": {
+          "return_type": "oid"
+        },
+        "min": {
+          "return_type": "oid"
+        }
+      },
+      "pg_lsn": {
+        "max": {
+          "return_type": "pg_lsn"
+        },
+        "min": {
+          "return_type": "pg_lsn"
+        }
+      },
+      "text": {
+        "max": {
+          "return_type": "text"
+        },
+        "min": {
+          "return_type": "text"
+        }
+      },
+      "tid": {
+        "max": {
+          "return_type": "tid"
+        },
+        "min": {
+          "return_type": "tid"
+        }
+      },
+      "time": {
+        "max": {
+          "return_type": "time"
+        },
+        "min": {
+          "return_type": "time"
+        }
+      },
+      "timestamp": {
+        "max": {
+          "return_type": "timestamp"
+        },
+        "min": {
+          "return_type": "timestamp"
+        }
+      },
+      "timestamptz": {
+        "max": {
+          "return_type": "timestamptz"
+        },
+        "min": {
+          "return_type": "timestamptz"
+        }
+      },
+      "timetz": {
+        "max": {
+          "return_type": "timetz"
+        },
+        "min": {
+          "return_type": "timetz"
+        }
+      },
+      "xid8": {
+        "max": {
+          "return_type": "xid8"
+        },
+        "min": {
+          "return_type": "xid8"
+        }
+      },
+      "xml": {
+        "xmlagg": {
+          "return_type": "xml"
+        }
       }
     }
   },

--- a/static/chinook-deployment.json
+++ b/static/chinook-deployment.json
@@ -1033,408 +1033,408 @@
           }
         }
       }
-    }
-  },
-  "aggregate_functions": {
-    "bit": {
-      "bit_and": {
-        "return_type": "bit"
-      },
-      "bit_or": {
-        "return_type": "bit"
-      },
-      "bit_xor": {
-        "return_type": "bit"
-      }
     },
-    "bool": {
-      "bool_and": {
-        "return_type": "bool"
-      },
-      "bool_or": {
-        "return_type": "bool"
-      },
-      "every": {
-        "return_type": "bool"
-      }
-    },
-    "bpchar": {
-      "max": {
-        "return_type": "bpchar"
-      },
-      "min": {
-        "return_type": "bpchar"
-      }
-    },
-    "date": {
-      "max": {
-        "return_type": "date"
-      },
-      "min": {
-        "return_type": "date"
-      }
-    },
-    "float4": {
-      "avg": {
-        "return_type": "float8"
-      },
-      "max": {
-        "return_type": "float4"
-      },
-      "min": {
-        "return_type": "float4"
-      },
-      "stddev": {
-        "return_type": "float8"
-      },
-      "stddev_pop": {
-        "return_type": "float8"
-      },
-      "stddev_samp": {
-        "return_type": "float8"
-      },
-      "sum": {
-        "return_type": "float4"
-      },
-      "var_pop": {
-        "return_type": "float8"
-      },
-      "var_samp": {
-        "return_type": "float8"
-      },
-      "variance": {
-        "return_type": "float8"
-      }
-    },
-    "float8": {
-      "avg": {
-        "return_type": "float8"
-      },
-      "max": {
-        "return_type": "float8"
-      },
-      "min": {
-        "return_type": "float8"
-      },
-      "stddev": {
-        "return_type": "float8"
-      },
-      "stddev_pop": {
-        "return_type": "float8"
-      },
-      "stddev_samp": {
-        "return_type": "float8"
-      },
-      "sum": {
-        "return_type": "float8"
-      },
-      "var_pop": {
-        "return_type": "float8"
-      },
-      "var_samp": {
-        "return_type": "float8"
-      },
-      "variance": {
-        "return_type": "float8"
-      }
-    },
-    "geometry": {
-      "st_3dextent": {
-        "return_type": "box3d"
-      },
-      "st_collect": {
-        "return_type": "geometry"
-      },
-      "st_coverageunion": {
-        "return_type": "geometry"
-      },
-      "st_extent": {
-        "return_type": "box2d"
-      },
-      "st_makeline": {
-        "return_type": "geometry"
-      },
-      "st_memcollect": {
-        "return_type": "geometry"
-      },
-      "st_memunion": {
-        "return_type": "geometry"
-      },
-      "st_polygonize": {
-        "return_type": "geometry"
-      },
-      "st_union": {
-        "return_type": "geometry"
-      }
-    },
-    "inet": {
-      "max": {
-        "return_type": "inet"
-      },
-      "min": {
-        "return_type": "inet"
-      }
-    },
-    "int2": {
-      "avg": {
-        "return_type": "numeric"
-      },
-      "bit_and": {
-        "return_type": "int2"
-      },
-      "bit_or": {
-        "return_type": "int2"
-      },
-      "bit_xor": {
-        "return_type": "int2"
-      },
-      "max": {
-        "return_type": "int2"
-      },
-      "min": {
-        "return_type": "int2"
-      },
-      "stddev": {
-        "return_type": "numeric"
-      },
-      "stddev_pop": {
-        "return_type": "numeric"
-      },
-      "stddev_samp": {
-        "return_type": "numeric"
-      },
-      "sum": {
-        "return_type": "int8"
-      },
-      "var_pop": {
-        "return_type": "numeric"
-      },
-      "var_samp": {
-        "return_type": "numeric"
-      },
-      "variance": {
-        "return_type": "numeric"
-      }
-    },
-    "int4": {
-      "avg": {
-        "return_type": "numeric"
-      },
-      "bit_and": {
-        "return_type": "int4"
-      },
-      "bit_or": {
-        "return_type": "int4"
-      },
-      "bit_xor": {
-        "return_type": "int4"
-      },
-      "max": {
-        "return_type": "int4"
-      },
-      "min": {
-        "return_type": "int4"
-      },
-      "stddev": {
-        "return_type": "numeric"
-      },
-      "stddev_pop": {
-        "return_type": "numeric"
-      },
-      "stddev_samp": {
-        "return_type": "numeric"
-      },
-      "sum": {
-        "return_type": "int8"
-      },
-      "var_pop": {
-        "return_type": "numeric"
-      },
-      "var_samp": {
-        "return_type": "numeric"
-      },
-      "variance": {
-        "return_type": "numeric"
-      }
-    },
-    "int8": {
-      "avg": {
-        "return_type": "numeric"
-      },
-      "bit_and": {
-        "return_type": "int8"
-      },
-      "bit_or": {
-        "return_type": "int8"
-      },
-      "bit_xor": {
-        "return_type": "int8"
-      },
-      "max": {
-        "return_type": "int8"
-      },
-      "min": {
-        "return_type": "int8"
-      },
-      "stddev": {
-        "return_type": "numeric"
-      },
-      "stddev_pop": {
-        "return_type": "numeric"
-      },
-      "stddev_samp": {
-        "return_type": "numeric"
-      },
-      "sum": {
-        "return_type": "numeric"
-      },
-      "var_pop": {
-        "return_type": "numeric"
-      },
-      "var_samp": {
-        "return_type": "numeric"
-      },
-      "variance": {
-        "return_type": "numeric"
-      }
-    },
-    "interval": {
-      "avg": {
-        "return_type": "interval"
-      },
-      "max": {
-        "return_type": "interval"
-      },
-      "min": {
-        "return_type": "interval"
-      },
-      "sum": {
-        "return_type": "interval"
-      }
-    },
-    "money": {
-      "max": {
-        "return_type": "money"
-      },
-      "min": {
-        "return_type": "money"
-      },
-      "sum": {
-        "return_type": "money"
-      }
-    },
-    "numeric": {
-      "avg": {
-        "return_type": "numeric"
-      },
-      "max": {
-        "return_type": "numeric"
-      },
-      "min": {
-        "return_type": "numeric"
-      },
-      "stddev": {
-        "return_type": "numeric"
-      },
-      "stddev_pop": {
-        "return_type": "numeric"
-      },
-      "stddev_samp": {
-        "return_type": "numeric"
-      },
-      "sum": {
-        "return_type": "numeric"
-      },
-      "var_pop": {
-        "return_type": "numeric"
-      },
-      "var_samp": {
-        "return_type": "numeric"
-      },
-      "variance": {
-        "return_type": "numeric"
-      }
-    },
-    "oid": {
-      "max": {
-        "return_type": "oid"
-      },
-      "min": {
-        "return_type": "oid"
-      }
-    },
-    "pg_lsn": {
-      "max": {
-        "return_type": "pg_lsn"
-      },
-      "min": {
-        "return_type": "pg_lsn"
-      }
-    },
-    "text": {
-      "max": {
-        "return_type": "text"
-      },
-      "min": {
-        "return_type": "text"
-      }
-    },
-    "tid": {
-      "max": {
-        "return_type": "tid"
-      },
-      "min": {
-        "return_type": "tid"
-      }
-    },
-    "time": {
-      "max": {
-        "return_type": "time"
-      },
-      "min": {
-        "return_type": "time"
-      }
-    },
-    "timestamp": {
-      "max": {
-        "return_type": "timestamp"
-      },
-      "min": {
-        "return_type": "timestamp"
-      }
-    },
-    "timestamptz": {
-      "max": {
-        "return_type": "timestamptz"
-      },
-      "min": {
-        "return_type": "timestamptz"
-      }
-    },
-    "timetz": {
-      "max": {
-        "return_type": "timetz"
-      },
-      "min": {
-        "return_type": "timetz"
-      }
-    },
-    "topoelement": {
-      "topoelementarray_agg": {
-        "return_type": "topoelementarray"
-      }
-    },
-    "xid8": {
-      "max": {
-        "return_type": "xid8"
-      },
-      "min": {
-        "return_type": "xid8"
-      }
-    },
-    "xml": {
-      "xmlagg": {
-        "return_type": "xml"
+    "aggregate_functions": {
+      "bit": {
+        "bit_and": {
+          "return_type": "bit"
+        },
+        "bit_or": {
+          "return_type": "bit"
+        },
+        "bit_xor": {
+          "return_type": "bit"
+        }
+      },
+      "bool": {
+        "bool_and": {
+          "return_type": "bool"
+        },
+        "bool_or": {
+          "return_type": "bool"
+        },
+        "every": {
+          "return_type": "bool"
+        }
+      },
+      "bpchar": {
+        "max": {
+          "return_type": "bpchar"
+        },
+        "min": {
+          "return_type": "bpchar"
+        }
+      },
+      "date": {
+        "max": {
+          "return_type": "date"
+        },
+        "min": {
+          "return_type": "date"
+        }
+      },
+      "float4": {
+        "avg": {
+          "return_type": "float8"
+        },
+        "max": {
+          "return_type": "float4"
+        },
+        "min": {
+          "return_type": "float4"
+        },
+        "stddev": {
+          "return_type": "float8"
+        },
+        "stddev_pop": {
+          "return_type": "float8"
+        },
+        "stddev_samp": {
+          "return_type": "float8"
+        },
+        "sum": {
+          "return_type": "float4"
+        },
+        "var_pop": {
+          "return_type": "float8"
+        },
+        "var_samp": {
+          "return_type": "float8"
+        },
+        "variance": {
+          "return_type": "float8"
+        }
+      },
+      "float8": {
+        "avg": {
+          "return_type": "float8"
+        },
+        "max": {
+          "return_type": "float8"
+        },
+        "min": {
+          "return_type": "float8"
+        },
+        "stddev": {
+          "return_type": "float8"
+        },
+        "stddev_pop": {
+          "return_type": "float8"
+        },
+        "stddev_samp": {
+          "return_type": "float8"
+        },
+        "sum": {
+          "return_type": "float8"
+        },
+        "var_pop": {
+          "return_type": "float8"
+        },
+        "var_samp": {
+          "return_type": "float8"
+        },
+        "variance": {
+          "return_type": "float8"
+        }
+      },
+      "geometry": {
+        "st_3dextent": {
+          "return_type": "box3d"
+        },
+        "st_collect": {
+          "return_type": "geometry"
+        },
+        "st_coverageunion": {
+          "return_type": "geometry"
+        },
+        "st_extent": {
+          "return_type": "box2d"
+        },
+        "st_makeline": {
+          "return_type": "geometry"
+        },
+        "st_memcollect": {
+          "return_type": "geometry"
+        },
+        "st_memunion": {
+          "return_type": "geometry"
+        },
+        "st_polygonize": {
+          "return_type": "geometry"
+        },
+        "st_union": {
+          "return_type": "geometry"
+        }
+      },
+      "inet": {
+        "max": {
+          "return_type": "inet"
+        },
+        "min": {
+          "return_type": "inet"
+        }
+      },
+      "int2": {
+        "avg": {
+          "return_type": "numeric"
+        },
+        "bit_and": {
+          "return_type": "int2"
+        },
+        "bit_or": {
+          "return_type": "int2"
+        },
+        "bit_xor": {
+          "return_type": "int2"
+        },
+        "max": {
+          "return_type": "int2"
+        },
+        "min": {
+          "return_type": "int2"
+        },
+        "stddev": {
+          "return_type": "numeric"
+        },
+        "stddev_pop": {
+          "return_type": "numeric"
+        },
+        "stddev_samp": {
+          "return_type": "numeric"
+        },
+        "sum": {
+          "return_type": "int8"
+        },
+        "var_pop": {
+          "return_type": "numeric"
+        },
+        "var_samp": {
+          "return_type": "numeric"
+        },
+        "variance": {
+          "return_type": "numeric"
+        }
+      },
+      "int4": {
+        "avg": {
+          "return_type": "numeric"
+        },
+        "bit_and": {
+          "return_type": "int4"
+        },
+        "bit_or": {
+          "return_type": "int4"
+        },
+        "bit_xor": {
+          "return_type": "int4"
+        },
+        "max": {
+          "return_type": "int4"
+        },
+        "min": {
+          "return_type": "int4"
+        },
+        "stddev": {
+          "return_type": "numeric"
+        },
+        "stddev_pop": {
+          "return_type": "numeric"
+        },
+        "stddev_samp": {
+          "return_type": "numeric"
+        },
+        "sum": {
+          "return_type": "int8"
+        },
+        "var_pop": {
+          "return_type": "numeric"
+        },
+        "var_samp": {
+          "return_type": "numeric"
+        },
+        "variance": {
+          "return_type": "numeric"
+        }
+      },
+      "int8": {
+        "avg": {
+          "return_type": "numeric"
+        },
+        "bit_and": {
+          "return_type": "int8"
+        },
+        "bit_or": {
+          "return_type": "int8"
+        },
+        "bit_xor": {
+          "return_type": "int8"
+        },
+        "max": {
+          "return_type": "int8"
+        },
+        "min": {
+          "return_type": "int8"
+        },
+        "stddev": {
+          "return_type": "numeric"
+        },
+        "stddev_pop": {
+          "return_type": "numeric"
+        },
+        "stddev_samp": {
+          "return_type": "numeric"
+        },
+        "sum": {
+          "return_type": "numeric"
+        },
+        "var_pop": {
+          "return_type": "numeric"
+        },
+        "var_samp": {
+          "return_type": "numeric"
+        },
+        "variance": {
+          "return_type": "numeric"
+        }
+      },
+      "interval": {
+        "avg": {
+          "return_type": "interval"
+        },
+        "max": {
+          "return_type": "interval"
+        },
+        "min": {
+          "return_type": "interval"
+        },
+        "sum": {
+          "return_type": "interval"
+        }
+      },
+      "money": {
+        "max": {
+          "return_type": "money"
+        },
+        "min": {
+          "return_type": "money"
+        },
+        "sum": {
+          "return_type": "money"
+        }
+      },
+      "numeric": {
+        "avg": {
+          "return_type": "numeric"
+        },
+        "max": {
+          "return_type": "numeric"
+        },
+        "min": {
+          "return_type": "numeric"
+        },
+        "stddev": {
+          "return_type": "numeric"
+        },
+        "stddev_pop": {
+          "return_type": "numeric"
+        },
+        "stddev_samp": {
+          "return_type": "numeric"
+        },
+        "sum": {
+          "return_type": "numeric"
+        },
+        "var_pop": {
+          "return_type": "numeric"
+        },
+        "var_samp": {
+          "return_type": "numeric"
+        },
+        "variance": {
+          "return_type": "numeric"
+        }
+      },
+      "oid": {
+        "max": {
+          "return_type": "oid"
+        },
+        "min": {
+          "return_type": "oid"
+        }
+      },
+      "pg_lsn": {
+        "max": {
+          "return_type": "pg_lsn"
+        },
+        "min": {
+          "return_type": "pg_lsn"
+        }
+      },
+      "text": {
+        "max": {
+          "return_type": "text"
+        },
+        "min": {
+          "return_type": "text"
+        }
+      },
+      "tid": {
+        "max": {
+          "return_type": "tid"
+        },
+        "min": {
+          "return_type": "tid"
+        }
+      },
+      "time": {
+        "max": {
+          "return_type": "time"
+        },
+        "min": {
+          "return_type": "time"
+        }
+      },
+      "timestamp": {
+        "max": {
+          "return_type": "timestamp"
+        },
+        "min": {
+          "return_type": "timestamp"
+        }
+      },
+      "timestamptz": {
+        "max": {
+          "return_type": "timestamptz"
+        },
+        "min": {
+          "return_type": "timestamptz"
+        }
+      },
+      "timetz": {
+        "max": {
+          "return_type": "timetz"
+        },
+        "min": {
+          "return_type": "timetz"
+        }
+      },
+      "topoelement": {
+        "topoelementarray_agg": {
+          "return_type": "topoelementarray"
+        }
+      },
+      "xid8": {
+        "max": {
+          "return_type": "xid8"
+        },
+        "min": {
+          "return_type": "xid8"
+        }
+      },
+      "xml": {
+        "xmlagg": {
+          "return_type": "xml"
+        }
       }
     }
   },

--- a/static/citus/chinook-deployment.json
+++ b/static/citus/chinook-deployment.json
@@ -834,384 +834,384 @@
           }
         }
       }
-    }
-  },
-  "aggregate_functions": {
-    "bit": {
-      "bit_and": {
-        "return_type": "bit"
-      },
-      "bit_or": {
-        "return_type": "bit"
-      },
-      "bit_xor": {
-        "return_type": "bit"
-      }
     },
-    "bool": {
-      "bool_and": {
-        "return_type": "bool"
-      },
-      "bool_or": {
-        "return_type": "bool"
-      },
-      "every": {
-        "return_type": "bool"
-      }
-    },
-    "bpchar": {
-      "max": {
-        "return_type": "bpchar"
-      },
-      "min": {
-        "return_type": "bpchar"
-      }
-    },
-    "date": {
-      "max": {
-        "return_type": "date"
-      },
-      "min": {
-        "return_type": "date"
-      }
-    },
-    "float4": {
-      "avg": {
-        "return_type": "float8"
-      },
-      "max": {
-        "return_type": "float4"
-      },
-      "min": {
-        "return_type": "float4"
-      },
-      "stddev": {
-        "return_type": "float8"
-      },
-      "stddev_pop": {
-        "return_type": "float8"
-      },
-      "stddev_samp": {
-        "return_type": "float8"
-      },
-      "sum": {
-        "return_type": "float4"
-      },
-      "var_pop": {
-        "return_type": "float8"
-      },
-      "var_samp": {
-        "return_type": "float8"
-      },
-      "variance": {
-        "return_type": "float8"
-      }
-    },
-    "float8": {
-      "avg": {
-        "return_type": "float8"
-      },
-      "max": {
-        "return_type": "float8"
-      },
-      "min": {
-        "return_type": "float8"
-      },
-      "stddev": {
-        "return_type": "float8"
-      },
-      "stddev_pop": {
-        "return_type": "float8"
-      },
-      "stddev_samp": {
-        "return_type": "float8"
-      },
-      "sum": {
-        "return_type": "float8"
-      },
-      "var_pop": {
-        "return_type": "float8"
-      },
-      "var_samp": {
-        "return_type": "float8"
-      },
-      "variance": {
-        "return_type": "float8"
-      }
-    },
-    "inet": {
-      "max": {
-        "return_type": "inet"
-      },
-      "min": {
-        "return_type": "inet"
-      }
-    },
-    "int2": {
-      "avg": {
-        "return_type": "numeric"
-      },
-      "bit_and": {
-        "return_type": "int2"
-      },
-      "bit_or": {
-        "return_type": "int2"
-      },
-      "bit_xor": {
-        "return_type": "int2"
-      },
-      "max": {
-        "return_type": "int2"
-      },
-      "min": {
-        "return_type": "int2"
-      },
-      "stddev": {
-        "return_type": "numeric"
-      },
-      "stddev_pop": {
-        "return_type": "numeric"
-      },
-      "stddev_samp": {
-        "return_type": "numeric"
-      },
-      "sum": {
-        "return_type": "int8"
-      },
-      "var_pop": {
-        "return_type": "numeric"
-      },
-      "var_samp": {
-        "return_type": "numeric"
-      },
-      "variance": {
-        "return_type": "numeric"
-      }
-    },
-    "int4": {
-      "avg": {
-        "return_type": "numeric"
-      },
-      "bit_and": {
-        "return_type": "int4"
-      },
-      "bit_or": {
-        "return_type": "int4"
-      },
-      "bit_xor": {
-        "return_type": "int4"
-      },
-      "max": {
-        "return_type": "int4"
-      },
-      "min": {
-        "return_type": "int4"
-      },
-      "stddev": {
-        "return_type": "numeric"
-      },
-      "stddev_pop": {
-        "return_type": "numeric"
-      },
-      "stddev_samp": {
-        "return_type": "numeric"
-      },
-      "sum": {
-        "return_type": "int8"
-      },
-      "var_pop": {
-        "return_type": "numeric"
-      },
-      "var_samp": {
-        "return_type": "numeric"
-      },
-      "variance": {
-        "return_type": "numeric"
-      }
-    },
-    "int8": {
-      "avg": {
-        "return_type": "numeric"
-      },
-      "bit_and": {
-        "return_type": "int8"
-      },
-      "bit_or": {
-        "return_type": "int8"
-      },
-      "bit_xor": {
-        "return_type": "int8"
-      },
-      "max": {
-        "return_type": "int8"
-      },
-      "min": {
-        "return_type": "int8"
-      },
-      "stddev": {
-        "return_type": "numeric"
-      },
-      "stddev_pop": {
-        "return_type": "numeric"
-      },
-      "stddev_samp": {
-        "return_type": "numeric"
-      },
-      "sum": {
-        "return_type": "numeric"
-      },
-      "var_pop": {
-        "return_type": "numeric"
-      },
-      "var_samp": {
-        "return_type": "numeric"
-      },
-      "variance": {
-        "return_type": "numeric"
-      }
-    },
-    "interval": {
-      "avg": {
-        "return_type": "interval"
-      },
-      "max": {
-        "return_type": "interval"
-      },
-      "min": {
-        "return_type": "interval"
-      },
-      "sum": {
-        "return_type": "interval"
-      }
-    },
-    "json": {
-      "json_cat_agg": {
-        "return_type": "json"
-      }
-    },
-    "jsonb": {
-      "jsonb_cat_agg": {
-        "return_type": "jsonb"
-      }
-    },
-    "money": {
-      "max": {
-        "return_type": "money"
-      },
-      "min": {
-        "return_type": "money"
-      },
-      "sum": {
-        "return_type": "money"
-      }
-    },
-    "numeric": {
-      "avg": {
-        "return_type": "numeric"
-      },
-      "max": {
-        "return_type": "numeric"
-      },
-      "min": {
-        "return_type": "numeric"
-      },
-      "stddev": {
-        "return_type": "numeric"
-      },
-      "stddev_pop": {
-        "return_type": "numeric"
-      },
-      "stddev_samp": {
-        "return_type": "numeric"
-      },
-      "sum": {
-        "return_type": "numeric"
-      },
-      "var_pop": {
-        "return_type": "numeric"
-      },
-      "var_samp": {
-        "return_type": "numeric"
-      },
-      "variance": {
-        "return_type": "numeric"
-      }
-    },
-    "oid": {
-      "max": {
-        "return_type": "oid"
-      },
-      "min": {
-        "return_type": "oid"
-      }
-    },
-    "pg_lsn": {
-      "max": {
-        "return_type": "pg_lsn"
-      },
-      "min": {
-        "return_type": "pg_lsn"
-      }
-    },
-    "text": {
-      "max": {
-        "return_type": "text"
-      },
-      "min": {
-        "return_type": "text"
-      }
-    },
-    "tid": {
-      "max": {
-        "return_type": "tid"
-      },
-      "min": {
-        "return_type": "tid"
-      }
-    },
-    "time": {
-      "max": {
-        "return_type": "time"
-      },
-      "min": {
-        "return_type": "time"
-      }
-    },
-    "timestamp": {
-      "max": {
-        "return_type": "timestamp"
-      },
-      "min": {
-        "return_type": "timestamp"
-      }
-    },
-    "timestamptz": {
-      "max": {
-        "return_type": "timestamptz"
-      },
-      "min": {
-        "return_type": "timestamptz"
-      }
-    },
-    "timetz": {
-      "max": {
-        "return_type": "timetz"
-      },
-      "min": {
-        "return_type": "timetz"
-      }
-    },
-    "xid8": {
-      "max": {
-        "return_type": "xid8"
-      },
-      "min": {
-        "return_type": "xid8"
-      }
-    },
-    "xml": {
-      "xmlagg": {
-        "return_type": "xml"
+    "aggregate_functions": {
+      "bit": {
+        "bit_and": {
+          "return_type": "bit"
+        },
+        "bit_or": {
+          "return_type": "bit"
+        },
+        "bit_xor": {
+          "return_type": "bit"
+        }
+      },
+      "bool": {
+        "bool_and": {
+          "return_type": "bool"
+        },
+        "bool_or": {
+          "return_type": "bool"
+        },
+        "every": {
+          "return_type": "bool"
+        }
+      },
+      "bpchar": {
+        "max": {
+          "return_type": "bpchar"
+        },
+        "min": {
+          "return_type": "bpchar"
+        }
+      },
+      "date": {
+        "max": {
+          "return_type": "date"
+        },
+        "min": {
+          "return_type": "date"
+        }
+      },
+      "float4": {
+        "avg": {
+          "return_type": "float8"
+        },
+        "max": {
+          "return_type": "float4"
+        },
+        "min": {
+          "return_type": "float4"
+        },
+        "stddev": {
+          "return_type": "float8"
+        },
+        "stddev_pop": {
+          "return_type": "float8"
+        },
+        "stddev_samp": {
+          "return_type": "float8"
+        },
+        "sum": {
+          "return_type": "float4"
+        },
+        "var_pop": {
+          "return_type": "float8"
+        },
+        "var_samp": {
+          "return_type": "float8"
+        },
+        "variance": {
+          "return_type": "float8"
+        }
+      },
+      "float8": {
+        "avg": {
+          "return_type": "float8"
+        },
+        "max": {
+          "return_type": "float8"
+        },
+        "min": {
+          "return_type": "float8"
+        },
+        "stddev": {
+          "return_type": "float8"
+        },
+        "stddev_pop": {
+          "return_type": "float8"
+        },
+        "stddev_samp": {
+          "return_type": "float8"
+        },
+        "sum": {
+          "return_type": "float8"
+        },
+        "var_pop": {
+          "return_type": "float8"
+        },
+        "var_samp": {
+          "return_type": "float8"
+        },
+        "variance": {
+          "return_type": "float8"
+        }
+      },
+      "inet": {
+        "max": {
+          "return_type": "inet"
+        },
+        "min": {
+          "return_type": "inet"
+        }
+      },
+      "int2": {
+        "avg": {
+          "return_type": "numeric"
+        },
+        "bit_and": {
+          "return_type": "int2"
+        },
+        "bit_or": {
+          "return_type": "int2"
+        },
+        "bit_xor": {
+          "return_type": "int2"
+        },
+        "max": {
+          "return_type": "int2"
+        },
+        "min": {
+          "return_type": "int2"
+        },
+        "stddev": {
+          "return_type": "numeric"
+        },
+        "stddev_pop": {
+          "return_type": "numeric"
+        },
+        "stddev_samp": {
+          "return_type": "numeric"
+        },
+        "sum": {
+          "return_type": "int8"
+        },
+        "var_pop": {
+          "return_type": "numeric"
+        },
+        "var_samp": {
+          "return_type": "numeric"
+        },
+        "variance": {
+          "return_type": "numeric"
+        }
+      },
+      "int4": {
+        "avg": {
+          "return_type": "numeric"
+        },
+        "bit_and": {
+          "return_type": "int4"
+        },
+        "bit_or": {
+          "return_type": "int4"
+        },
+        "bit_xor": {
+          "return_type": "int4"
+        },
+        "max": {
+          "return_type": "int4"
+        },
+        "min": {
+          "return_type": "int4"
+        },
+        "stddev": {
+          "return_type": "numeric"
+        },
+        "stddev_pop": {
+          "return_type": "numeric"
+        },
+        "stddev_samp": {
+          "return_type": "numeric"
+        },
+        "sum": {
+          "return_type": "int8"
+        },
+        "var_pop": {
+          "return_type": "numeric"
+        },
+        "var_samp": {
+          "return_type": "numeric"
+        },
+        "variance": {
+          "return_type": "numeric"
+        }
+      },
+      "int8": {
+        "avg": {
+          "return_type": "numeric"
+        },
+        "bit_and": {
+          "return_type": "int8"
+        },
+        "bit_or": {
+          "return_type": "int8"
+        },
+        "bit_xor": {
+          "return_type": "int8"
+        },
+        "max": {
+          "return_type": "int8"
+        },
+        "min": {
+          "return_type": "int8"
+        },
+        "stddev": {
+          "return_type": "numeric"
+        },
+        "stddev_pop": {
+          "return_type": "numeric"
+        },
+        "stddev_samp": {
+          "return_type": "numeric"
+        },
+        "sum": {
+          "return_type": "numeric"
+        },
+        "var_pop": {
+          "return_type": "numeric"
+        },
+        "var_samp": {
+          "return_type": "numeric"
+        },
+        "variance": {
+          "return_type": "numeric"
+        }
+      },
+      "interval": {
+        "avg": {
+          "return_type": "interval"
+        },
+        "max": {
+          "return_type": "interval"
+        },
+        "min": {
+          "return_type": "interval"
+        },
+        "sum": {
+          "return_type": "interval"
+        }
+      },
+      "json": {
+        "json_cat_agg": {
+          "return_type": "json"
+        }
+      },
+      "jsonb": {
+        "jsonb_cat_agg": {
+          "return_type": "jsonb"
+        }
+      },
+      "money": {
+        "max": {
+          "return_type": "money"
+        },
+        "min": {
+          "return_type": "money"
+        },
+        "sum": {
+          "return_type": "money"
+        }
+      },
+      "numeric": {
+        "avg": {
+          "return_type": "numeric"
+        },
+        "max": {
+          "return_type": "numeric"
+        },
+        "min": {
+          "return_type": "numeric"
+        },
+        "stddev": {
+          "return_type": "numeric"
+        },
+        "stddev_pop": {
+          "return_type": "numeric"
+        },
+        "stddev_samp": {
+          "return_type": "numeric"
+        },
+        "sum": {
+          "return_type": "numeric"
+        },
+        "var_pop": {
+          "return_type": "numeric"
+        },
+        "var_samp": {
+          "return_type": "numeric"
+        },
+        "variance": {
+          "return_type": "numeric"
+        }
+      },
+      "oid": {
+        "max": {
+          "return_type": "oid"
+        },
+        "min": {
+          "return_type": "oid"
+        }
+      },
+      "pg_lsn": {
+        "max": {
+          "return_type": "pg_lsn"
+        },
+        "min": {
+          "return_type": "pg_lsn"
+        }
+      },
+      "text": {
+        "max": {
+          "return_type": "text"
+        },
+        "min": {
+          "return_type": "text"
+        }
+      },
+      "tid": {
+        "max": {
+          "return_type": "tid"
+        },
+        "min": {
+          "return_type": "tid"
+        }
+      },
+      "time": {
+        "max": {
+          "return_type": "time"
+        },
+        "min": {
+          "return_type": "time"
+        }
+      },
+      "timestamp": {
+        "max": {
+          "return_type": "timestamp"
+        },
+        "min": {
+          "return_type": "timestamp"
+        }
+      },
+      "timestamptz": {
+        "max": {
+          "return_type": "timestamptz"
+        },
+        "min": {
+          "return_type": "timestamptz"
+        }
+      },
+      "timetz": {
+        "max": {
+          "return_type": "timetz"
+        },
+        "min": {
+          "return_type": "timetz"
+        }
+      },
+      "xid8": {
+        "max": {
+          "return_type": "xid8"
+        },
+        "min": {
+          "return_type": "xid8"
+        }
+      },
+      "xml": {
+        "xmlagg": {
+          "return_type": "xml"
+        }
       }
     }
   },

--- a/static/cockroach/chinook-deployment.json
+++ b/static/cockroach/chinook-deployment.json
@@ -918,166 +918,166 @@
           }
         }
       }
-    }
-  },
-  "aggregate_functions": {
-    "bool": {
-      "bool_and": {
-        "return_type": "bool"
-      },
-      "bool_or": {
-        "return_type": "bool"
-      },
-      "every": {
-        "return_type": "bool"
-      }
     },
-    "bytea": {
-      "concat_agg": {
-        "return_type": "bytea"
+    "aggregate_functions": {
+      "bool": {
+        "bool_and": {
+          "return_type": "bool"
+        },
+        "bool_or": {
+          "return_type": "bool"
+        },
+        "every": {
+          "return_type": "bool"
+        }
       },
-      "xor_agg": {
-        "return_type": "bytea"
-      }
-    },
-    "float8": {
-      "avg": {
-        "return_type": "float8"
+      "bytea": {
+        "concat_agg": {
+          "return_type": "bytea"
+        },
+        "xor_agg": {
+          "return_type": "bytea"
+        }
       },
-      "sqrdiff": {
-        "return_type": "float8"
+      "float8": {
+        "avg": {
+          "return_type": "float8"
+        },
+        "sqrdiff": {
+          "return_type": "float8"
+        },
+        "stddev": {
+          "return_type": "float8"
+        },
+        "stddev_pop": {
+          "return_type": "float8"
+        },
+        "stddev_samp": {
+          "return_type": "float8"
+        },
+        "sum": {
+          "return_type": "float8"
+        },
+        "var_pop": {
+          "return_type": "float8"
+        },
+        "var_samp": {
+          "return_type": "float8"
+        },
+        "variance": {
+          "return_type": "float8"
+        }
       },
-      "stddev": {
-        "return_type": "float8"
+      "geometry": {
+        "st_collect": {
+          "return_type": "geometry"
+        },
+        "st_extent": {
+          "return_type": "box2d"
+        },
+        "st_makeline": {
+          "return_type": "geometry"
+        },
+        "st_memcollect": {
+          "return_type": "geometry"
+        },
+        "st_memunion": {
+          "return_type": "geometry"
+        },
+        "st_union": {
+          "return_type": "geometry"
+        }
       },
-      "stddev_pop": {
-        "return_type": "float8"
+      "int8": {
+        "avg": {
+          "return_type": "numeric"
+        },
+        "bit_and": {
+          "return_type": "int8"
+        },
+        "bit_or": {
+          "return_type": "int8"
+        },
+        "sqrdiff": {
+          "return_type": "numeric"
+        },
+        "stddev": {
+          "return_type": "numeric"
+        },
+        "stddev_pop": {
+          "return_type": "numeric"
+        },
+        "stddev_samp": {
+          "return_type": "numeric"
+        },
+        "sum": {
+          "return_type": "numeric"
+        },
+        "sum_int": {
+          "return_type": "int8"
+        },
+        "var_pop": {
+          "return_type": "numeric"
+        },
+        "var_samp": {
+          "return_type": "numeric"
+        },
+        "variance": {
+          "return_type": "numeric"
+        },
+        "xor_agg": {
+          "return_type": "int8"
+        }
       },
-      "stddev_samp": {
-        "return_type": "float8"
+      "interval": {
+        "avg": {
+          "return_type": "interval"
+        },
+        "sum": {
+          "return_type": "interval"
+        }
       },
-      "sum": {
-        "return_type": "float8"
+      "numeric": {
+        "avg": {
+          "return_type": "numeric"
+        },
+        "sqrdiff": {
+          "return_type": "numeric"
+        },
+        "stddev": {
+          "return_type": "numeric"
+        },
+        "stddev_pop": {
+          "return_type": "numeric"
+        },
+        "stddev_samp": {
+          "return_type": "numeric"
+        },
+        "sum": {
+          "return_type": "numeric"
+        },
+        "var_pop": {
+          "return_type": "numeric"
+        },
+        "var_samp": {
+          "return_type": "numeric"
+        },
+        "variance": {
+          "return_type": "numeric"
+        }
       },
-      "var_pop": {
-        "return_type": "float8"
+      "text": {
+        "concat_agg": {
+          "return_type": "text"
+        }
       },
-      "var_samp": {
-        "return_type": "float8"
-      },
-      "variance": {
-        "return_type": "float8"
-      }
-    },
-    "geometry": {
-      "st_collect": {
-        "return_type": "geometry"
-      },
-      "st_extent": {
-        "return_type": "box2d"
-      },
-      "st_makeline": {
-        "return_type": "geometry"
-      },
-      "st_memcollect": {
-        "return_type": "geometry"
-      },
-      "st_memunion": {
-        "return_type": "geometry"
-      },
-      "st_union": {
-        "return_type": "geometry"
-      }
-    },
-    "int8": {
-      "avg": {
-        "return_type": "numeric"
-      },
-      "bit_and": {
-        "return_type": "int8"
-      },
-      "bit_or": {
-        "return_type": "int8"
-      },
-      "sqrdiff": {
-        "return_type": "numeric"
-      },
-      "stddev": {
-        "return_type": "numeric"
-      },
-      "stddev_pop": {
-        "return_type": "numeric"
-      },
-      "stddev_samp": {
-        "return_type": "numeric"
-      },
-      "sum": {
-        "return_type": "numeric"
-      },
-      "sum_int": {
-        "return_type": "int8"
-      },
-      "var_pop": {
-        "return_type": "numeric"
-      },
-      "var_samp": {
-        "return_type": "numeric"
-      },
-      "variance": {
-        "return_type": "numeric"
-      },
-      "xor_agg": {
-        "return_type": "int8"
-      }
-    },
-    "interval": {
-      "avg": {
-        "return_type": "interval"
-      },
-      "sum": {
-        "return_type": "interval"
-      }
-    },
-    "numeric": {
-      "avg": {
-        "return_type": "numeric"
-      },
-      "sqrdiff": {
-        "return_type": "numeric"
-      },
-      "stddev": {
-        "return_type": "numeric"
-      },
-      "stddev_pop": {
-        "return_type": "numeric"
-      },
-      "stddev_samp": {
-        "return_type": "numeric"
-      },
-      "sum": {
-        "return_type": "numeric"
-      },
-      "var_pop": {
-        "return_type": "numeric"
-      },
-      "var_samp": {
-        "return_type": "numeric"
-      },
-      "variance": {
-        "return_type": "numeric"
-      }
-    },
-    "text": {
-      "concat_agg": {
-        "return_type": "text"
-      }
-    },
-    "varbit": {
-      "bit_and": {
-        "return_type": "varbit"
-      },
-      "bit_or": {
-        "return_type": "varbit"
+      "varbit": {
+        "bit_and": {
+          "return_type": "varbit"
+        },
+        "bit_or": {
+          "return_type": "varbit"
+        }
       }
     }
   },

--- a/static/yugabyte/chinook-deployment.json
+++ b/static/yugabyte/chinook-deployment.json
@@ -777,354 +777,354 @@
           }
         }
       }
-    }
-  },
-  "aggregate_functions": {
-    "abstime": {
-      "max": {
-        "return_type": "abstime"
-      },
-      "min": {
-        "return_type": "abstime"
-      }
     },
-    "bit": {
-      "bit_and": {
-        "return_type": "bit"
-      },
-      "bit_or": {
-        "return_type": "bit"
-      }
-    },
-    "bool": {
-      "bool_and": {
-        "return_type": "bool"
-      },
-      "bool_or": {
-        "return_type": "bool"
-      },
-      "every": {
-        "return_type": "bool"
-      }
-    },
-    "bpchar": {
-      "max": {
-        "return_type": "bpchar"
-      },
-      "min": {
-        "return_type": "bpchar"
-      }
-    },
-    "date": {
-      "max": {
-        "return_type": "date"
-      },
-      "min": {
-        "return_type": "date"
-      }
-    },
-    "float4": {
-      "avg": {
-        "return_type": "float8"
-      },
-      "max": {
-        "return_type": "float4"
-      },
-      "min": {
-        "return_type": "float4"
-      },
-      "stddev": {
-        "return_type": "float8"
-      },
-      "stddev_pop": {
-        "return_type": "float8"
-      },
-      "stddev_samp": {
-        "return_type": "float8"
-      },
-      "sum": {
-        "return_type": "float4"
-      },
-      "var_pop": {
-        "return_type": "float8"
-      },
-      "var_samp": {
-        "return_type": "float8"
-      },
-      "variance": {
-        "return_type": "float8"
-      }
-    },
-    "float8": {
-      "avg": {
-        "return_type": "float8"
-      },
-      "max": {
-        "return_type": "float8"
-      },
-      "min": {
-        "return_type": "float8"
-      },
-      "stddev": {
-        "return_type": "float8"
-      },
-      "stddev_pop": {
-        "return_type": "float8"
-      },
-      "stddev_samp": {
-        "return_type": "float8"
-      },
-      "sum": {
-        "return_type": "float8"
-      },
-      "var_pop": {
-        "return_type": "float8"
-      },
-      "var_samp": {
-        "return_type": "float8"
-      },
-      "variance": {
-        "return_type": "float8"
-      }
-    },
-    "inet": {
-      "max": {
-        "return_type": "inet"
-      },
-      "min": {
-        "return_type": "inet"
-      }
-    },
-    "int2": {
-      "avg": {
-        "return_type": "numeric"
-      },
-      "bit_and": {
-        "return_type": "int2"
-      },
-      "bit_or": {
-        "return_type": "int2"
-      },
-      "max": {
-        "return_type": "int2"
-      },
-      "min": {
-        "return_type": "int2"
-      },
-      "stddev": {
-        "return_type": "numeric"
-      },
-      "stddev_pop": {
-        "return_type": "numeric"
-      },
-      "stddev_samp": {
-        "return_type": "numeric"
-      },
-      "sum": {
-        "return_type": "int8"
-      },
-      "var_pop": {
-        "return_type": "numeric"
-      },
-      "var_samp": {
-        "return_type": "numeric"
-      },
-      "variance": {
-        "return_type": "numeric"
-      }
-    },
-    "int4": {
-      "avg": {
-        "return_type": "numeric"
-      },
-      "bit_and": {
-        "return_type": "int4"
-      },
-      "bit_or": {
-        "return_type": "int4"
-      },
-      "max": {
-        "return_type": "int4"
-      },
-      "min": {
-        "return_type": "int4"
-      },
-      "stddev": {
-        "return_type": "numeric"
-      },
-      "stddev_pop": {
-        "return_type": "numeric"
-      },
-      "stddev_samp": {
-        "return_type": "numeric"
-      },
-      "sum": {
-        "return_type": "int8"
-      },
-      "var_pop": {
-        "return_type": "numeric"
-      },
-      "var_samp": {
-        "return_type": "numeric"
-      },
-      "variance": {
-        "return_type": "numeric"
-      }
-    },
-    "int8": {
-      "avg": {
-        "return_type": "numeric"
-      },
-      "bit_and": {
-        "return_type": "int8"
-      },
-      "bit_or": {
-        "return_type": "int8"
-      },
-      "max": {
-        "return_type": "int8"
-      },
-      "min": {
-        "return_type": "int8"
-      },
-      "stddev": {
-        "return_type": "numeric"
-      },
-      "stddev_pop": {
-        "return_type": "numeric"
-      },
-      "stddev_samp": {
-        "return_type": "numeric"
-      },
-      "sum": {
-        "return_type": "numeric"
-      },
-      "var_pop": {
-        "return_type": "numeric"
-      },
-      "var_samp": {
-        "return_type": "numeric"
-      },
-      "variance": {
-        "return_type": "numeric"
-      }
-    },
-    "interval": {
-      "avg": {
-        "return_type": "interval"
-      },
-      "max": {
-        "return_type": "interval"
-      },
-      "min": {
-        "return_type": "interval"
-      },
-      "sum": {
-        "return_type": "interval"
-      }
-    },
-    "money": {
-      "max": {
-        "return_type": "money"
-      },
-      "min": {
-        "return_type": "money"
-      },
-      "sum": {
-        "return_type": "money"
-      }
-    },
-    "numeric": {
-      "avg": {
-        "return_type": "numeric"
-      },
-      "max": {
-        "return_type": "numeric"
-      },
-      "min": {
-        "return_type": "numeric"
-      },
-      "stddev": {
-        "return_type": "numeric"
-      },
-      "stddev_pop": {
-        "return_type": "numeric"
-      },
-      "stddev_samp": {
-        "return_type": "numeric"
-      },
-      "sum": {
-        "return_type": "numeric"
-      },
-      "var_pop": {
-        "return_type": "numeric"
-      },
-      "var_samp": {
-        "return_type": "numeric"
-      },
-      "variance": {
-        "return_type": "numeric"
-      }
-    },
-    "oid": {
-      "max": {
-        "return_type": "oid"
-      },
-      "min": {
-        "return_type": "oid"
-      }
-    },
-    "text": {
-      "max": {
-        "return_type": "text"
-      },
-      "min": {
-        "return_type": "text"
-      }
-    },
-    "tid": {
-      "max": {
-        "return_type": "tid"
-      },
-      "min": {
-        "return_type": "tid"
-      }
-    },
-    "time": {
-      "max": {
-        "return_type": "time"
-      },
-      "min": {
-        "return_type": "time"
-      }
-    },
-    "timestamp": {
-      "max": {
-        "return_type": "timestamp"
-      },
-      "min": {
-        "return_type": "timestamp"
-      }
-    },
-    "timestamptz": {
-      "max": {
-        "return_type": "timestamptz"
-      },
-      "min": {
-        "return_type": "timestamptz"
-      }
-    },
-    "timetz": {
-      "max": {
-        "return_type": "timetz"
-      },
-      "min": {
-        "return_type": "timetz"
-      }
-    },
-    "xml": {
-      "xmlagg": {
-        "return_type": "xml"
+    "aggregate_functions": {
+      "abstime": {
+        "max": {
+          "return_type": "abstime"
+        },
+        "min": {
+          "return_type": "abstime"
+        }
+      },
+      "bit": {
+        "bit_and": {
+          "return_type": "bit"
+        },
+        "bit_or": {
+          "return_type": "bit"
+        }
+      },
+      "bool": {
+        "bool_and": {
+          "return_type": "bool"
+        },
+        "bool_or": {
+          "return_type": "bool"
+        },
+        "every": {
+          "return_type": "bool"
+        }
+      },
+      "bpchar": {
+        "max": {
+          "return_type": "bpchar"
+        },
+        "min": {
+          "return_type": "bpchar"
+        }
+      },
+      "date": {
+        "max": {
+          "return_type": "date"
+        },
+        "min": {
+          "return_type": "date"
+        }
+      },
+      "float4": {
+        "avg": {
+          "return_type": "float8"
+        },
+        "max": {
+          "return_type": "float4"
+        },
+        "min": {
+          "return_type": "float4"
+        },
+        "stddev": {
+          "return_type": "float8"
+        },
+        "stddev_pop": {
+          "return_type": "float8"
+        },
+        "stddev_samp": {
+          "return_type": "float8"
+        },
+        "sum": {
+          "return_type": "float4"
+        },
+        "var_pop": {
+          "return_type": "float8"
+        },
+        "var_samp": {
+          "return_type": "float8"
+        },
+        "variance": {
+          "return_type": "float8"
+        }
+      },
+      "float8": {
+        "avg": {
+          "return_type": "float8"
+        },
+        "max": {
+          "return_type": "float8"
+        },
+        "min": {
+          "return_type": "float8"
+        },
+        "stddev": {
+          "return_type": "float8"
+        },
+        "stddev_pop": {
+          "return_type": "float8"
+        },
+        "stddev_samp": {
+          "return_type": "float8"
+        },
+        "sum": {
+          "return_type": "float8"
+        },
+        "var_pop": {
+          "return_type": "float8"
+        },
+        "var_samp": {
+          "return_type": "float8"
+        },
+        "variance": {
+          "return_type": "float8"
+        }
+      },
+      "inet": {
+        "max": {
+          "return_type": "inet"
+        },
+        "min": {
+          "return_type": "inet"
+        }
+      },
+      "int2": {
+        "avg": {
+          "return_type": "numeric"
+        },
+        "bit_and": {
+          "return_type": "int2"
+        },
+        "bit_or": {
+          "return_type": "int2"
+        },
+        "max": {
+          "return_type": "int2"
+        },
+        "min": {
+          "return_type": "int2"
+        },
+        "stddev": {
+          "return_type": "numeric"
+        },
+        "stddev_pop": {
+          "return_type": "numeric"
+        },
+        "stddev_samp": {
+          "return_type": "numeric"
+        },
+        "sum": {
+          "return_type": "int8"
+        },
+        "var_pop": {
+          "return_type": "numeric"
+        },
+        "var_samp": {
+          "return_type": "numeric"
+        },
+        "variance": {
+          "return_type": "numeric"
+        }
+      },
+      "int4": {
+        "avg": {
+          "return_type": "numeric"
+        },
+        "bit_and": {
+          "return_type": "int4"
+        },
+        "bit_or": {
+          "return_type": "int4"
+        },
+        "max": {
+          "return_type": "int4"
+        },
+        "min": {
+          "return_type": "int4"
+        },
+        "stddev": {
+          "return_type": "numeric"
+        },
+        "stddev_pop": {
+          "return_type": "numeric"
+        },
+        "stddev_samp": {
+          "return_type": "numeric"
+        },
+        "sum": {
+          "return_type": "int8"
+        },
+        "var_pop": {
+          "return_type": "numeric"
+        },
+        "var_samp": {
+          "return_type": "numeric"
+        },
+        "variance": {
+          "return_type": "numeric"
+        }
+      },
+      "int8": {
+        "avg": {
+          "return_type": "numeric"
+        },
+        "bit_and": {
+          "return_type": "int8"
+        },
+        "bit_or": {
+          "return_type": "int8"
+        },
+        "max": {
+          "return_type": "int8"
+        },
+        "min": {
+          "return_type": "int8"
+        },
+        "stddev": {
+          "return_type": "numeric"
+        },
+        "stddev_pop": {
+          "return_type": "numeric"
+        },
+        "stddev_samp": {
+          "return_type": "numeric"
+        },
+        "sum": {
+          "return_type": "numeric"
+        },
+        "var_pop": {
+          "return_type": "numeric"
+        },
+        "var_samp": {
+          "return_type": "numeric"
+        },
+        "variance": {
+          "return_type": "numeric"
+        }
+      },
+      "interval": {
+        "avg": {
+          "return_type": "interval"
+        },
+        "max": {
+          "return_type": "interval"
+        },
+        "min": {
+          "return_type": "interval"
+        },
+        "sum": {
+          "return_type": "interval"
+        }
+      },
+      "money": {
+        "max": {
+          "return_type": "money"
+        },
+        "min": {
+          "return_type": "money"
+        },
+        "sum": {
+          "return_type": "money"
+        }
+      },
+      "numeric": {
+        "avg": {
+          "return_type": "numeric"
+        },
+        "max": {
+          "return_type": "numeric"
+        },
+        "min": {
+          "return_type": "numeric"
+        },
+        "stddev": {
+          "return_type": "numeric"
+        },
+        "stddev_pop": {
+          "return_type": "numeric"
+        },
+        "stddev_samp": {
+          "return_type": "numeric"
+        },
+        "sum": {
+          "return_type": "numeric"
+        },
+        "var_pop": {
+          "return_type": "numeric"
+        },
+        "var_samp": {
+          "return_type": "numeric"
+        },
+        "variance": {
+          "return_type": "numeric"
+        }
+      },
+      "oid": {
+        "max": {
+          "return_type": "oid"
+        },
+        "min": {
+          "return_type": "oid"
+        }
+      },
+      "text": {
+        "max": {
+          "return_type": "text"
+        },
+        "min": {
+          "return_type": "text"
+        }
+      },
+      "tid": {
+        "max": {
+          "return_type": "tid"
+        },
+        "min": {
+          "return_type": "tid"
+        }
+      },
+      "time": {
+        "max": {
+          "return_type": "time"
+        },
+        "min": {
+          "return_type": "time"
+        }
+      },
+      "timestamp": {
+        "max": {
+          "return_type": "timestamp"
+        },
+        "min": {
+          "return_type": "timestamp"
+        }
+      },
+      "timestamptz": {
+        "max": {
+          "return_type": "timestamptz"
+        },
+        "min": {
+          "return_type": "timestamptz"
+        }
+      },
+      "timetz": {
+        "max": {
+          "return_type": "timetz"
+        },
+        "min": {
+          "return_type": "timetz"
+        }
+      },
+      "xml": {
+        "xmlagg": {
+          "return_type": "xml"
+        }
       }
     }
   },


### PR DESCRIPTION
### What

We move the field `aggregate_functions` into the `metadata` object in `RawConfiguration`, in order to co-locate all introspected metadata.

### How

<!-- How is it trying to accomplish it (what are the implementation steps)? -->
