### PR TITLE
Fix Slack reporting so it always happens, but only for `main`.

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -75,7 +75,7 @@ jobs:
 
       # scream into Slack if something goes wrong
       - name: Report Status
-        if: always()
+        if: always() && github.ref == 'refs/heads/main'
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ job.status }}

--- a/.github/workflows/build-images-and-deploy.yaml
+++ b/.github/workflows/build-images-and-deploy.yaml
@@ -88,7 +88,7 @@ jobs:
 
       # scream into Slack if something goes wrong
       - name: Report Status
-        if: always()
+        if: always() && github.ref == 'refs/heads/main'
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ job.status }}

--- a/.github/workflows/cargo-test.yaml
+++ b/.github/workflows/cargo-test.yaml
@@ -91,7 +91,7 @@ jobs:
 
       # scream into Slack if something goes wrong
       - name: report status
-        if: github.ref == 'refs/heads/main'
+        if: always() && github.ref == 'refs/heads/main'
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ job.status }}
@@ -142,7 +142,7 @@ jobs:
 
       # scream into Slack if something goes wrong
       - name: report status
-        if: github.ref == 'refs/heads/main'
+        if: always() && github.ref == 'refs/heads/main'
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ job.status }}

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -25,7 +25,7 @@ jobs:
 
       # scream into Slack if something goes wrong
       - name: Report Status
-        if: github.ref == 'refs/heads/main'
+        if: always() && github.ref == 'refs/heads/main'
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ job.status }}


### PR DESCRIPTION
### What

Turns out getting this right is more trouble than you would think.

This should fix the notifications so that they happen on a build failure on `main`, but no other time.

### How

We need to call `always()` to signify to GitHub Actions that we want to run even on failure, but we also need to check the branch because otherwise it'll run on all pushes for all branches.