### PR TITLE
constant folding boolean expressions in exists clauses

### DIFF
--- a/crates/query-engine/sql/src/sql/rewrites/constant_folding.rs
+++ b/crates/query-engine/sql/src/sql/rewrites/constant_folding.rs
@@ -146,6 +146,10 @@ pub fn normalize_expr(expr: Expression) -> Expression {
                 (None, None) => Expression::Value(Value::Bool(false)),
             }
         }
+        // fold the expressions in the select.
+        Expression::Exists { select } => Expression::Exists {
+            select: Box::new(normalize_select(*select)),
+        },
         // reverse not on literal bool.
         Expression::Not(expr) => match normalize_expr(*expr) {
             Expression::Value(Value::Bool(false)) => Expression::Value(Value::Bool(true)),

--- a/crates/query-engine/translation/tests/snapshots/tests__it_select_where_unrelated_exists.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__it_select_where_unrelated_exists.snap
@@ -26,10 +26,7 @@ FROM
                   "public"."Artist" AS "%1_artist"
                 WHERE
                   (
-                    (
-                      true
-                      AND ("%1_artist"."Name" = cast($1 as varchar))
-                    )
+                    ("%1_artist"."Name" = cast($1 as varchar))
                     AND ("%0_album"."ArtistId" = "%1_artist"."ArtistId")
                   )
               )


### PR DESCRIPTION
### What

We didn't cover `EXISTS` clauses in constant folding of boolean expressions. This PR handles them and removes an unnecessary `true AND` case in a test.

### How

normalize the select inside the exists clause.