### PR TITLE
Share the Rust cache across jobs.

### DIFF
--- a/.github/workflows/cargo-build.yaml
+++ b/.github/workflows/cargo-build.yaml
@@ -23,6 +23,8 @@ jobs:
           rustup show
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "build" # share the cache across jobs
 
       - name: build crates
         run: |

--- a/.github/workflows/cargo-machete.yaml
+++ b/.github/workflows/cargo-machete.yaml
@@ -19,6 +19,8 @@ jobs:
           cargo install cargo-machete
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "build" # share the cache across jobs
 
       - name: find unused dependencies
         run: |

--- a/.github/workflows/cargo-test.yaml
+++ b/.github/workflows/cargo-test.yaml
@@ -27,6 +27,8 @@ jobs:
           curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "build" # share the cache across jobs
 
       - name: run tests
         run: |
@@ -64,6 +66,8 @@ jobs:
           curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "build" # share the cache across jobs
 
       - id: configuration
         name: extract job configuration
@@ -132,6 +136,8 @@ jobs:
           curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "build" # share the cache across jobs
 
       - name: run tests
         run: |
@@ -181,6 +187,8 @@ jobs:
           curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "build" # share the cache across jobs
 
       - name: start dependencies
         uses: isbang/compose-action@v1.5.1

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -18,6 +18,8 @@ jobs:
           rustup show
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "build" # share the cache across jobs
 
       - name: check formatting
         run: |

--- a/.github/workflows/schema-definitions.yaml
+++ b/.github/workflows/schema-definitions.yaml
@@ -16,6 +16,8 @@ jobs:
         run: rustup show
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "build" # share the cache across jobs
 
       - name: OpenAPI Definitions
         run: cargo test --bin openapi-generator


### PR DESCRIPTION
### What

Apparently we are generating a new Rust cache per job. This grows really fast.

Let's not do this.

### How

By setting a "shared key", we can ensure that all jobs share the same cache.

I have chosen the name arbitrarily.