### PR TITLE
Update ndc-spec to get the build working.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,7 +1411,7 @@ dependencies = [
 [[package]]
 name = "ndc-client"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.8#2c2def8a01af2f95100b4274599030c930525bee"
+source = "git+https://github.com/hasura//ndc-spec.git?rev=3778605#3778605e9428d46e1f21ae02b077414afd0d0a68"
 dependencies = [
  "async-trait",
  "indexmap 1.9.3",
@@ -1498,7 +1498,7 @@ dependencies = [
 [[package]]
 name = "ndc-test"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.8#2c2def8a01af2f95100b4274599030c930525bee"
+source = "git+https://github.com/hasura//ndc-spec.git?rev=3778605#3778605e9428d46e1f21ae02b077414afd0d0a68"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,11 @@ members = [
   "crates/tests/other-db-tests",
   "crates/tests/tests-common"
 ]
+
+# Temporary patch to get the build working. We shall remove this once a new
+# version of ndc-spec is published, and ndc-sdk is updated accordingly.
+# The "//" is to convince Cargo to accept this, due to
+# https://github.com/rust-lang/cargo/issues/10756 .
+[patch."https://github.com/hasura/ndc-spec.git"]
+ndc-client = { git = "https://github.com/hasura//ndc-spec.git", rev = "3778605" }
+ndc-test = { git = "https://github.com/hasura//ndc-spec.git", rev = "3778605" }


### PR DESCRIPTION
### What

ndc-spec v0.1.0-rc.8 uses workspace inheritance to set the version and edition, which unfortunately does not work with Crane for Nix (when using Git targets).

I have inlined the version and edition to solve this, but we also need to release a new version of ndc-spec and update ndc-sdk.

Until that happens, let's just override it (transitively) using `patch` in _Cargo.toml_.

### How

[`[patch."..."]`, in _Cargo.toml_](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section), allows us to hijack a dependency and point it somewhere else. Unlike just setting the version, this works transitively, so it will also update ndc-sdk. This is important because it's the dependency build step which fails in Crane, so we need to ensure we have no reference to the previous version.

Unfortunately, there's an open bug in Cargo which means that [patch overrides can't use the same Git repository](https://github.com/rust-lang/cargo/issues/10756), even if the commit reference is different. We work around this by adding an extra "/" to trick Cargo into thinking it's a different repository.