### PR TITLE
chore: always build and push Docker image

### DIFF
--- a/.github/workflows/build-images-and-deploy.yaml
+++ b/.github/workflows/build-images-and-deploy.yaml
@@ -1,11 +1,6 @@
 name: multi-architecture docker build
 
-on:
-  push:
-    branches:
-      - main
-    tags:
-      - "v*"
+on: [push]
 
 jobs:
   build_and_deploy:


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

We'd like to trigger the e2e tests after each commit. In order to do so, there must already be a Docker image built for this commit.

### How

Make Docker build action run on all pushes.
