### PR TITLE
CI: Switch to Cachix for Nix caching.

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -11,14 +11,19 @@ jobs:
     name: Benchmark
     runs-on: ubuntu-latest
     steps:
-      - name: Install Nix ❄
-        uses: DeterminateSystems/nix-installer-action@v6
-
-      - name: Run the Magic Nix Cache 🔌
-        uses: DeterminateSystems/magic-nix-cache-action@v2
-
       - name: Checkout 🛎️
         uses: actions/checkout@v4
+
+      - name: Install Nix ❄
+        uses: cachix/install-nix-action@v22
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up the Nix Cache 🔌
+        uses: cachix/cachix-action@v12
+        with:
+          name: hasura-v3-dev
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build the Docker image 🔨
         run: |

--- a/.github/workflows/build-images-and-deploy.yaml
+++ b/.github/workflows/build-images-and-deploy.yaml
@@ -26,10 +26,15 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Nix ❄
-        uses: DeterminateSystems/nix-installer-action@v6
+        uses: cachix/install-nix-action@v22
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run the Magic Nix Cache 🔌
-        uses: DeterminateSystems/magic-nix-cache-action@v2
+      - name: Set up the Nix Cache 🔌
+        uses: cachix/cachix-action@v12
+        with:
+          name: hasura-v3-dev
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - id: gcloud-auth
         name: Authenticate to Google Cloud 🔑


### PR DESCRIPTION
### What

We are mostly not using our cache, because GitHub's own cache rate-limits us to the point where it's unusable.

Cachix should do better.

### How

Replace the Magic Nix Cache action with the Cachix action, using our newly-minted auth token.