### PR TITLE
add utility commands for metrics in justfile

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -140,9 +140,9 @@ A benchmark history can be viewed [here](https://hasura.github.io/ndc-postgres/d
 
 ## Testing metrics
 
-We have a Prometheus / Grafana set up in Docker. Run `just start-metrics` to
-start them, you can then navigation to `localhost:3001` for Grafana, or
-`localhost:9090` for Prometheus.
+We have a Prometheus / Grafana set up in Docker. Run `just open-prometheus` or
+`just open-grafana` to start them and navigate to the prometheus or grafana
+dashboards respectively.
 
 ### Editing Grafana dashboard
 

--- a/justfile
+++ b/justfile
@@ -270,6 +270,19 @@ run-engine: start-dependencies
     --metadata-path ./static/postgres/chinook-metadata.json \
     --authn-config-path ./static/auth_config.json
 
+# Navigate to the jaeger console
+open-jaeger:
+  open http://localhost:4002/search?service=ndc-postgres
+
+# Navigate to the grafana console
+open-grafana: start-metrics
+  @echo "The login and password are admin:grafana"
+  open http://localhost:3001
+
+# Navigate to the prometheus console
+open-prometheus: start-metrics
+  open http://localhost:9090
+
 # start a postgres docker image and connect to it using psql
 repl-postgres:
   @docker compose up --wait postgres


### PR DESCRIPTION
### What

I want to open our various dashboards in the browser, but I don't want to remember ports and open up my browser and type addresses. this makes it a bit easier.

### How

Adding new justfile commands: `open-jaeger`, `open-prometheus`, `open-grafana`.
