### PR TITLE
Redirect issues to graphql-engine repo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ The documentation and community will help you troubleshoot most issues.
 If you have encountered a bug or need to get in touch with us, you can contact us using one of the following channels:
 
 - Support & feedback: [Discord](https://discord.gg/hasura)
-- Issue & bug tracking: [GitHub issues](https://github.com/hasura/ndc-postgres/issues)
+- Issue & bug tracking: [GitHub issues](https://github.com/hasura/graphql-engine/issues)
 - Follow product updates: [@HasuraHQ](https://twitter.com/hasurahq)
 - Talk to us on our [website chat](https://hasura.io)
 


### PR DESCRIPTION
According to the current OSS plan: issues on local repos should be disabled and feedback for V3 directed to the graphql-engine repo. This ensures customers will not need a detailed understanding of our repository structure to report problems in the correct location.

