### PR TITLE
CI: Build with Nix.

### DIFF
--- a/.github/workflows/nix-build.yaml
+++ b/.github/workflows/nix-build.yaml
@@ -1,0 +1,41 @@
+name: nix build
+
+on:
+  push:
+
+jobs:
+  nix-build:
+    name: nix build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Install Nix ❄
+        uses: cachix/install-nix-action@v22
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up the Nix Cache 🔌
+        uses: cachix/cachix-action@v12
+        with:
+          name: hasura-v3-dev
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build a binary with Nix
+        run: nix build --print-build-logs
+
+      - name: Build a Docker image with Nix
+        run: nix build --print-build-logs '.#docker'
+
+      # scream into Slack if something goes wrong
+      - name: Report Status
+        if: always() && github.ref == 'refs/heads/main'
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: failure
+          notification_title: "😧 Error on <{repo_url}|{repo}>"
+          message_format: "🐴 *{workflow}* {status_message} for <{repo_url}|{repo}>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.BROKEN_BUILD_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
### What

Now that our Nix build is generally quite fast, thanks to proper caching, we can run it on every pull request.

Once this is merged, we can use [GitHub Actions' `workflow_run` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run) to trigger other builds, which means we will not have to spin-wait to run other jobs (such as the benchmarks or end-to-end tests).

### How

It's a new CI workflow. Mostly I copied and pasted stuff.