### PR TITLE
Remove `id: workflow_dispatch` in CI

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -29,7 +29,6 @@ jobs:
 
       - name: Dispatch Postgres E2E tests
         uses: aurelien-baudet/workflow-dispatch@v2
-        id: workflow_dispatch
         with:
           inputs: '{ "connector": "${{ steps.short-git-hash.outputs.hash }}" }'
           repo: hasura/v3-e2e-testing
@@ -39,7 +38,6 @@ jobs:
 
       - name: Dispatch Postgres Config Server E2E tests
         uses: aurelien-baudet/workflow-dispatch@v2
-        id: workflow_dispatch
         with:
           inputs: '{ "connector": "${{ steps.short-git-hash.outputs.hash }}" }'
           repo: hasura/v3-e2e-testing


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

These should not be duplicates, so this breaks CI: https://github.com/hasura/ndc-postgres/actions/runs/6786949614

### How

Remove the `id`s altogether, they shouldn't do anything anyway.