### PR TITLE
Make it easier to run the deployment script without actually deploying.

### DIFF
--- a/.github/workflows/nix-docker.yaml
+++ b/.github/workflows/nix-docker.yaml
@@ -36,7 +36,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and deploy docker images 🚀
-        run: nix run .#publish-docker-image ${{ github.ref }} ${{ matrix.connector }}
+        run: nix run .#publish-docker-image '${{ github.ref }}' '${{ matrix.connector }}' 'ghcr.io/hasura/${{ matrix.connector }}'
 
       # scream into Slack if something goes wrong
       - name: Report Status

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -13,20 +13,23 @@ if [[ "${1:-}" == '-n' || "${1:-}" == '--dry-run' ]]; then
   shift
 fi
 
-if [[ $# -ne 2 ]]; then
-    echo >&2 "Usage: ${0} [-n|--dry-run] REF BINARY"
+if [[ $# -ne 3 ]]; then
+    echo >&2 "Usage: ${0} [-n|--dry-run] REF BINARY IMAGE"
     echo >&2
     echo >&2 '    REF should be in the form "refs/heads/<branch>" or "refs/tags/<tag>"'
-    echo >&2 '      (in a Github workflow the variable `github.ref` has this format)'
+    echo >&2 '      (in a Github workflow the variable "github.ref" has this format)'
+    echo >&2
+    echo >&2 '    BINARY is the name of the binary, e.g. "ndc-postgres"'
+    echo >&2
+    echo >&2 '    IMAGE is the path of the Docker image, e.g. "ghcr.io/hasura/ndc-postgres"'
     echo >&2
     echo >&2 '    "--dry-run" will not push anything, but it will still build'
     exit 1
 fi
 
 github_ref="$1"
-binary_image_name="$2" # ie, 'ndc-postgres'
-
-image_path="ghcr.io/hasura/${binary_image_name}"
+binary_image_name="$2"
+image_path="$3"
 
 # Runs the given command, unless `--dry-run` was set.
 function run {


### PR DESCRIPTION
### What

I want to make the deployment script easier to extend.

I have:

1. added a `--dry-run` flag which stops it from pushing, which makes it easier to test, kind of; and
2. changed the parameters so you need to explicitly name the image rather than computing it.

In order to test the script, I also needed to make it run from this branch, temporarily. I have therefore added a line to make sure test failures are only reported to Slack from the `main` branch or a tag.

### How

The usual. Bashing the keyboard to create more bash.