### PR TITLE
Automatically open `ndc-multitenant` PR on merge

### DIFF
--- a/.github/workflows/update-multitenant-dep.yaml
+++ b/.github/workflows/update-multitenant-dep.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - djh/NDAT-1003/auto-open-multitenant-pr
 
 jobs:
   send-pull-requests:


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

When we merge to `main`, automatically open a new PR on `ndc-multitenant`

### How

Github Actions, copied from https://github.com/hasura/v3-engine/blob/main/.github/workflows/update_multitenant_dep.yml

Look! https://github.com/hasura/ndc-multitenant/pull/67
