### PR TITLE
chore: add internal.visibility = 'user' for execute query span

### DIFF
--- a/crates/query-engine/execution/src/execution.rs
+++ b/crates/query-engine/execution/src/execution.rs
@@ -31,7 +31,7 @@ pub async fn execute(
 
     let connection_result = pool
         .acquire()
-        .instrument(info_span!("Acquire connection",))
+        .instrument(info_span!("Acquire connection"))
         .await;
 
     let mut connection = acquisition_timer.complete_with(connection_result)?;


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

We'd like to expose query execution time spans to our users.

### How

We add the `internal.visibility` = `user` annotation.