### PR TITLE
chore: trigger `postgres-config-server` tests

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -27,7 +27,7 @@ jobs:
           fi
           echo "hash=$(git rev-parse --short=9 "$GITHUB_SHA")" >> $GITHUB_OUTPUT
 
-      - name: Dispatch E2E tests
+      - name: Dispatch Postgres E2E tests
         uses: aurelien-baudet/workflow-dispatch@v2
         id: workflow_dispatch
         with:
@@ -36,6 +36,16 @@ jobs:
           ref: main
           token: ${{ secrets.E2E_WORKFLOW_PAT }}
           workflow: "cargo test postgres"
+
+      - name: Dispatch Postgres Config Server E2E tests
+        uses: aurelien-baudet/workflow-dispatch@v2
+        id: workflow_dispatch
+        with:
+          inputs: '{ "connector": "${{ steps.short-git-hash.outputs.hash }}" }'
+          repo: hasura/v3-e2e-testing
+          ref: main
+          token: ${{ secrets.E2E_WORKFLOW_PAT }}
+          workflow: "cargo test postgres-config-server"
 
       - name: Report failures
         if: always() && github.ref == 'refs/heads/main'


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

On merges to `main`, trigger these tests: https://github.com/hasura/v3-e2e-testing/blob/main/.github/workflows/cargo-test-postgres-config-server.yaml#L1

### How

<!-- How is it trying to accomplish it (what are the implementation steps)? -->
