### PR TITLE
update-multitenant-dep: just tag everyone

### DIFF
--- a/.github/workflows/update-multitenant-dep.yaml
+++ b/.github/workflows/update-multitenant-dep.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - gil/fix-update-multitenant-dep
 
 jobs:
   send-pull-requests:


### PR DESCRIPTION
### What

The `update-multitenant-dep` flow seems to fail:
```
GraphQL: Could not resolve to a User with the login of 'github-merge-queue[bot]'. (u000)
```

I think this is because we use merge queues, so when we assign the PR to `$GITHUB_ACTOR` we actually assign it to `github-merge-queue[bot]` instead of the developer.

### How

We'll assign it to the team.