### PR TITLE
add missing isProcedure tag to native query mutations

### DIFF
--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__schema_tests__schema_test__get_schema.snap
@@ -2552,84 +2552,6 @@ expression: result
       "foreign_keys": {}
     },
     {
-      "name": "delete_playlist_track",
-      "arguments": {
-        "track_id": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        }
-      },
-      "type": "delete_playlist_track",
-      "uniqueness_constraints": {},
-      "foreign_keys": {}
-    },
-    {
-      "name": "insert_album",
-      "arguments": {
-        "artist_id": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        },
-        "id": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        },
-        "title": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        }
-      },
-      "type": "insert_album",
-      "uniqueness_constraints": {},
-      "foreign_keys": {}
-    },
-    {
-      "name": "insert_artist",
-      "arguments": {
-        "id": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        },
-        "name": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        }
-      },
-      "type": "insert_artist",
-      "uniqueness_constraints": {},
-      "foreign_keys": {}
-    },
-    {
       "name": "value_types",
       "arguments": {
         "bool": {
@@ -2784,6 +2706,87 @@ expression: result
   ],
   "functions": [],
   "procedures": [
+    {
+      "name": "delete_playlist_track",
+      "arguments": {
+        "track_id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "delete_playlist_track"
+      }
+    },
+    {
+      "name": "insert_album",
+      "arguments": {
+        "artist_id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        },
+        "id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        },
+        "title": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "insert_album"
+      }
+    },
+    {
+      "name": "insert_artist",
+      "arguments": {
+        "id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        },
+        "name": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "insert_artist"
+      }
+    },
     {
       "name": "v1_delete_Album_by_AlbumId",
       "description": "Delete any value on the Album table using the AlbumId key",

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__schema_tests__schema_test__get_schema.snap
@@ -2364,84 +2364,6 @@ expression: result
       "foreign_keys": {}
     },
     {
-      "name": "delete_playlist_track",
-      "arguments": {
-        "track_id": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        }
-      },
-      "type": "delete_playlist_track",
-      "uniqueness_constraints": {},
-      "foreign_keys": {}
-    },
-    {
-      "name": "insert_album",
-      "arguments": {
-        "artist_id": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        },
-        "id": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        },
-        "title": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        }
-      },
-      "type": "insert_album",
-      "uniqueness_constraints": {},
-      "foreign_keys": {}
-    },
-    {
-      "name": "insert_artist",
-      "arguments": {
-        "id": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        },
-        "name": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        }
-      },
-      "type": "insert_artist",
-      "uniqueness_constraints": {},
-      "foreign_keys": {}
-    },
-    {
       "name": "value_types",
       "arguments": {
         "bool": {
@@ -2596,6 +2518,87 @@ expression: result
   ],
   "functions": [],
   "procedures": [
+    {
+      "name": "delete_playlist_track",
+      "arguments": {
+        "track_id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "delete_playlist_track"
+      }
+    },
+    {
+      "name": "insert_album",
+      "arguments": {
+        "artist_id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        },
+        "id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        },
+        "title": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "insert_album"
+      }
+    },
+    {
+      "name": "insert_artist",
+      "arguments": {
+        "id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        },
+        "name": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "insert_artist"
+      }
+    },
     {
       "name": "v1_delete_Album_by_AlbumId",
       "description": "Delete any value on the Album table using the AlbumId key",

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
@@ -2818,84 +2818,6 @@ expression: result
       "foreign_keys": {}
     },
     {
-      "name": "delete_playlist_track",
-      "arguments": {
-        "track_id": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        }
-      },
-      "type": "delete_playlist_track",
-      "uniqueness_constraints": {},
-      "foreign_keys": {}
-    },
-    {
-      "name": "insert_album",
-      "arguments": {
-        "artist_id": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        },
-        "id": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        },
-        "title": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        }
-      },
-      "type": "insert_album",
-      "uniqueness_constraints": {},
-      "foreign_keys": {}
-    },
-    {
-      "name": "insert_artist",
-      "arguments": {
-        "id": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        },
-        "name": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        }
-      },
-      "type": "insert_artist",
-      "uniqueness_constraints": {},
-      "foreign_keys": {}
-    },
-    {
       "name": "value_types",
       "arguments": {
         "bool": {
@@ -3050,6 +2972,87 @@ expression: result
   ],
   "functions": [],
   "procedures": [
+    {
+      "name": "delete_playlist_track",
+      "arguments": {
+        "track_id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "delete_playlist_track"
+      }
+    },
+    {
+      "name": "insert_album",
+      "arguments": {
+        "artist_id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        },
+        "id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        },
+        "title": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "insert_album"
+      }
+    },
+    {
+      "name": "insert_artist",
+      "arguments": {
+        "id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        },
+        "name": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "insert_artist"
+      }
+    },
     {
       "name": "v1_delete_Album_by_AlbumId",
       "description": "Delete any value on the Album table using the AlbumId key",

--- a/static/aurora/v2-chinook-deployment-template.json
+++ b/static/aurora/v2-chinook-deployment-template.json
@@ -928,7 +928,8 @@
             "description": null
           }
         },
-        "description": null
+        "description": null,
+        "isProcedure": true
       },
       "insert_album": {
         "sql": "INSERT INTO public.\"Album\" VALUES({{id}}, {{title}}, {{artist_id}}) RETURNING *",
@@ -984,7 +985,8 @@
             "description": null
           }
         },
-        "description": null
+        "description": null,
+        "isProcedure": true
       },
       "insert_artist": {
         "sql": "INSERT INTO public.\"Artist\" VALUES ({{id}}, {{name}}) RETURNING *",
@@ -1024,7 +1026,8 @@
             "description": null
           }
         },
-        "description": null
+        "description": null,
+        "isProcedure": true
       },
       "value_types": {
         "sql": "SELECT {{bool}} as bool, {{int4}} as int4, {{int2}} as int2, {{int8}} as int8, {{float4}} as float4, {{float8}} as \"float8\", {{numeric}} as numeric, {{char}} as char, {{varchar}} as \"varchar\", {{text}} as text, {{date}} as date, {{time}} as time, {{timetz}} as timetz, {{timestamp}} as timestamp, {{timestamptz}} as timestamptz, {{uuid}} as uuid",

--- a/static/citus/v2-chinook-deployment.json
+++ b/static/citus/v2-chinook-deployment.json
@@ -922,7 +922,8 @@
             "description": null
           }
         },
-        "description": null
+        "description": null,
+        "isProcedure": true
       },
       "insert_album": {
         "sql": "INSERT INTO public.\"Album\" VALUES({{id}}, {{title}}, {{artist_id}}) RETURNING *",
@@ -978,7 +979,8 @@
             "description": null
           }
         },
-        "description": null
+        "description": null,
+        "isProcedure": true
       },
       "insert_artist": {
         "sql": "INSERT INTO public.\"Artist\" VALUES ({{id}}, {{name}}) RETURNING *",
@@ -1018,7 +1020,8 @@
             "description": null
           }
         },
-        "description": null
+        "description": null,
+        "isProcedure": true
       },
       "value_types": {
         "sql": "SELECT {{bool}} as bool, {{int4}} as int4, {{int2}} as int2, {{int8}} as int8, {{float4}} as float4, {{float8}} as \"float8\", {{numeric}} as numeric, {{char}} as char, {{varchar}} as \"varchar\", {{text}} as text, {{date}} as date, {{time}} as time, {{timetz}} as timetz, {{timestamp}} as timestamp, {{timestamptz}} as timestamptz, {{uuid}} as uuid",

--- a/static/cockroach/v2-chinook-deployment.json
+++ b/static/cockroach/v2-chinook-deployment.json
@@ -971,7 +971,8 @@
             "description": null
           }
         },
-        "description": null
+        "description": null,
+        "isProcedure": true
       },
       "insert_album": {
         "sql": "INSERT INTO public.\"Album\" VALUES({{id}}, {{title}}, {{artist_id}}) RETURNING *",
@@ -1027,7 +1028,8 @@
             "description": null
           }
         },
-        "description": null
+        "description": null,
+        "isProcedure": true
       },
       "insert_artist": {
         "sql": "INSERT INTO public.\"Artist\" VALUES ({{id}}, {{name}}) RETURNING *",
@@ -1067,7 +1069,8 @@
             "description": null
           }
         },
-        "description": null
+        "description": null,
+        "isProcedure": true
       },
       "value_types": {
         "sql": "SELECT {{bool}} as bool, {{int4}} as int4, {{int2}} as int2, {{int8}} as int8, {{float4}} as float4, {{float8}} as \"float8\", {{numeric}} as numeric, {{char}} as char, {{varchar}} as \"varchar\", {{text}} as text, {{date}} as date, {{time}} as time, {{timetz}} as timetz, {{timestamp}} as timestamp, {{timestamptz}} as timestamptz, {{uuid}} as uuid",

--- a/static/postgres/v2-chinook-deployment.json
+++ b/static/postgres/v2-chinook-deployment.json
@@ -1113,7 +1113,8 @@
             "description": null
           }
         },
-        "description": null
+        "description": null,
+        "isProcedure": true
       },
       "insert_album": {
         "sql": "INSERT INTO public.\"Album\" VALUES({{id}}, {{title}}, {{artist_id}}) RETURNING *",
@@ -1169,7 +1170,8 @@
             "description": null
           }
         },
-        "description": null
+        "description": null,
+        "isProcedure": true
       },
       "insert_artist": {
         "sql": "INSERT INTO public.\"Artist\" VALUES ({{id}}, {{name}}) RETURNING *",
@@ -1209,7 +1211,8 @@
             "description": null
           }
         },
-        "description": null
+        "description": null,
+        "isProcedure": true
       },
       "value_types": {
         "sql": "SELECT {{bool}} as bool, {{int4}} as int4, {{int2}} as int2, {{int8}} as int8, {{float4}} as float4, {{float8}} as \"float8\", {{numeric}} as numeric, {{char}} as char, {{varchar}} as \"varchar\", {{text}} as text, {{date}} as date, {{time}} as time, {{timetz}} as timetz, {{timestamp}} as timestamp, {{timestamptz}} as timestamptz, {{uuid}} as uuid",

--- a/static/yugabyte/v2-chinook-deployment.json
+++ b/static/yugabyte/v2-chinook-deployment.json
@@ -922,7 +922,8 @@
             "description": null
           }
         },
-        "description": null
+        "description": null,
+        "isProcedure": true
       },
       "insert_album": {
         "sql": "INSERT INTO public.\"Album\" VALUES({{id}}, {{title}}, {{artist_id}}) RETURNING *",
@@ -978,7 +979,8 @@
             "description": null
           }
         },
-        "description": null
+        "description": null,
+        "isProcedure": true
       },
       "insert_artist": {
         "sql": "INSERT INTO public.\"Artist\" VALUES ({{id}}, {{name}}) RETURNING *",
@@ -1018,7 +1020,8 @@
             "description": null
           }
         },
-        "description": null
+        "description": null,
+        "isProcedure": true
       },
       "value_types": {
         "sql": "SELECT {{bool}} as bool, {{int4}} as int4, {{int2}} as int2, {{int8}} as int8, {{float4}} as float4, {{float8}} as \"float8\", {{numeric}} as numeric, {{char}} as char, {{varchar}} as \"varchar\", {{text}} as text, {{date}} as date, {{time}} as time, {{timetz}} as timetz, {{timestamp}} as timestamp, {{timestamptz}} as timestamptz, {{uuid}} as uuid",


### PR DESCRIPTION
### What

The native query mutations we defined in the deployment files were accidentally not marked as procedures, so they were exposed as collections in the schema instead of procedures.

### How

1. Add `isProcedure: true` field to native query mutations definitions
2. Rerun the tests
3. cargo insta review and accept
