### PR TITLE
Use the health check when possible in scripts.

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -37,7 +37,6 @@ jobs:
           docker compose up --detach --wait agent-configuration
           CONFIGURATION_SERVER_PORT="$(docker compose port agent-configuration 9100 | sed 's/.\+://')"
           CONFIGURATION_SERVER_URL="http://localhost:${CONFIGURATION_SERVER_PORT}/"
-          ../../scripts/wait-until --timeout=30 --report -- nc -z localhost "$CONFIGURATION_SERVER_PORT"
           curl -fsS "$CONFIGURATION_SERVER_URL" \
             | jq --arg uri 'postgresql://postgres:password@postgres' '. + {"connectionUri": {"uri": $uri}}' \
             | curl -fsS "$CONFIGURATION_SERVER_URL" -H 'Content-Type: application/json' -d @- \

--- a/benchmarks/component/docker-compose.yaml
+++ b/benchmarks/component/docker-compose.yaml
@@ -62,6 +62,14 @@ services:
         source: ./generated/deployment.json
         target: /deployment.json
         read_only: true
+    healthcheck:
+      test:
+        - CMD
+        - ndc-postgres
+        - check-health
+      interval: 1s
+      timeout: 1s
+      retries: 30
     depends_on:
       postgres:
         condition: service_started
@@ -74,6 +82,15 @@ services:
     init: true
     ports:
       - 9100
+    healthcheck:
+      test:
+        - CMD
+        - ndc-postgres
+        - check-health
+        - --port=9100
+      interval: 1s
+      timeout: 1s
+      retries: 30
     depends_on:
       postgres:
         condition: service_started

--- a/scripts/generate-chinook-configuration.sh
+++ b/scripts/generate-chinook-configuration.sh
@@ -20,7 +20,7 @@ trap stop EXIT
 # start the configuration server
 cargo run --bin "$EXECUTABLE" --quiet -- configuration serve &
 CONFIGURATION_SERVER_PID=$!
-./scripts/wait-until --timeout=30 --report -- nc -z localhost 9100
+./scripts/wait-until --timeout=30 --report -- cargo run --bin "$EXECUTABLE" --quiet -- check-health --port=9100
 if ! kill -0 "$CONFIGURATION_SERVER_PID"; then
   echo >&2 'The server stopped abruptly.'
   exit 1


### PR DESCRIPTION
### What

`ndc-postgres check-health` should be more robust than using `nc -z`, as it makes a call to `/health` and ensures it receives a successful response, instead of just verifying that the port is open.

### How

I switched out `nc -z localhost $PORT` for `ndc-postgres check-health --port=$PORT` where possible. There's only one place where it's still necessary.

In the benchmarks' Docker Compose file, I added health checks so we could remove the call to `wait-until` in CI. I expect it will fix the sporadic failures we're seeing.