### PR TITLE
update ndc-hub to get json-formatted extract errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ab90e7b70bea63a153137162affb6a0bce26b584c24a4c7885509783e2cf30b"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "pin-project-lite",
+ "serde",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "axum-test-helper"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,10 +1481,11 @@ dependencies = [
 [[package]]
 name = "ndc-sdk"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-hub.git?rev=65b4ae3#65b4ae3342d01a3749d928eab7ea7c6aba0671ff"
+source = "git+https://github.com/hasura/ndc-hub.git?rev=f2a2a75#f2a2a75aacb31fd9f214bbe9845cdbfe0d7815ac"
 dependencies = [
  "async-trait",
  "axum",
+ "axum-extra",
  "base64 0.21.5",
  "bytes",
  "clap",

--- a/crates/connectors/ndc-postgres/Cargo.toml
+++ b/crates/connectors/ndc-postgres/Cargo.toml
@@ -15,7 +15,7 @@ name = "ndc-postgres"
 path = "bin/main.rs"
 
 [dependencies]
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "65b4ae3" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "f2a2a75" }
 query-engine-execution = { path = "../../query-engine/execution" }
 query-engine-metadata = { path = "../../query-engine/metadata" }
 query-engine-sql = { path = "../../query-engine/sql" }

--- a/crates/query-engine/translation/Cargo.toml
+++ b/crates/query-engine/translation/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 
 [dependencies]
 
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "65b4ae3" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "f2a2a75" }
 
 query-engine-metadata = { path = "../metadata" }
 query-engine-sql = { path = "../sql" }

--- a/crates/tests/tests-common/Cargo.toml
+++ b/crates/tests/tests-common/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/lib.rs"
 [dependencies]
 ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.9" }
 ndc-postgres = { path = "../../connectors/ndc-postgres" }
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "65b4ae3" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "f2a2a75" }
 ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.9" }
 
 axum = "0.6.20"


### PR DESCRIPTION
### What

This PR updates to the latest ndc-hub that contains a fix for returning json-formatted extract errors.

### How

sed
