### PR TITLE
Do not serialize `None`.

### DIFF
--- a/crates/query-engine/metadata/src/metadata/database.rs
+++ b/crates/query-engine/metadata/src/metadata/database.rs
@@ -83,6 +83,7 @@ pub struct ForeignRelations(pub BTreeMap<String, ForeignRelation>);
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ForeignRelation {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub foreign_schema: Option<String>,
     pub foreign_table: String,
     pub column_mapping: BTreeMap<String, String>,


### PR DESCRIPTION
### What

The E2E tests fail because deserializing and re-serializing a configuration with no foreign schema results in `null`. Let's just omit it.

### How

We use `serde(skip_serializing_if = "Option::is_none")`.