### PR TITLE
CI: Bump protoc to v25.x.

### DIFF
--- a/.github/workflows/cargo-build.yaml
+++ b/.github/workflows/cargo-build.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: install protoc
         uses: arduino/setup-protoc@v2
         with:
-          version: "24.3"
+          version: "25.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: install tools

--- a/.github/workflows/cargo-test.yaml
+++ b/.github/workflows/cargo-test.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: install protoc
         uses: arduino/setup-protoc@v2
         with:
-          version: "24.3"
+          version: "25.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: install tools
@@ -117,7 +117,7 @@ jobs:
       - name: install protoc
         uses: arduino/setup-protoc@v2
         with:
-          version: "24.3"
+          version: "25.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: setup deployment
@@ -177,7 +177,7 @@ jobs:
       - name: install protoc
         uses: arduino/setup-protoc@v2
         with:
-          version: "24.3"
+          version: "25.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: install tools


### PR DESCRIPTION
### What

Installing protoc is currently failing sometimes. Perhaps this will help.

### How

It's a simple version bump. I decided we were fine with installing minor version updates though.