### PR TITLE
Avoid converting paths to strings and back.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,7 +1460,7 @@ dependencies = [
 [[package]]
 name = "ndc-sdk"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-hub.git?rev=619655a#619655a05c1ab3022d62d232f5e1fb32c9b68e5f"
+source = "git+https://github.com/hasura/ndc-hub.git?rev=65b4ae3#65b4ae3342d01a3749d928eab7ea7c6aba0671ff"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/connectors/ndc-postgres/Cargo.toml
+++ b/crates/connectors/ndc-postgres/Cargo.toml
@@ -15,7 +15,7 @@ name = "ndc-postgres"
 path = "bin/main.rs"
 
 [dependencies]
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "619655a" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "65b4ae3" }
 query-engine-execution = { path = "../../query-engine/execution" }
 query-engine-metadata = { path = "../../query-engine/metadata" }
 query-engine-sql = { path = "../../query-engine/sql" }

--- a/crates/query-engine/translation/Cargo.toml
+++ b/crates/query-engine/translation/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 
 [dependencies]
 
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "619655a" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "65b4ae3" }
 
 query-engine-metadata = { path = "../metadata" }
 query-engine-sql = { path = "../sql" }

--- a/crates/tests/tests-common/Cargo.toml
+++ b/crates/tests/tests-common/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/lib.rs"
 [dependencies]
 ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.9" }
 ndc-postgres = { path = "../../connectors/ndc-postgres" }
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "619655a" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "65b4ae3" }
 ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.9" }
 
 axum = "0.6.20"

--- a/crates/tests/tests-common/src/common_tests/configuration_tests.rs
+++ b/crates/tests/tests-common/src/common_tests/configuration_tests.rs
@@ -1,8 +1,11 @@
-use crate::deployment::helpers::get_path_from_project_root;
-use crate::schemas::check_value_conforms_to_schema;
+use std::fs;
+use std::path::Path;
+
 use ndc_postgres::configuration;
 use similar_asserts::assert_eq;
-use std::fs;
+
+use crate::deployment::helpers::get_path_from_project_root;
+use crate::schemas::check_value_conforms_to_schema;
 
 const CONFIGURATION_QUERY: &str =
     include_str!("../../../../connectors/ndc-postgres/src/configuration.sql");
@@ -13,7 +16,10 @@ const CONFIGURATION_QUERY: &str =
 // other tests.
 //
 // If you have changed it intentionally, run `just generate-chinook-configuration`.
-pub async fn configure_is_idempotent(connection_string: &str, chinook_deployment_path: &str) {
+pub async fn configure_is_idempotent(
+    connection_string: &str,
+    chinook_deployment_path: impl AsRef<Path>,
+) {
     let expected_value = read_configuration(chinook_deployment_path);
 
     let mut args: configuration::RawConfiguration = serde_json::from_value(expected_value.clone())
@@ -47,13 +53,13 @@ pub async fn configure_initial_configuration_is_unchanged(
         .expect("configuration::configure")
 }
 
-pub fn configuration_conforms_to_the_schema(chinook_deployment_path: &str) {
+pub fn configuration_conforms_to_the_schema(chinook_deployment_path: impl AsRef<Path>) {
     check_value_conforms_to_schema::<configuration::RawConfiguration>(read_configuration(
         chinook_deployment_path,
     ));
 }
 
-fn read_configuration(chinook_deployment_path: &str) -> serde_json::Value {
+fn read_configuration(chinook_deployment_path: impl AsRef<Path>) -> serde_json::Value {
     let file = fs::File::open(get_path_from_project_root(chinook_deployment_path))
         .expect("fs::File::open");
     serde_json::from_reader(file).expect("serde_json::from_reader")

--- a/crates/tests/tests-common/src/deployment/configuration.rs
+++ b/crates/tests/tests-common/src/deployment/configuration.rs
@@ -1,17 +1,20 @@
 //! Deployment configuration functions used across test cases.
 //! Use via helpers in `mod.rs` rather than directly.
-//!
-use super::helpers::get_path_from_project_root;
-use serde_json::Value;
+
 use std::fs;
+use std::path::Path;
+
+use serde_json::Value;
+
+use super::helpers::get_path_from_project_root;
 
 /// Load deployment at `main_deployment_path`
 /// replace url with `new_postgres_url`
 /// save at `new_deployment_path`
 pub fn copy_deployment_with_new_postgres_url(
-    main_deployment_path: &str,
+    main_deployment_path: impl AsRef<Path>,
     new_postgres_url: &str,
-    new_deployment_path: &str,
+    new_deployment_path: impl AsRef<Path>,
 ) {
     let full_path = get_path_from_project_root(main_deployment_path);
 
@@ -37,7 +40,7 @@ pub fn copy_deployment_with_new_postgres_url(
 }
 
 /// Erase test deployment file created at `deployment_path`
-pub fn delete_deployment(deployment_path: &str) {
+pub fn delete_deployment(deployment_path: impl AsRef<Path>) {
     let absolute_path = get_path_from_project_root(deployment_path);
 
     fs::remove_file(absolute_path).unwrap()

--- a/crates/tests/tests-common/src/deployment/helpers.rs
+++ b/crates/tests/tests-common/src/deployment/helpers.rs
@@ -1,11 +1,11 @@
 //! miscellaneous helpers
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Find the project root via the crate root provided by `cargo test`,
 /// and get our single static configuration file.
 /// This depends on the convention that all our crates live in `/crates/<name>`
 /// and will break in the unlikely case that we change this
-pub fn get_path_from_project_root(deployment_path: &str) -> PathBuf {
+pub fn get_path_from_project_root(deployment_path: impl AsRef<Path>) -> PathBuf {
     let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     d.push("../../../");
     d.push(deployment_path);

--- a/crates/tests/tests-common/src/deployment/mod.rs
+++ b/crates/tests/tests-common/src/deployment/mod.rs
@@ -7,20 +7,23 @@ mod configuration;
 mod database;
 pub mod helpers;
 
+use std::path::{Path, PathBuf};
+
 pub struct FreshDeployment {
     pub db_name: String,
-    pub deployment_path: String,
+    pub deployment_path: PathBuf,
     pub admin_connection_string: String, // for dropping after
 }
 
 /// Create a new deployment, pointing to a fresh copy of the database
 pub async fn create_fresh_deployment(
     connection_string: &str,
-    deployment_path: &str,
+    deployment_path: impl AsRef<Path>,
 ) -> FreshDeployment {
     let (db_name, new_connection_string) = database::create_fresh_database(connection_string).await;
 
-    let new_deployment_path = format!("static/temp-deploys/{}.json", db_name);
+    let new_deployment_path =
+        PathBuf::from("static/temp-deploys").join(format!("{}.json", db_name));
 
     configuration::copy_deployment_with_new_postgres_url(
         deployment_path,

--- a/crates/tests/tests-common/src/router.rs
+++ b/crates/tests/tests-common/src/router.rs
@@ -1,5 +1,7 @@
+use std::path::Path;
+
 /// Creates a router with a fresh state from the test deployment.
-pub async fn create_router(chinook_deployment_path: &str) -> axum::Router {
+pub async fn create_router(chinook_deployment_path: impl AsRef<Path>) -> axum::Router {
     let _ = env_logger::builder().is_test(true).try_init();
 
     // work out where the deployment configs live
@@ -8,7 +10,7 @@ pub async fn create_router(chinook_deployment_path: &str) -> axum::Router {
 
     // initialise server state with the static configuration.
     let state = ndc_sdk::default_main::init_server_state::<ndc_postgres::connector::Postgres>(
-        test_deployment_file.display().to_string(),
+        test_deployment_file,
     )
     .await;
 
@@ -16,7 +18,7 @@ pub async fn create_router(chinook_deployment_path: &str) -> axum::Router {
 }
 
 /// Creates a router with a fresh state from a deployment file path
-pub async fn create_router_from_deployment(deployment_path: &str) -> axum::Router {
+pub async fn create_router_from_deployment(deployment_path: impl AsRef<Path>) -> axum::Router {
     let _ = env_logger::builder().is_test(true).try_init();
 
     // work out where the deployment configs live
@@ -25,7 +27,7 @@ pub async fn create_router_from_deployment(deployment_path: &str) -> axum::Route
 
     // initialise server state with the static configuration.
     let state = ndc_sdk::default_main::init_server_state::<ndc_postgres::connector::Postgres>(
-        test_deployment_file.display().to_string(),
+        test_deployment_file,
     )
     .await;
 


### PR DESCRIPTION
### What

Paths are not strings. They can often be `OsString` values, which is not the same thing; specifically, they don't have to be UTF-8.

[ndc-sdk now accepts anything that converts to a `Path`](https://github.com/hasura/ndc-hub/pull/71), not just `String`, so we can avoid converting them here.

### How

Mostly changing `&str` to `impl AsRef<Path>`.