### PR TITLE
remove source_collection_or_type from tests

### DIFF
--- a/crates/query-engine/translation/tests/goldenfiles/dup_array_relationship/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/dup_array_relationship/request.json
@@ -40,7 +40,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album",
       "arguments": {}
     }

--- a/crates/query-engine/translation/tests/goldenfiles/native_queries/select_artist_with_album_by_title/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/native_queries/select_artist_with_album_by_title/request.json
@@ -47,7 +47,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "artist",
       "target_collection": "album_by_title",
       "arguments": {}
     }

--- a/crates/query-engine/translation/tests/goldenfiles/native_queries/select_artist_with_album_by_title_relationship_arguments/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/native_queries/select_artist_with_album_by_title_relationship_arguments/request.json
@@ -59,7 +59,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "artist",
       "target_collection": "album_by_title",
       "arguments": {
         "id": {

--- a/crates/query-engine/translation/tests/goldenfiles/nested_aggregates/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/nested_aggregates/request.json
@@ -37,7 +37,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album",
       "arguments": {}
     }

--- a/crates/query-engine/translation/tests/goldenfiles/nested_array_relationships/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/nested_array_relationships/request.json
@@ -34,7 +34,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album",
       "arguments": {}
     },
@@ -43,7 +42,6 @@
         "AlbumId": "AlbumId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Album",
       "target_collection": "Track",
       "arguments": {}
     }

--- a/crates/query-engine/translation/tests/goldenfiles/nested_recursive_relationship/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/nested_recursive_relationship/request.json
@@ -34,7 +34,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album",
       "arguments": {}
     },
@@ -43,7 +42,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Album",
       "target_collection": "Artist",
       "arguments": {}
     }

--- a/crates/query-engine/translation/tests/goldenfiles/select_track_order_by_artist_id_and_album_title/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/select_track_order_by_artist_id_and_album_title/request.json
@@ -63,7 +63,6 @@
         "AlbumId": "AlbumId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Track",
       "target_collection": "Album",
       "arguments": {}
     }

--- a/crates/query-engine/translation/tests/goldenfiles/select_where_album_id_equals_self_nested_object_relationship/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/select_where_album_id_equals_self_nested_object_relationship/request.json
@@ -161,7 +161,6 @@
         "AlbumId": "AlbumId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Track",
       "target_collection": "Album",
       "arguments": {}
     },
@@ -170,7 +169,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Album",
       "target_collection": "Artist",
       "arguments": {}
     }

--- a/crates/query-engine/translation/tests/goldenfiles/select_where_array_relationship/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/select_where_array_relationship/request.json
@@ -80,7 +80,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album"
     }
   }

--- a/crates/query-engine/translation/tests/goldenfiles/select_where_related_exists/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/select_where_related_exists/request.json
@@ -55,7 +55,6 @@
         "id": "artist_id"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "artist",
       "target_collection": "album"
     }
   }

--- a/crates/query-engine/translation/tests/goldenfiles/simple_array_relationship/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/simple_array_relationship/request.json
@@ -26,7 +26,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album",
       "arguments": {}
     }

--- a/crates/query-engine/translation/tests/goldenfiles/simple_object_relationship/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/simple_object_relationship/request.json
@@ -26,7 +26,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Album",
       "target_collection": "Artist",
       "arguments": {}
     }

--- a/crates/query-engine/translation/tests/goldenfiles/sorting_by_nested_relationship_column/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/sorting_by_nested_relationship_column/request.json
@@ -45,7 +45,6 @@
         "artist_id": "artist_id"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "album",
       "target_collection": "artist",
       "arguments": {}
     },
@@ -54,7 +53,6 @@
         "album_id": "album_id"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "track",
       "target_collection": "album",
       "arguments": {}
     }

--- a/crates/query-engine/translation/tests/goldenfiles/sorting_by_nested_relationship_column_with_predicate/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/sorting_by_nested_relationship_column_with_predicate/request.json
@@ -62,7 +62,6 @@
         "artist_id": "artist_id"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "album",
       "target_collection": "artist",
       "arguments": {}
     },
@@ -71,7 +70,6 @@
         "album_id": "album_id"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "track",
       "target_collection": "album",
       "arguments": {}
     }

--- a/crates/query-engine/translation/tests/goldenfiles/sorting_by_nested_relationship_count/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/sorting_by_nested_relationship_count/request.json
@@ -39,7 +39,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album",
       "arguments": {}
     }

--- a/crates/query-engine/translation/tests/goldenfiles/sorting_by_recursive_relationship_column/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/sorting_by_recursive_relationship_column/request.json
@@ -45,7 +45,6 @@
         "CEOId": "PersonId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Company",
       "target_collection": "Person",
       "arguments": {}
     },
@@ -54,7 +53,6 @@
         "ParentId": "PersonId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Person",
       "target_collection": "Person",
       "arguments": {}
     }

--- a/crates/query-engine/translation/tests/goldenfiles/sorting_by_relationship_column/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/sorting_by_relationship_column/request.json
@@ -39,7 +39,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Album",
       "target_collection": "Artist",
       "arguments": {}
     }

--- a/crates/query-engine/translation/tests/goldenfiles/sorting_by_relationship_count/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/sorting_by_relationship_count/request.json
@@ -37,7 +37,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album",
       "arguments": {}
     }

--- a/crates/query-engine/translation/tests/goldenfiles/sorting_by_relationship_count_with_predicate/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/sorting_by_relationship_count_with_predicate/request.json
@@ -70,7 +70,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album",
       "arguments": {}
     },
@@ -79,7 +78,6 @@
         "AlbumId": "album_id"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Album",
       "target_collection": "track",
       "arguments": {}
     }

--- a/crates/query-engine/translation/tests/goldenfiles/very_nested_recursive_relationship/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/very_nested_recursive_relationship/request.json
@@ -58,7 +58,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album",
       "arguments": {}
     },
@@ -67,7 +66,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Album",
       "target_collection": "Artist",
       "arguments": {}
     }

--- a/crates/tests/tests-common/goldenfiles/aggregate_count_artist_albums.json
+++ b/crates/tests/tests-common/goldenfiles/aggregate_count_artist_albums.json
@@ -42,7 +42,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album",
       "arguments": {}
     }

--- a/crates/tests/tests-common/goldenfiles/aggregate_count_artist_albums_plus_field.json
+++ b/crates/tests/tests-common/goldenfiles/aggregate_count_artist_albums_plus_field.json
@@ -61,7 +61,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album",
       "arguments": {}
     }

--- a/crates/tests/tests-common/goldenfiles/dup_array_relationship.json
+++ b/crates/tests/tests-common/goldenfiles/dup_array_relationship.json
@@ -76,7 +76,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album",
       "arguments": {}
     }

--- a/crates/tests/tests-common/goldenfiles/native_queries/select_artist_with_album_by_title_relationship_arguments.json
+++ b/crates/tests/tests-common/goldenfiles/native_queries/select_artist_with_album_by_title_relationship_arguments.json
@@ -60,7 +60,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "album_by_title",
       "arguments": {
         "id": {

--- a/crates/tests/tests-common/goldenfiles/native_queries/select_order_by_artist_album_count.json
+++ b/crates/tests/tests-common/goldenfiles/native_queries/select_order_by_artist_album_count.json
@@ -76,7 +76,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "album_by_title",
       "arguments": {
         "id": { "type": "literal", "value": 1000 },

--- a/crates/tests/tests-common/goldenfiles/native_queries/select_sort_relationship.json
+++ b/crates/tests/tests-common/goldenfiles/native_queries/select_sort_relationship.json
@@ -54,7 +54,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "album_by_title",
       "target_collection": "artist",
       "arguments": {}
     }

--- a/crates/tests/tests-common/goldenfiles/native_queries/select_where_relationship.json
+++ b/crates/tests/tests-common/goldenfiles/native_queries/select_where_relationship.json
@@ -62,7 +62,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "album_by_title",
       "target_collection": "artist",
       "arguments": {}
     }

--- a/crates/tests/tests-common/goldenfiles/nested_array_relationships.json
+++ b/crates/tests/tests-common/goldenfiles/nested_array_relationships.json
@@ -84,7 +84,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album",
       "arguments": {}
     },
@@ -93,7 +92,6 @@
         "AlbumId": "AlbumId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Album",
       "target_collection": "Track",
       "arguments": {}
     }

--- a/crates/tests/tests-common/goldenfiles/nested_object_relationships.json
+++ b/crates/tests/tests-common/goldenfiles/nested_object_relationships.json
@@ -58,7 +58,6 @@
         "AlbumId": "AlbumId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Track",
       "target_collection": "Album",
       "arguments": {}
     },
@@ -67,7 +66,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Album",
       "target_collection": "Artist",
       "arguments": {}
     }

--- a/crates/tests/tests-common/goldenfiles/select_album_object_relationship_to_artist.json
+++ b/crates/tests/tests-common/goldenfiles/select_album_object_relationship_to_artist.json
@@ -44,7 +44,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Album",
       "target_collection": "Artist",
       "arguments": {}
     }

--- a/crates/tests/tests-common/goldenfiles/select_artist_array_relationship_to_album.json
+++ b/crates/tests/tests-common/goldenfiles/select_artist_array_relationship_to_album.json
@@ -56,7 +56,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album",
       "arguments": {}
     }

--- a/crates/tests/tests-common/goldenfiles/select_order_by_album_artist_name.json
+++ b/crates/tests/tests-common/goldenfiles/select_order_by_album_artist_name.json
@@ -54,7 +54,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Album",
       "target_collection": "Artist",
       "arguments": {}
     },
@@ -63,7 +62,6 @@
         "AlbumId": "AlbumId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Track",
       "target_collection": "Album",
       "arguments": {}
     }

--- a/crates/tests/tests-common/goldenfiles/select_order_by_artist_album_count.json
+++ b/crates/tests/tests-common/goldenfiles/select_order_by_artist_album_count.json
@@ -37,7 +37,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album",
       "arguments": {}
     }

--- a/crates/tests/tests-common/goldenfiles/select_order_by_artist_album_count_agg.json
+++ b/crates/tests/tests-common/goldenfiles/select_order_by_artist_album_count_agg.json
@@ -39,7 +39,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album",
       "arguments": {}
     }

--- a/crates/tests/tests-common/goldenfiles/select_order_by_artist_name.json
+++ b/crates/tests/tests-common/goldenfiles/select_order_by_artist_name.json
@@ -39,7 +39,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Album",
       "target_collection": "Artist",
       "arguments": {}
     }

--- a/crates/tests/tests-common/goldenfiles/select_order_by_artist_name_with_name.json
+++ b/crates/tests/tests-common/goldenfiles/select_order_by_artist_name_with_name.json
@@ -60,7 +60,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Album",
       "target_collection": "Artist",
       "arguments": {}
     }

--- a/crates/tests/tests-common/goldenfiles/select_track_order_by_artist_id_and_album_title.json
+++ b/crates/tests/tests-common/goldenfiles/select_track_order_by_artist_id_and_album_title.json
@@ -63,7 +63,6 @@
         "AlbumId": "AlbumId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Track",
       "target_collection": "Album",
       "arguments": {}
     }

--- a/crates/tests/tests-common/goldenfiles/select_where_album_id_equals_self_nested_object_relationship.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_album_id_equals_self_nested_object_relationship.json
@@ -113,7 +113,6 @@
         "AlbumId": "AlbumId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Track",
       "target_collection": "Album",
       "arguments": {}
     },
@@ -122,7 +121,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Album",
       "target_collection": "Artist",
       "arguments": {}
     }

--- a/crates/tests/tests-common/goldenfiles/select_where_array_relationship.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_array_relationship.json
@@ -80,7 +80,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album"
     }
   }

--- a/crates/tests/tests-common/goldenfiles/select_where_related_exists.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_related_exists.json
@@ -79,7 +79,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album"
     }
   }

--- a/crates/tests/tests-common/goldenfiles/sorting_by_nested_relationship_column_with_predicate.json
+++ b/crates/tests/tests-common/goldenfiles/sorting_by_nested_relationship_column_with_predicate.json
@@ -70,7 +70,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Album",
       "target_collection": "Artist",
       "arguments": {}
     },
@@ -79,7 +78,6 @@
         "AlbumId": "AlbumId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Track",
       "target_collection": "Album",
       "arguments": {}
     }

--- a/crates/tests/tests-common/goldenfiles/sorting_by_nested_relationship_column_with_predicate_exists.json
+++ b/crates/tests/tests-common/goldenfiles/sorting_by_nested_relationship_column_with_predicate_exists.json
@@ -79,7 +79,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Album",
       "target_collection": "Artist",
       "arguments": {}
     },
@@ -88,7 +87,6 @@
         "AlbumId": "AlbumId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Track",
       "target_collection": "Album",
       "arguments": {}
     }

--- a/crates/tests/tests-common/goldenfiles/sorting_by_nested_relationship_count.json
+++ b/crates/tests/tests-common/goldenfiles/sorting_by_nested_relationship_count.json
@@ -109,7 +109,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album",
       "arguments": {}
     },
@@ -118,7 +117,6 @@
         "AlbumId": "AlbumId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Album",
       "target_collection": "Track",
       "arguments": {}
     }

--- a/crates/tests/tests-common/goldenfiles/sorting_by_relationship_count_with_predicate.json
+++ b/crates/tests/tests-common/goldenfiles/sorting_by_relationship_count_with_predicate.json
@@ -70,7 +70,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album",
       "arguments": {}
     },
@@ -79,7 +78,6 @@
         "AlbumId": "AlbumId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Album",
       "target_collection": "Track",
       "arguments": {}
     }

--- a/crates/tests/tests-common/goldenfiles/very_nested_recursive_relationship.json
+++ b/crates/tests/tests-common/goldenfiles/very_nested_recursive_relationship.json
@@ -112,7 +112,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "array",
-      "source_collection_or_type": "Artist",
       "target_collection": "Album",
       "arguments": {}
     },
@@ -121,7 +120,6 @@
         "ArtistId": "ArtistId"
       },
       "relationship_type": "object",
-      "source_collection_or_type": "Album",
       "target_collection": "Artist",
       "arguments": {}
     }


### PR DESCRIPTION
### What

This field [has been removed](https://github.com/hasura/ndc-spec/commit/f347d2fe017b575b64e0067c9e1dc0f379dbf73f) from ndc-spec. We haven't been using it in code but it remained in our tests. This PR removes it from the tests.

