### PR TITLE
When updating ndc-multitenant, allow for updating dependencies.

### DIFF
--- a/.github/workflows/update-multitenant-dep.yaml
+++ b/.github/workflows/update-multitenant-dep.yaml
@@ -31,9 +31,7 @@ jobs:
       - name: Send pull-request
         run: |
           # get newest commit to use
-          pushd ndc-postgres
-          LATEST_SHA=$(git rev-parse --short HEAD)
-          popd
+          LATEST_SHA=$(cd ndc-postgres && git rev-parse --short HEAD)
 
           BRANCH_NAME="update-ndc-postgres-to-$LATEST_SHA"
           DEP_FILEPATH="Cargo.toml"
@@ -54,8 +52,8 @@ jobs:
           eval `ssh-agent -s`
           ssh-add - <<< '${{ secrets.SSH_GIT_ACCESS_PRIVATE }}'
 
-          # Update Cargo lock file only for workspace
-          cargo update -w
+          # Update Cargo lock file, but as little as possible
+          cargo update -p ndc-postgres
 
           # Commit the changes and push the feature branch to origin
           git add .


### PR DESCRIPTION
### What

Transitive dependencies shouldn't get in the way.

### How

The `-w` flag means that only direct dependencies are upgraded, which is a bit too restrictive.

`-p ndc-postgres` limits the upgrade to ndc-postgres and its friends, which seems to work well.