### PR TITLE
Update snapshot paths.

### DIFF
--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__basic__select_5.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__basic__select_5.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__basic__select_by_pk.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__basic__select_by_pk.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__basic__select_int_and_string.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__basic__select_int_and_string.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__native_queries__select_artist.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__native_queries__select_artist.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__native_queries__select_artist_with_album_by_title_relationship_arguments.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__native_queries__select_artist_with_album_by_title_relationship_arguments.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__native_queries__select_artists_below_id.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__native_queries__select_artists_below_id.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_album_id_equals_self.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_album_id_equals_self.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_album_id_greater_than.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_album_id_greater_than.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_album_id_greater_than_or_equal_to.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_album_id_greater_than_or_equal_to.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_album_id_is_not_null.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_album_id_is_not_null.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_album_id_less_than.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_album_id_less_than.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_album_id_less_than_or_equal_to.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_album_id_less_than_or_equal_to.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_ilike.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_ilike.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_in.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_in.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_iregex.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_iregex.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_like.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_like.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_nilike.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_nilike.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_niregex.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_niregex.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_not_in.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_not_in.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_not_like.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_not_like.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_nregex.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_nregex.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_nsimilar.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_nsimilar.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_regex.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_regex.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_similar.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_name_similar.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_unrelated_exists.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_unrelated_exists.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_variable.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_variable.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_variable_int.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__predicates__select_where_variable_int.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__sorting__select_order_by_album_artist_name.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__sorting__select_order_by_album_artist_name.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-citus/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__sorting__select_order_by_artist_album_count.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__sorting__select_order_by_artist_album_count.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__sorting__select_order_by_artist_album_count_agg.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__sorting__select_order_by_artist_album_count_agg.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__sorting__select_order_by_artist_name.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__sorting__select_order_by_artist_name.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-citus/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__sorting__select_order_by_name.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__sorting__select_order_by_name.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-citus/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-citus/tests/snapshots/query_tests__sorting__select_track_order_by_artist_id_and_album_title.snap
+++ b/crates/connectors/ndc-citus/tests/snapshots/query_tests__sorting__select_track_order_by_artist_id_and_album_title.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-citus/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__aggregation__aggregate_count_artist_albums.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__aggregation__aggregate_count_artist_albums.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__aggregation__aggregate_count_artist_albums_plus_field.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__aggregation__aggregate_count_artist_albums_plus_field.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__basic__select_5.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__basic__select_5.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__basic__select_by_pk.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__basic__select_by_pk.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__basic__select_int_and_string.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__basic__select_int_and_string.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__native_queries__select_artist.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__native_queries__select_artist.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__native_queries__select_artist_with_album_by_title_relationship_arguments.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__native_queries__select_artist_with_album_by_title_relationship_arguments.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__native_queries__select_artists_below_id.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__native_queries__select_artists_below_id.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__native_queries__select_sort_relationship.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__native_queries__select_sort_relationship.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-cockroach/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__native_queries__select_where_relationship.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__native_queries__select_where_relationship.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-cockroach/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_album_id_equals_self.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_album_id_equals_self.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_album_id_greater_than.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_album_id_greater_than.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_album_id_greater_than_or_equal_to.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_album_id_greater_than_or_equal_to.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_album_id_is_not_null.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_album_id_is_not_null.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_album_id_less_than.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_album_id_less_than.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_album_id_less_than_or_equal_to.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_album_id_less_than_or_equal_to.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_ilike.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_ilike.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_in.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_in.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_iregex.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_iregex.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_like.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_like.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_nilike.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_nilike.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_niregex.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_niregex.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_not_in.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_not_in.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_not_like.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_not_like.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_nregex.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_nregex.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_nsimilar.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_nsimilar.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_regex.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_regex.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_similar.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_name_similar.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_related_exists.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_related_exists.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_unrelated_exists.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_unrelated_exists.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_variable.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_variable.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_variable_int.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__predicates__select_where_variable_int.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__relationships__dup_array_relationship.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__relationships__dup_array_relationship.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__relationships__nested_array_relationships.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__relationships__nested_array_relationships.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__relationships__nested_object_relationships.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__relationships__nested_object_relationships.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__relationships__select_album_object_relationship_to_artist.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__relationships__select_album_object_relationship_to_artist.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__relationships__select_artist_array_relationship_to_album.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__relationships__select_artist_array_relationship_to_album.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__sorting__select_order_by_album_artist_name.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__sorting__select_order_by_album_artist_name.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__sorting__select_order_by_artist_album_count.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__sorting__select_order_by_artist_album_count.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__sorting__select_order_by_artist_album_count_agg.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__sorting__select_order_by_artist_album_count_agg.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__sorting__select_order_by_artist_name.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__sorting__select_order_by_artist_name.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__sorting__select_order_by_artist_name_with_name.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__sorting__select_order_by_artist_name_with_name.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__sorting__select_order_by_name.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__sorting__select_order_by_name.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__sorting__select_track_order_by_artist_id_and_album_title.snap
+++ b/crates/connectors/ndc-cockroach/tests/snapshots/query_tests__sorting__select_track_order_by_artist_id_and_album_title.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-cockroach/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/mutation_tests__basic__select_by_pk.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/mutation_tests__basic__select_by_pk.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/mutation_tests.rs
+source: crates/connectors/ndc-postgres/tests/mutation_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__basic__select_5.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__basic__select_5.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__basic__select_by_pk.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__basic__select_by_pk.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__basic__select_int_and_string.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__basic__select_int_and_string.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__native_queries__select_artist.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__native_queries__select_artist.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__native_queries__select_artist_with_album_by_title_relationship_arguments.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__native_queries__select_artist_with_album_by_title_relationship_arguments.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__native_queries__select_artists_below_id.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__native_queries__select_artists_below_id.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_album_id_equals_self.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_album_id_equals_self.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_album_id_greater_than.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_album_id_greater_than.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_album_id_greater_than_or_equal_to.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_album_id_greater_than_or_equal_to.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_album_id_is_not_null.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_album_id_is_not_null.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_album_id_less_than.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_album_id_less_than.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_album_id_less_than_or_equal_to.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_album_id_less_than_or_equal_to.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_eq.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_eq.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_ilike.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_ilike.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_in.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_in.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_iregex.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_iregex.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_like.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_like.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_neq.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_neq.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_nilike.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_nilike.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_niregex.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_niregex.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_not_in.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_not_in.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_not_like.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_not_like.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_nregex.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_nregex.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_nsimilar.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_nsimilar.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_regex.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_regex.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_similar.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_name_similar.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_unrelated_exists.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_unrelated_exists.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_variable.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_variable.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_variable_int.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__predicates__select_where_variable_int.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__sorting__select_order_by_album_artist_name.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__sorting__select_order_by_album_artist_name.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__sorting__select_order_by_artist_album_count.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__sorting__select_order_by_artist_album_count.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__sorting__select_order_by_artist_album_count_agg.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__sorting__select_order_by_artist_album_count_agg.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__sorting__select_order_by_artist_name.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__sorting__select_order_by_artist_name.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__sorting__select_order_by_name.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__sorting__select_order_by_name.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [

--- a/crates/connectors/ndc-postgres/tests/snapshots/query_tests__sorting__select_track_order_by_artist_id_and_album_title.snap
+++ b/crates/connectors/ndc-postgres/tests/snapshots/query_tests__sorting__select_track_order_by_artist_id_and_album_title.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ndc-postgres/tests/query_tests.rs
+source: crates/connectors/ndc-postgres/tests/query_tests.rs
 expression: result
 ---
 [


### PR DESCRIPTION
### What

`cargo-insta` doesn't seem to complain if the paths are wrong. This makes diffs confusing when snapshots actually change.

It does, however, provide a `--force-update-snapshots` option to solve this.

### How

```
$ cargo insta test --force-update-snapshots
```
