### PR TITLE
chore: only trigger alerts for jobs that only run on main

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -78,7 +78,7 @@ jobs:
 
       # scream into Slack if something goes wrong
       - name: Report Status
-        if: github.ref == 'refs/heads/main'
+        if: always()
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ job.status }}

--- a/.github/workflows/cargo-build.yaml
+++ b/.github/workflows/cargo-build.yaml
@@ -45,15 +45,3 @@ jobs:
       - name: lint
         run: |
           cargo clippy --release -- --deny=clippy::all
-
-      # scream into Slack if something goes wrong
-      - name: report status
-        if: github.ref == 'refs/heads/main'
-        uses: ravsamhq/notify-slack-action@v2
-        with:
-          status: ${{ job.status }}
-          notify_when: failure
-          notification_title: "😧 Error on <{repo_url}|{repo}>"
-          message_format: "🐴 *{workflow}* {status_message} for <{repo_url}|{repo}>"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.BROKEN_BUILD_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/cargo-machete.yaml
+++ b/.github/workflows/cargo-machete.yaml
@@ -23,15 +23,3 @@ jobs:
       - name: find unused dependencies
         run: |
           cargo machete
-
-      # scream into Slack if something goes wrong
-      - name: Report Status
-        if: github.ref == 'refs/heads/main'
-        uses: ravsamhq/notify-slack-action@v2
-        with:
-          status: ${{ job.status }}
-          notify_when: failure
-          notification_title: "😧 Error on <{repo_url}|{repo}>"
-          message_format: "🐴 *{workflow}* {status_message} for <{repo_url}|{repo}>"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.BROKEN_BUILD_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/cargo-test.yaml
+++ b/.github/workflows/cargo-test.yaml
@@ -34,18 +34,6 @@ jobs:
         env:
           RUST_LOG: INFO
 
-      # scream into Slack if something goes wrong
-      - name: report status
-        if: github.ref == 'refs/heads/main'
-        uses: ravsamhq/notify-slack-action@v2
-        with:
-          status: ${{ job.status }}
-          notify_when: failure
-          notification_title: "😧 Error on <{repo_url}|{repo}>"
-          message_format: "🐴 *{workflow}* {status_message} for <{repo_url}|{repo}>"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.BROKEN_BUILD_SLACK_WEBHOOK_URL }}
-
   test-connector:
     strategy:
       matrix:
@@ -202,15 +190,3 @@ jobs:
           cargo nextest run --no-fail-fast --release -p other-db-tests --features yugabyte
         env:
           RUST_LOG: INFO
-
-      # scream into Slack if something goes wrong
-      - name: report status
-        if: github.ref == 'refs/heads/main'
-        uses: ravsamhq/notify-slack-action@v2
-        with:
-          status: ${{ job.status }}
-          notify_when: failure
-          notification_title: "😧 Error on <{repo_url}|{repo}>"
-          message_format: "🐴 *{workflow}* {status_message} for <{repo_url}|{repo}>"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.BROKEN_BUILD_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -49,18 +49,6 @@ jobs:
         run: |
           nix develop --command nixpkgs-fmt --check .
 
-      # scream into Slack if something goes wrong
-      - name: Report Status
-        if: github.ref == 'refs/heads/main'
-        uses: ravsamhq/notify-slack-action@v2
-        with:
-          status: ${{ job.status }}
-          notify_when: failure
-          notification_title: "😧 Error on <{repo_url}|{repo}>"
-          message_format: "🐴 *{workflow}* {status_message} for <{repo_url}|{repo}>"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.BROKEN_BUILD_SLACK_WEBHOOK_URL }}
-
   prettier:
     name: check formatting with prettier
     runs-on: ubuntu-latest
@@ -74,15 +62,3 @@ jobs:
       - name: check formatting
         run: |
           nix develop --command prettier --check .
-
-      # scream into Slack if something goes wrong
-      - name: Report Status
-        if: github.ref == 'refs/heads/main'
-        uses: ravsamhq/notify-slack-action@v2
-        with:
-          status: ${{ job.status }}
-          notify_when: failure
-          notification_title: "😧 Error on <{repo_url}|{repo}>"
-          message_format: "🐴 *{workflow}* {status_message} for <{repo_url}|{repo}>"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.BROKEN_BUILD_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nix-check.yaml
+++ b/.github/workflows/nix-check.yaml
@@ -18,18 +18,6 @@ jobs:
         run: |
           nix flake check --print-build-logs
 
-      # scream into Slack if something goes wrong
-      - name: Report Status
-        if: github.ref == 'refs/heads/main'
-        uses: ravsamhq/notify-slack-action@v2
-        with:
-          status: ${{ job.status }}
-          notify_when: failure
-          notification_title: "😧 Error on <{repo_url}|{repo}>"
-          message_format: "🐴 *{workflow}* {status_message} for <{repo_url}|{repo}>"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.BROKEN_BUILD_SLACK_WEBHOOK_URL }}
-
   nix-develop:
     name: nix develop
     runs-on: ubuntu-latest
@@ -43,15 +31,3 @@ jobs:
       - name: nix develop --command true
         run: |
           nix develop --print-build-logs --command true
-
-      # scream into Slack if something goes wrong
-      - name: Report Status
-        if: github.ref == 'refs/heads/main'
-        uses: ravsamhq/notify-slack-action@v2
-        with:
-          status: ${{ job.status }}
-          notify_when: failure
-          notification_title: "😧 Error on <{repo_url}|{repo}>"
-          message_format: "🐴 *{workflow}* {status_message} for <{repo_url}|{repo}>"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.BROKEN_BUILD_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nix-docker.yaml
+++ b/.github/workflows/nix-docker.yaml
@@ -63,7 +63,7 @@ jobs:
 
       # scream into Slack if something goes wrong
       - name: Report Status
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+        if: always()
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ job.status }}

--- a/.github/workflows/schema-definitions.yaml
+++ b/.github/workflows/schema-definitions.yaml
@@ -19,15 +19,3 @@ jobs:
 
       - name: OpenAPI Definitions
         run: cargo test --bin openapi-generator
-
-      # scream into Slack if something goes wrong
-      - name: Report Status
-        if: github.ref == 'refs/heads/main'
-        uses: ravsamhq/notify-slack-action@v2
-        with:
-          status: ${{ job.status }}
-          notify_when: failure
-          notification_title: "😧 Error on <{repo_url}|{repo}>"
-          message_format: "🐴 *{workflow}* {status_message} for <{repo_url}|{repo}>"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.BROKEN_BUILD_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

Our Slack alerts only work with `if: always()`

### How

Keep them on jobs that only run on `main` (where they are useful). Remove otherwise.
