### PR TITLE
Log errors that occur during `/explain`

### DIFF
--- a/crates/connectors/ndc-postgres/src/connector.rs
+++ b/crates/connectors/ndc-postgres/src/connector.rs
@@ -139,7 +139,9 @@ impl connector::Connector for Postgres {
                     meta.signal_type = "log",
                     event.domain = "ndc",
                     event.name = "Explain error",
-                    body = %err
+                    name = "Explain error",
+                    body = %err,
+                    error = true,
                 );
                 err
             })


### PR DESCRIPTION
### What

Make an OpenTelemetry log event when the queries to `/explain` encounter an error.

### How

OpenTelemetry log events are simply events with the field `meta.signal_type = "log"`, and otherwise adhering to the semantic conventions of logs, see https://opentelemetry.io/docs/specs/otel/logs/data-model/.

Similarly, we set `error = true`, which both Honeycomb and Jaeger recognizes in the UI.

The `tracing::event!(..)`  macro captures the place in the code where it was called. Therefore I have opted to not try and abstract over making error-log events, as that information becomes just noise otherwise.

The `body` attribute of the event/log is just the Display'd Error message. Depending on the future uses we want for these log messages we will probably amend them with more attributes/ more information.

In Jaeger:
![image](https://github.com/hasura/ndc-postgres/assets/358550/648c9e8a-89bb-4fd1-9bd2-300d7ab095ef)

In Honeycomb:
![image](https://github.com/hasura/ndc-postgres/assets/358550/f3a8b2a3-89d1-497e-b4bb-2a21aa2fc0a3)

