### PR TITLE
Use a Debian-based image for PostgreSQL, not Alpine.

### DIFF
--- a/benchmarks/component/docker-compose.yaml
+++ b/benchmarks/component/docker-compose.yaml
@@ -96,7 +96,7 @@ services:
         condition: service_started
 
   postgres:
-    image: postgis/postgis:16-3.4-alpine
+    image: postgis/postgis:${POSTGRESQL_VERSION:-16}-3.4
     platform: linux/amd64
     command:
       - -F # turn fsync off for speed

--- a/crates/tests/databases-tests/src/aurora/query_tests.rs
+++ b/crates/tests/databases-tests/src/aurora/query_tests.rs
@@ -243,8 +243,6 @@ mod sorting {
         insta::assert_json_snapshot!(result);
     }
 
-    // Aurora sorts strings differently than PostgreSQL,
-    // so the 5th row might be different.
     #[tokio::test]
     async fn sorting_by_nested_relationship_column_with_predicate_exists() {
         let result = run_query(

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__sorting__select_order_by_album_artist_name.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__sorting__select_order_by_album_artist_name.snap
@@ -6,19 +6,19 @@ expression: result
   {
     "rows": [
       {
-        "Name": "Bad Boy Boogie"
+        "Name": "Fanfare for the Common Man"
       },
       {
-        "Name": "Breaking The Rules"
+        "Name": "OAM's Blues"
       },
       {
-        "Name": "C.O.D."
+        "Name": "\"Eine Kleine Nachtmusik\" Serenade In G, K. 525: I. Allegro"
       },
       {
-        "Name": "Dog Eat Dog"
+        "Name": "Requiem, Op.48: 4. Pie Jesu"
       },
       {
-        "Name": "Evil Walks"
+        "Name": "Fantasia On Greensleeves"
       }
     ]
   }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__sorting__select_order_by_artist_name.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__sorting__select_order_by_artist_name.snap
@@ -6,19 +6,19 @@ expression: result
   {
     "rows": [
       {
-        "Name": "Worlds"
+        "Name": "Fauré: Requiem, Ravel: Pavane & Others"
       },
       {
         "Name": "The World of Classical Favourites"
       },
       {
-        "Name": "Sir Neville Marriner: A Celebration"
-      },
-      {
-        "Name": "Fauré: Requiem, Ravel: Pavane & Others"
-      },
-      {
         "Name": "Bach: Orchestral Suites Nos. 1 - 4"
+      },
+      {
+        "Name": "Restless and Wild"
+      },
+      {
+        "Name": "Balls to the Wall"
       }
     ]
   }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__sorting__select_order_by_artist_name_with_name.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__sorting__select_order_by_artist_name_with_name.snap
@@ -6,26 +6,6 @@ expression: result
   {
     "rows": [
       {
-        "Name": "For Those About To Rock We Salute You",
-        "Artist": {
-          "rows": [
-            {
-              "Name": "AC/DC"
-            }
-          ]
-        }
-      },
-      {
-        "Name": "Let There Be Rock",
-        "Artist": {
-          "rows": [
-            {
-              "Name": "AC/DC"
-            }
-          ]
-        }
-      },
-      {
         "Name": "A Copland Celebration, Vol. I",
         "Artist": {
           "rows": [
@@ -41,6 +21,26 @@ expression: result
           "rows": [
             {
               "Name": "Aaron Goldberg"
+            }
+          ]
+        }
+      },
+      {
+        "Name": "Sir Neville Marriner: A Celebration",
+        "Artist": {
+          "rows": [
+            {
+              "Name": "Academy of St. Martin in the Fields Chamber Ensemble & Sir Neville Marriner"
+            }
+          ]
+        }
+      },
+      {
+        "Name": "Fauré: Requiem, Ravel: Pavane & Others",
+        "Artist": {
+          "rows": [
+            {
+              "Name": "Academy of St. Martin in the Fields, John Birch, Sir Neville Marriner & Sylvia McNair"
             }
           ]
         }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__sorting__select_order_by_name.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__sorting__select_order_by_name.snap
@@ -6,19 +6,19 @@ expression: result
   {
     "rows": [
       {
-        "Title": "A Matter of Life and Death"
+        "Title": "Achtung Baby"
       },
       {
-        "Title": "A Real Dead One"
+        "Title": "A Copland Celebration, Vol. I"
       },
       {
-        "Title": "A Real Live One"
+        "Title": "Acústico"
       },
       {
-        "Title": "A Soprano Inspired"
+        "Title": "Acústico MTV"
       },
       {
-        "Title": "A TempestadeTempestade Ou O Livro Dos Dias"
+        "Title": "Acústico MTV [Live]"
       }
     ]
   }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__sorting__sorting_by_nested_relationship_column_with_predicate_exists.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__sorting__sorting_by_nested_relationship_column_with_predicate_exists.snap
@@ -18,7 +18,7 @@ expression: result
         "Name": "Restless and Wild"
       },
       {
-        "Name": "\"40\""
+        "Name": "\"?\""
       }
     ]
   }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.6"
 
 services:
   postgres:
-    image: postgis/postgis:${POSTGRESQL_VERSION:-16}-3.4-alpine
+    image: postgis/postgis:${POSTGRESQL_VERSION:-16}-3.4
     platform: linux/amd64
     command:
       - -F # turn fsync off for speed


### PR DESCRIPTION
### What

PostGIS recommends their Debian image, not their Alpine image, for "normal" usage. This is probably closer to what our users will actually use too, especially if they're using a cloud-managed PostgreSQL server.

Interestingly, this "fixes" the discrepancy in sorting strings between PostgreSQL and AWS Aurora. They now behave the same way. This implies that either musl handles sorting differently to glibc, or PostgreSQL on Alpine is built without the relevant sorting information. Either way, it seems sensible to use the "official" build rather than an offshoot.

I made this change because I was suffering issues with starting the Alpine-based image on macOS Sonoma. I didn't dig too much into why this was the case.

### How

I just changed the image name and ran the tests.