### PR TITLE
Only try to deploy to Staging after building is complete.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,21 +1,25 @@
-name: multi-architecture docker build
+name: deploy
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - "v*"
+  workflow_run:
+    workflows:
+      - nix build
+    types:
+      - completed
 
 jobs:
-  build_and_deploy:
-    name: build and deploy
+  deploy:
+    name: push
     runs-on: ubuntu-latest
+    # only run if the previous workflow succeeded,
+    # and only on the `main` branch or version tags
+    if: |
+      github.event.workflow_run.conclusion == 'success'
+        && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     permissions:
       contents: read
       id-token: write
       packages: write
-
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
@@ -53,14 +57,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and deploy Docker images to Google Container Registry 🚀
+      - name: Push Docker images to Google Container Registry 🚢
         run: nix run .#publish-docker-image '${{ github.ref }}' 'us-docker.pkg.dev/hasura-ddn/ddn/ndc-postgres'
 
-      - name: Build and deploy Docker images to GitHub Packages 🚀
+      - name: Push Docker images to GitHub Packages 🚢
         run: nix run .#publish-docker-image '${{ github.ref }}' 'ghcr.io/hasura/ndc-postgres'
 
-      - name: Deploy to staging
-        if: github.ref == 'refs/heads/main'
+      - name: Deploy to Staging 🚀
         env:
           BUILDKITE_AUTH_TOKEN: ${{ secrets.BUILDKITE_AUTH_TOKEN }}
         run: |
@@ -88,7 +91,7 @@ jobs:
 
       # scream into Slack if something goes wrong
       - name: Report Status
-        if: always() && github.ref == 'refs/heads/main'
+        if: always()
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ job.status }}


### PR DESCRIPTION
### What

This sets up the deployment workflow to only kick off after the Nix build finishes. This means that the Docker image will end up in the cache and won't have to be re-built, which reduces duplicate work.

If this works out, we can re-use this mechanism for other workflows too.

### How

I have replaced the trigger on the `push` event with [GitHub Action's `workflow_run` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run), instructing GitHub Actions to start the deployment workflow after the "nix build" workflow has completed.

Unfortunately, it won't actually run until this change is merged, as this is policy for `workflow_run` events.

> **Note:** This event will only trigger a workflow run if the workflow file is on the default branch.

This means that this is completely untested and may fail catastrophically. The only way to find out is to merge it.