### PR TITLE
Inline workspace-level directives to make Crane happy.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,6 @@
 [workspace]
 resolver = "2"
 
-package.version = "0.1.0"
-package.edition = "2021"
-package.license = "Apache-2.0"
-
 members = [
   "crates/connectors/ndc-postgres",
   "crates/query-engine/execution",

--- a/crates/connectors/ndc-postgres/Cargo.toml
+++ b/crates/connectors/ndc-postgres/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ndc-postgres"
-version.workspace = true
-edition.workspace = true
-license.workspace = true
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
 
 default-run = "ndc-postgres"
 

--- a/crates/documentation/openapi/Cargo.toml
+++ b/crates/documentation/openapi/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "openapi-generator"
-version.workspace = true
-edition.workspace = true
-license.workspace = true
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 insta = { version = "1.34.0", features = ["json"] }

--- a/crates/query-engine/execution/Cargo.toml
+++ b/crates/query-engine/execution/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "query-engine-execution"
-version.workspace = true
-edition.workspace = true
-license.workspace = true
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 query-engine-sql = { path = "../sql" }

--- a/crates/query-engine/metadata/Cargo.toml
+++ b/crates/query-engine/metadata/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "query-engine-metadata"
-version.workspace = true
-edition.workspace = true
-license.workspace = true
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 schemars = { version = "0.8.16", features = ["smol_str"] }

--- a/crates/query-engine/sql/Cargo.toml
+++ b/crates/query-engine/sql/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "query-engine-sql"
-version.workspace = true
-edition.workspace = true
-license.workspace = true
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 serde_json = "1.0.108"

--- a/crates/query-engine/translation/Cargo.toml
+++ b/crates/query-engine/translation/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "query-engine-translation"
-version.workspace = true
-edition.workspace = true
-license.workspace = true
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 

--- a/crates/tests/databases-tests/Cargo.toml
+++ b/crates/tests/databases-tests/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "databases-tests"
-version.workspace = true
-edition.workspace = true
-license.workspace = true
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
 
 [features]
 # We only run the AWS Aurora tests if this feature is enabled.

--- a/crates/tests/tests-common/Cargo.toml
+++ b/crates/tests/tests-common/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "tests-common"
-version.workspace = true
-edition.workspace = true
-license.workspace = true
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
 
 [lib]
 name = "tests_common"


### PR DESCRIPTION
### What

Crane does not properly inline workspace-level directives in all situations, which means that the version information is not available to it once it's constructed a derivation for each crate.

This becomes an issue once we use ndc-postgres as a library.

### How

We can work around this problem by not using workspace-level directives, copying and pasting the information instead.