### PR TITLE
Add error graphs to Grafana

### DIFF
--- a/metrics/grafana/dashboards/ndc-postgres.json
+++ b/metrics/grafana/dashboards/ndc-postgres.json
@@ -76,9 +76,7 @@
         "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -154,9 +152,7 @@
         "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -426,9 +422,7 @@
         "namePlacement": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -515,9 +509,7 @@
         "namePlacement": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },


### PR DESCRIPTION
![Screenshot from 2023-11-17 16 53 29](https://github.com/hasura/ndc-postgres/assets/6302310/934ce78e-1d22-4a73-912d-e8628537cd5d)

This PR tracks the rate of various errors, as well as an overall % of invalid requests.