### PR TITLE
Always wrap connection URIs in `{"value": ...}` on serialization.

### DIFF
--- a/justfile
+++ b/justfile
@@ -239,7 +239,7 @@ start-dependencies:
 # injects the Aurora connection string into a deployment configuration template
 create-aurora-deployment:
   cat {{ AURORA_CHINOOK_DEPLOYMENT_TEMPLATE }} \
-    | jq '.connectionUri ={"uri":(env | .AURORA_CONNECTION_STRING)}' \
+    | jq '.connectionUri.uri.value = (env | .AURORA_CONNECTION_STRING)' \
     | prettier --parser=json \
     > {{ AURORA_CHINOOK_DEPLOYMENT }}
 

--- a/static/aurora/chinook-deployment-template.json
+++ b/static/aurora/chinook-deployment-template.json
@@ -1,7 +1,9 @@
 {
   "version": 1,
   "connectionUri": {
-    "uri": "this should be templated in by justfile"
+    "uri": {
+      "value": "this should be templated in by justfile"
+    }
   },
   "poolSettings": {
     "maxConnections": 1,

--- a/static/chinook-deployment.json
+++ b/static/chinook-deployment.json
@@ -1,7 +1,9 @@
 {
   "version": 1,
   "connectionUri": {
-    "uri": "postgresql://postgres:password@localhost:64002"
+    "uri": {
+      "value": "postgresql://postgres:password@localhost:64002"
+    }
   },
   "metadata": {
     "tables": {

--- a/static/citus/chinook-deployment.json
+++ b/static/citus/chinook-deployment.json
@@ -1,7 +1,9 @@
 {
   "version": 1,
   "connectionUri": {
-    "uri": "postgresql://postgres:password@localhost:64004?sslmode=disable"
+    "uri": {
+      "value": "postgresql://postgres:password@localhost:64004?sslmode=disable"
+    }
   },
   "metadata": {
     "tables": {

--- a/static/cockroach/chinook-deployment.json
+++ b/static/cockroach/chinook-deployment.json
@@ -1,7 +1,9 @@
 {
   "version": 1,
   "connectionUri": {
-    "uri": "postgresql://postgres:password@localhost:64003/defaultdb"
+    "uri": {
+      "value": "postgresql://postgres:password@localhost:64003/defaultdb"
+    }
   },
   "metadata": {
     "tables": {

--- a/static/yugabyte/chinook-deployment.json
+++ b/static/yugabyte/chinook-deployment.json
@@ -1,7 +1,9 @@
 {
   "version": 1,
   "connectionUri": {
-    "uri": "postgresql://yugabyte@localhost:64005"
+    "uri": {
+      "value": "postgresql://yugabyte@localhost:64005"
+    }
   },
   "metadata": {
     "tables": {


### PR DESCRIPTION
### What

Connection URIs should be wrapped in `{"value": ...}`. This is the format specified by the JSON schema. We do accept raw strings too, for now.

We will follow up with test cases to ensure they do not diverge in the future.

### How

We serialize via `ResolvedSecretIntermediate`, choosing the `Wrapped` constructor.