### PR TITLE
e2e mutation setup and bugfixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,7 @@
 - Support variables as arguments to native queries ([#211](https://github.com/hasura/ndc-postgres/pull/211))
 - Introduce version 2 of connector deployment configuration. ([#208](https://github.com/hasura/ndc-postgres/pull/208))
 - Support array types ([#191](https://github.com/hasura/ndc-postgres/pull/191), ...)
-- Support Native Query Mutations ([#189](https://github.com/hasura/ndc-postgres/pull/189), [#198](https://github.com/hasura/ndc-postgres/pull/198))
+- Support Native Query Mutations ([#189](https://github.com/hasura/ndc-postgres/pull/189), [#198](https://github.com/hasura/ndc-postgres/pull/198), [#222](https://github.com/hasura/ndc-postgres/pull/222))
 
 ## [0.1.0] - 2023-11-29
 

--- a/crates/query-engine/sql/src/sql/ast.rs
+++ b/crates/query-engine/sql/src/sql/ast.rs
@@ -246,6 +246,7 @@ pub enum BinaryArrayOperator {
 pub enum Function {
     Coalesce,
     JsonAgg,
+    JsonBuildArray,
     Unknown(String),
 }
 

--- a/crates/query-engine/sql/src/sql/convert.rs
+++ b/crates/query-engine/sql/src/sql/convert.rs
@@ -407,6 +407,7 @@ impl Function {
         match self {
             Function::Coalesce => sql.append_syntax("coalesce"),
             Function::JsonAgg => sql.append_syntax("json_agg"),
+            Function::JsonBuildArray => sql.append_syntax("json_build_array"),
             Function::Unknown(name) => sql.append_syntax(name),
         }
     }

--- a/crates/query-engine/translation/tests/snapshots/tests__mutations__simple.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__mutations__simple.snap
@@ -20,7 +20,12 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%3_returning")), '[]') AS "returning"
+          json_build_array(
+            json_build_object(
+              '__value',
+              coalesce(json_agg(row_to_json("%3_returning")), '[]')
+            )
+          ) AS "returning"
         FROM
           (
             SELECT

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__delete_invoice_line.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__delete_invoice_line.snap
@@ -8,8 +8,12 @@ expression: result
       "affected_rows": 1,
       "returning": [
         {
-          "invoice_line_id": 90,
-          "quantity": 1
+          "__value": [
+            {
+              "invoice_line_id": 90,
+              "quantity": 1
+            }
+          ]
         }
       ]
     }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__delete_playlist.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__delete_playlist.snap
@@ -8,10 +8,14 @@ expression: result
       "affected_rows": 2,
       "returning": [
         {
-          "playlist_id": 1
-        },
-        {
-          "playlist_id": 8
+          "__value": [
+            {
+              "playlist_id": 1
+            },
+            {
+              "playlist_id": 8
+            }
+          ]
         }
       ]
     }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__insert_artist_album.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__insert_artist_album.snap
@@ -8,8 +8,12 @@ expression: result
       "affected_rows": 1,
       "returning": [
         {
-          "artist_id": 276,
-          "name": "Olympians"
+          "__value": [
+            {
+              "artist_id": 276,
+              "name": "Olympians"
+            }
+          ]
         }
       ]
     },
@@ -17,15 +21,19 @@ expression: result
       "affected_rows": 1,
       "returning": [
         {
-          "album_id": 348,
-          "title": "Lake Mannion",
-          "artist": {
-            "rows": [
-              {
-                "name": "Olympians"
+          "__value": [
+            {
+              "album_id": 348,
+              "title": "Lake Mannion",
+              "artist": {
+                "rows": [
+                  {
+                    "name": "Olympians"
+                  }
+                ]
               }
-            ]
-          }
+            }
+          ]
         }
       ]
     }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -176,7 +176,7 @@ services:
       COLLECTOR_ZIPKIN_HOST_PORT: "9411"
 
   auth-hook:
-    build: ../v3-engine/hasura-authn-webhook/dev-auth-webhook
+    build: ${HGE_V3_DIRECTORY:-../v3-engine}/hasura-authn-webhook/dev-auth-webhook
     init: true
     ports:
       - 3050:3050

--- a/docs/development.md
+++ b/docs/development.md
@@ -12,10 +12,9 @@
    - `brew install protobuf`
    - `apt-get install protobuf-compiler`
    - `dnf install protobuf-compiler`
-7. Clone [v3-engine](https://github.com/hasura/v3-engine) in a directory near this one:
-   ```
-   (cd .. && git clone git@github.com:hasura/v3-engine.git)
-   ```
+7. Clone [graphql-engine v3](https://github.com/hasura/graphql-engine-mono#git-checkout-with-only-hasura-v3-engine-code) in a directory near this one,
+   and set the `HGE_V3_DIRECTORY` environment variable to the location of the `v3` directory.
+   (e.g. `export HGE_V3_DIRECTORY="../graphql-engine/v3"`)
 
 ## Code structure and architecture
 

--- a/justfile
+++ b/justfile
@@ -1,5 +1,7 @@
 set shell := ["bash", "-c"]
 
+HGE_V3_DIR := env_var_or_default('HGE_V3_DIRECTORY', '../v3-engine')
+
 CONNECTOR_IMAGE_NAME := "ghcr.io/hasura/ndc-postgres"
 CONNECTOR_IMAGE_TAG := "dev"
 CONNECTOR_IMAGE := CONNECTOR_IMAGE_NAME + ":" + CONNECTOR_IMAGE_TAG
@@ -284,11 +286,11 @@ run-engine: start-dependencies
   @echo "http://localhost:3000/ for graphiql console"
   @echo "http://localhost:4002/ for jaeger console"
   # Run graphql-engine using static Chinook metadata
-  # we expect the `v3-engine` repo to live next door to this one
+  # Set `HGE_V3_DIRECTORY` to the location of your cloned v3 engine
   RUST_LOG=DEBUG \
   OTLP_ENDPOINT=http://localhost:4317 \
-    cargo run --release \
-    --manifest-path ../v3-engine/Cargo.toml \
+    cargo run \
+    --manifest-path {{ HGE_V3_DIR }}/Cargo.toml \
     --bin engine -- \
     --metadata-path ./static/postgres/chinook-metadata.json \
     --authn-config-path ./static/auth_config.json

--- a/static/postgres/chinook-metadata.json
+++ b/static/postgres/chinook-metadata.json
@@ -244,15 +244,7 @@
             "fields": {
               "ArtistId": {
                 "description": "The artist's primary key",
-                "arguments": {
-                  "id": {
-                    "description": "The cyling id",
-                    "type": {
-                      "type": "named",
-                      "name": "int4"
-                    }
-                  }
-                },
+                "arguments": {},
                 "type": {
                   "type": "named",
                   "name": "int4"
@@ -328,7 +320,38 @@
           }
         ],
         "functions": [],
-        "procedures": []
+        "procedures": [
+          {
+            "name": "insert_artist",
+            "description": "Insert an artist",
+            "arguments": {
+              "id": {
+                "description": "The id of the artist to insert",
+                "type": {
+                  "type": "named",
+                  "name": "Int!"
+                }
+              },
+              "name": {
+                "description": "The name of the artist to insert",
+                "type": {
+                  "type": "named",
+                  "name": "String!"
+                }
+              }
+            },
+            "result_type": {
+              "type": "nullable",
+              "underlying_type": {
+                "type": "array",
+                "element_type": {
+                  "type": "named",
+                  "name": "Artist"
+                }
+              }
+            }
+          }
+        ]
       }
     },
     "version": "v1",
@@ -651,6 +674,12 @@
     "definition": {
       "name": "artist_below_id",
       "objectType": "artist_below_id",
+      "arguments": [
+        {
+          "name": "id",
+          "type": "Int!"
+        }
+      ],
       "source": {
         "dataConnectorName": "db",
         "collection": "artist_below_id",
@@ -665,7 +694,19 @@
               }
             }
           }
+        },
+        "argumentMapping": {
+          "id": "id"
         }
+      },
+      "graphql": {
+        "selectUniques": [],
+        "selectMany": {
+          "queryRootField": "artist_below_id"
+        },
+        "filterExpressionType": "artist_below_id_Where_Exp",
+        "orderByExpressionType": "artist_below_id_Order_By",
+        "argumentsInputType": "artist_below_id_Args"
       },
       "filterableFields": [
         {
@@ -698,6 +739,67 @@
     },
     "version": "v1",
     "kind": "Model"
+  },
+  {
+    "kind": "CommandPermissions",
+    "version": "v1",
+    "definition": {
+      "commandName": "insert_artist",
+      "permissions": [
+        {
+          "role": "admin",
+          "allowExecution": true
+        },
+        {
+          "role": "user",
+          "allowExecution": true
+        }
+      ]
+    }
+  },
+  {
+    "kind": "Command",
+    "version": "v1",
+    "definition": {
+      "name": "insert_artist",
+      "arguments": [
+        {
+          "name": "id",
+          "type": "Int!"
+        },
+        {
+          "name": "name",
+          "type": "String!"
+        }
+      ],
+      "outputType": "[Artist]",
+      "source": {
+        "dataConnectorName": "db",
+        "dataConnectorCommand": {
+          "procedure": "insert_artist"
+        },
+        "typeMapping": {
+          "Artist": {
+            "fieldMapping": {
+              "ArtistId": {
+                "column": "ArtistId"
+              },
+              "Name": {
+                "column": "Name"
+              }
+            }
+          }
+        },
+        "argumentMapping": {
+          "id": "id",
+          "name": "name"
+        }
+      },
+      "graphql": {
+        "rootFieldName": "insert_artist",
+        "rootFieldKind": "Mutation"
+      }
+    }
   },
   {
     "definition": {


### PR DESCRIPTION
### What

We want to make sure that native query mutations can run e2e.
This PR adds some v3-engine metadata configuration so we can test this, as well as fixes a bug in the expected returned format.

To check, have hge-v3 cloned and run the following in different terminals:

```sh
just dev
```

```sh
just run-engine
```

```sh
curl -X POST \
    -H 'Host: example.hasura.app' \
    -H 'Content-Type: application/json' \
    -H 'x-hasura-role: admin' \
    http://localhost:3000/graphql \
    -d '{ "query": "mutation {insert_artist(id: 276, name: \"Olympians\") {Name}}" }'  | jq
```

The expected result is:

```json
{
  "data": {
    "insert_artist": [
      {
        "Name": "Olympians"
      }
    ]
  }
}
```

We also update some of the instructions and justfile so users can run this.

### How

- The bugfix wraps what was previously the `returning` field in a `json_build_array(json_build_object('__value', <thing>)) as "returning"`.
- We add a procedure, command permission, and a command for `insert_artist`, we also fix the `artist_below_id` so it can receive arguments and be run from v3 engine.
- The directory of `v3-engine` is now configurable via the environment variable `HGE_V3_DIRECTORY`, and user are advised to set this variable to where they cloned the v3 engine.
