### PR TITLE
update ndc-hub with status code metrics feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,7 +1452,7 @@ dependencies = [
 [[package]]
 name = "ndc-sdk"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-hub.git?rev=619655a#619655a05c1ab3022d62d232f5e1fb32c9b68e5f"
+source = "git+https://github.com/hasura/ndc-hub.git?rev=5b8761b7#5b8761b7f1d1267ad66e20d37fb038d235826b4d"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/connectors/ndc-postgres/Cargo.toml
+++ b/crates/connectors/ndc-postgres/Cargo.toml
@@ -15,7 +15,7 @@ name = "ndc-postgres"
 path = "bin/main.rs"
 
 [dependencies]
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "619655a" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "5b8761b7" }
 query-engine-execution = { path = "../../query-engine/execution" }
 query-engine-metadata = { path = "../../query-engine/metadata" }
 query-engine-sql = { path = "../../query-engine/sql" }

--- a/crates/connectors/ndc-postgres/src/connector.rs
+++ b/crates/connectors/ndc-postgres/src/connector.rs
@@ -36,6 +36,10 @@ impl connector::Connector for Postgres {
     /// The type of unserializable state
     type State = Arc<state::State>;
 
+    fn connector_name() -> String {
+        "ndc-postgres".to_string()
+    }
+
     fn make_empty_configuration() -> Self::RawConfiguration {
         configuration::RawConfiguration::empty()
     }

--- a/crates/query-engine/translation/Cargo.toml
+++ b/crates/query-engine/translation/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 
 [dependencies]
 
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "619655a" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "5b8761b7" }
 
 query-engine-metadata = { path = "../metadata" }
 query-engine-sql = { path = "../sql" }

--- a/crates/tests/tests-common/Cargo.toml
+++ b/crates/tests/tests-common/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/lib.rs"
 [dependencies]
 ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.9" }
 ndc-postgres = { path = "../../connectors/ndc-postgres" }
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "619655a" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "5b8761b7" }
 ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.9" }
 
 axum = "0.6.20"


### PR DESCRIPTION
### What

We update ndc-hub to the latest commit so we can use the new status code metrics feature.

### How

We update the hash and implement the new trait method `connector_name()`.
