### PR TITLE
Push Docker images to Google Container Registry too.

### DIFF
--- a/.github/workflows/nix-docker.yaml
+++ b/.github/workflows/nix-docker.yaml
@@ -18,6 +18,10 @@ jobs:
           - ndc-cockroach
           - ndc-postgres
       fail-fast: false
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
 
     steps:
       - name: Checkout 🛎️
@@ -29,6 +33,21 @@ jobs:
       - name: Run the Magic Nix Cache 🔌
         uses: DeterminateSystems/magic-nix-cache-action@v2
 
+      - id: gcloud-auth
+        name: Authenticate to Google Cloud 🔑
+        uses: google-github-actions/auth@v1
+        with:
+          token_format: access_token
+          service_account: "hasura-ci-docker-writer@hasura-ddn.iam.gserviceaccount.com"
+          workload_identity_provider: "projects/1025009031284/locations/global/workloadIdentityPools/hasura-ddn/providers/github"
+
+      - name: Login to Google Container Registry 📦
+        uses: "docker/login-action@v3"
+        with:
+          registry: "us-docker.pkg.dev"
+          username: "oauth2accesstoken"
+          password: "${{ steps.gcloud-auth.outputs.access_token }}"
+
       - name: Login to GitHub Container Registry 📦
         uses: docker/login-action@v3
         with:
@@ -36,7 +55,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and deploy docker images 🚀
+      - name: Build and deploy Docker images to Google Container Registry 🚀
+        run: nix run .#publish-docker-image '${{ github.ref }}' '${{ matrix.connector }}' 'us-docker.pkg.dev/hasura-ddn/ddn/${{ matrix.connector }}'
+
+      - name: Build and deploy Docker images to GitHub Packages 🚀
         run: nix run .#publish-docker-image '${{ github.ref }}' '${{ matrix.connector }}' 'ghcr.io/hasura/${{ matrix.connector }}'
 
       # scream into Slack if something goes wrong


### PR DESCRIPTION
### What

We would like images to be hosted on Google Container Registry for our own convenience.

We will keep pushing them to GitHub too, for now.

### How

Augmenting the GitHub workflow to log into Google Cloud and push the images there too.

For authentication, we first need to authenticate to Google Cloud with workload identity federation, then log into Google Container Registry.