### PR TITLE
run explain in a transaction

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Query transactions now run in read-only mode, and allow transaction isolation level configuration. ([#209](https://github.com/hasura/ndc-postgres/pull/209))
+- Query transactions now run in read-only mode, and allow transaction isolation level configuration. ([#209](https://github.com/hasura/ndc-postgres/pull/209), [#212](https://github.com/hasura/ndc-postgres/pull/212))
 - Support variables as arguments to native queries ([#211](https://github.com/hasura/ndc-postgres/pull/211))
 - Introduce version 2 of connector deployment configuration. ([#208](https://github.com/hasura/ndc-postgres/pull/208))
 - Support array types ([#191](https://github.com/hasura/ndc-postgres/pull/191), ...)


### PR DESCRIPTION
### What

We want to run explain queries in a transaction as well so they are running in the same environment a regular query runs.

### How

- move connection acquisition up, run pre and post statements.
