### PR TITLE
Always add `latest` tag to Docker images

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     # only run if the previous workflow succeeded,
     # and only on the `main` branch or version tags
+    # note we currently tag the image with 'latest', so will want to
+    # stop doing so if we run this on PR branches etc
     if: |
       github.event.workflow_run.conclusion == 'success'
         && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -49,6 +49,7 @@ function run {
 #
 # Additionally sets a branch tag assuming this is the latest tag for the given
 # branch. The branch tag has the form: dev-main
+# Also sets the 'latest' tag
 # Also sets a tag with just the branch short hash
 function set_dev_tags {
     local branch="$1"
@@ -60,7 +61,7 @@ function set_dev_tags {
     local short_hash
     short_hash="$(git rev-parse --short=9 HEAD)"
     version="${branch_prefix}-${short_hash}"
-    export docker_tags=("$version" "$branch_prefix" "$short_hash")
+    export docker_tags=("$version" "$branch_prefix" "$short_hash" "latest")
 }
 
 # The Github workflow passes a ref of the form refs/heads/<branch name> or
@@ -79,12 +80,12 @@ function set_docker_tags {
     input="$1"
     if [[ $input =~ ^refs/tags/(v.*)$ ]]; then
         local tag="${BASH_REMATCH[1]}"
-        export docker_tags=("$tag")
+        export docker_tags=("$tag" "latest")
     elif [[ $input =~ ^refs/heads/(.*)$ ]]; then
         local branch="${BASH_REMATCH[1]}"
         set_dev_tags "$branch"
     else
-        export docker_tags=()
+        export docker_tags=("latest")
     fi
 }
 


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

Most of our Docker images use a `latest` tag but we use `dev-main`. This adds `latest` too.

### How

Change bash script that makes Docker images.