### PR TITLE
Generate short hash for e2e trigger directly with git

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -13,8 +13,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # pull requests create a new merge commit so we have to work our way back
+      # to the actual commit so it matches the Docker image
       - name: Generate short SHA
-        run: echo "hash=$(git rev-parse --short=9 "$GITHUB_SHA")" >> $GITHUB_OUTPUT
+        run: |
+          if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+            GITHUB_SHA=$(cat $GITHUB_EVENT_PATH | jq -r .pull_request.head.sha)
+          fi
+          echo "hash=$(git rev-parse --short=9 "$GITHUB_SHA")" >> $GITHUB_OUTPUT
         id: short-git-hash
 
       - name: Wait for Docker image to be created


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

The generated hashes from `short-sha` did not always match the Docker image. This is because Github Actions creates a new merge commit for pull requests: https://github.com/orgs/community/discussions/26325

### How

Find the actual source commit and create a hash from that.