### PR TITLE
Use GitHub SHA for config server tests

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Dispatch Postgres Config Server E2E tests
         uses: aurelien-baudet/workflow-dispatch@v2
         with:
-          inputs: '{ "connector": "${{ steps.short-git-hash.outputs.hash }}" }'
+          inputs: '{ "connector": "${{ github.sha }}" }'
           repo: hasura/v3-e2e-testing
           ref: main
           token: ${{ secrets.E2E_WORKFLOW_PAT }}


### PR DESCRIPTION
We think the problem with the config server tests might be that the sha is short, so the checkout action thinks it's a tag. This fixes that, and now we'll see.