### PR TITLE
chore: action to auto bump nix env

### DIFF
--- a/.github/workflows/nix-update.yaml
+++ b/.github/workflows/nix-update.yaml
@@ -1,15 +1,9 @@
 name: update-flake-lock
 
-# Trying something out - what if we updated our Nix deps once a week
-# automatically? Choosing this repo because it's low-stakes - the Nix env is
-# only for local use and not for building anything. If it's annoying, let's bin
-# this.
-
 on:
-  merge_group:
   workflow_dispatch: # allows manual triggering
   schedule:
-    - cron: '0 0 * * 0' # runs weekly on Sunday at 00:00
+    - cron: "0 0 * * 0" # runs weekly on Sunday at 00:00
 
 jobs:
   lockfile:
@@ -25,6 +19,6 @@ jobs:
         uses: DeterminateSystems/update-flake-lock@main
         with:
           pr-title: "Update flake.lock" # Title of PR to be created
-          pr-labels: |                  # Labels to be set on the PR
+          pr-labels: | # Labels to be set on the PR
             dependencies
             automated


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

Tried this in `v3-e2e-testing`, it seemed to work nicely. Opens a PR once a week to bump our Nix flake lock.

### How

Use a Github action.
