### PR TITLE
set license in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 
 package.version = "0.1.0"
 package.edition = "2021"
+package.license = "Apache-2.0"
 
 members = [
   "crates/connectors/ndc-citus",

--- a/crates/connectors/ndc-citus/Cargo.toml
+++ b/crates/connectors/ndc-citus/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ndc-citus"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 default-run = "ndc-citus"
 

--- a/crates/connectors/ndc-cockroach/Cargo.toml
+++ b/crates/connectors/ndc-cockroach/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ndc-cockroach"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 default-run = "ndc-cockroach"
 

--- a/crates/connectors/ndc-postgres/Cargo.toml
+++ b/crates/connectors/ndc-postgres/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ndc-postgres"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 default-run = "ndc-postgres"
 

--- a/crates/documentation/openapi/Cargo.toml
+++ b/crates/documentation/openapi/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "openapi-generator"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 insta = { version = "1.33.0", features = ["json"] }

--- a/crates/query-engine/execution/Cargo.toml
+++ b/crates/query-engine/execution/Cargo.toml
@@ -2,6 +2,7 @@
 name = "query-engine-execution"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 query-engine-sql = { path = "../sql" }

--- a/crates/query-engine/metadata/Cargo.toml
+++ b/crates/query-engine/metadata/Cargo.toml
@@ -2,6 +2,7 @@
 name = "query-engine-metadata"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 schemars = { version = "0.8.15", features = ["smol_str"] }

--- a/crates/query-engine/sql/Cargo.toml
+++ b/crates/query-engine/sql/Cargo.toml
@@ -2,6 +2,7 @@
 name = "query-engine-sql"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 serde_json = "1.0.107"

--- a/crates/query-engine/translation/Cargo.toml
+++ b/crates/query-engine/translation/Cargo.toml
@@ -2,6 +2,7 @@
 name = "query-engine-translation"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 

--- a/crates/tests/other-db-tests/Cargo.toml
+++ b/crates/tests/other-db-tests/Cargo.toml
@@ -2,6 +2,7 @@
 name = "other-db-tests"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [features]
 # We only run the AWS Aurora tests if this feature is enabled.

--- a/crates/tests/tests-common/Cargo.toml
+++ b/crates/tests/tests-common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tests-common"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [lib]
 name = "tests_common"


### PR DESCRIPTION
### What

We set the project's license in the `Cargo.toml` files so that it can be picked up by tools such as [cargo-license](https://github.com/onur/cargo-license).
