### PR TITLE
test that failed mutations are rolled back

### DIFF
--- a/crates/tests/databases-tests/src/postgres/mutation_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/mutation_tests.rs
@@ -3,7 +3,7 @@
 mod basic {
     use super::super::common;
     use tests_common::deployment::{clean_up_deployment, create_fresh_deployment};
-    use tests_common::request::run_mutation;
+    use tests_common::request::{run_mutation, run_query};
 
     #[tokio::test]
     async fn delete_playlist() {
@@ -33,11 +33,15 @@ mod basic {
         .await
         .unwrap();
 
-        let result = run_mutation(
-            tests_common::router::create_router_from_deployment(&deployment.deployment_path).await,
-            "insert_artist_album",
-        )
-        .await;
+        let router =
+            tests_common::router::create_router_from_deployment(&deployment.deployment_path).await;
+
+        let mutation_result = run_mutation(router.clone(), "insert_artist_album").await;
+
+        // expect the artist to be returned, because we inserted it successfully.
+        let selection_result = run_query(router, "mutations/select_specific_artist").await;
+
+        let result = (mutation_result, selection_result);
 
         clean_up_deployment(deployment).await.unwrap();
         insta::assert_json_snapshot!(result)
@@ -60,5 +64,37 @@ mod basic {
 
         clean_up_deployment(deployment).await.unwrap();
         insta::assert_json_snapshot!(result)
+    }
+}
+
+#[cfg(test)]
+mod negative {
+    use super::super::common;
+    use tests_common::deployment::{clean_up_deployment, create_fresh_deployment};
+    use tests_common::request::{run_mutation500, run_query};
+
+    #[tokio::test]
+    /// Check that the second statement fails on duplicate key constraint,
+    /// and that it rolls back the first statement.
+    async fn insert_artist_album_bad() {
+        let deployment = create_fresh_deployment(
+            common::CONNECTION_STRING,
+            common::CHINOOK_DEPLOYMENT_PATH_V2,
+        )
+        .await
+        .unwrap();
+
+        let router =
+            tests_common::router::create_router_from_deployment(&deployment.deployment_path).await;
+
+        let mutation_result = run_mutation500(router.clone(), "insert_artist_album_bad").await;
+
+        // expect no rows returned because first operation was rolled back.
+        let selection_result = run_query(router, "mutations/select_specific_artist").await;
+
+        let result = (mutation_result, selection_result);
+
+        clean_up_deployment(deployment).await.unwrap();
+        insta::assert_json_snapshot!(result);
     }
 }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__insert_artist_album.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__insert_artist_album.snap
@@ -2,40 +2,51 @@
 source: crates/tests/databases-tests/src/postgres/mutation_tests.rs
 expression: result
 ---
-{
-  "operation_results": [
-    {
-      "affected_rows": 1,
-      "returning": [
-        {
-          "__value": [
-            {
-              "artist_id": 276,
-              "name": "Olympians"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "affected_rows": 1,
-      "returning": [
-        {
-          "__value": [
-            {
-              "album_id": 348,
-              "title": "Lake Mannion",
-              "artist": {
-                "rows": [
-                  {
-                    "name": "Olympians"
-                  }
-                ]
+[
+  {
+    "operation_results": [
+      {
+        "affected_rows": 1,
+        "returning": [
+          {
+            "__value": [
+              {
+                "artist_id": 276,
+                "name": "Olympians"
               }
-            }
-          ]
+            ]
+          }
+        ]
+      },
+      {
+        "affected_rows": 1,
+        "returning": [
+          {
+            "__value": [
+              {
+                "album_id": 348,
+                "title": "Lake Mannion",
+                "artist": {
+                  "rows": [
+                    {
+                      "name": "Olympians"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  [
+    {
+      "rows": [
+        {
+          "Name": "Olympians"
         }
       ]
     }
   ]
-}
+]

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__negative__insert_artist_album_bad.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__negative__insert_artist_album_bad.snap
@@ -1,0 +1,17 @@
+---
+source: crates/tests/databases-tests/src/postgres/mutation_tests.rs
+expression: result
+---
+[
+  {
+    "message": "Internal error",
+    "details": {
+      "cause": "error returned from database: duplicate key value violates unique constraint \"PK_Album\""
+    }
+  },
+  [
+    {
+      "rows": []
+    }
+  ]
+]

--- a/crates/tests/tests-common/goldenfiles/mutations/insert_artist_album_bad.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/insert_artist_album_bad.json
@@ -1,0 +1,66 @@
+{
+  "operations": [
+    {
+      "type": "procedure",
+      "name": "insert_artist",
+      "arguments": {
+        "id": 276,
+        "name": "Olympians"
+      },
+      "fields": {
+        "artist_id": {
+          "type": "column",
+          "column": "ArtistId"
+        },
+        "name": {
+          "type": "column",
+          "column": "Name"
+        }
+      }
+    },
+    {
+      "type": "procedure",
+      "name": "insert_album",
+      "arguments": {
+        "id": 347,
+        "title": "Lake Mannion",
+        "artist_id": 276
+      },
+      "fields": {
+        "album_id": {
+          "type": "column",
+          "column": "AlbumId"
+        },
+        "title": {
+          "type": "column",
+          "column": "Title"
+        },
+        "artist": {
+          "type": "relationship",
+          "column": "Title",
+          "relationship": "AlbumToArtist",
+          "query": {
+            "fields": {
+              "name": {
+                "type": "column",
+                "column": "Name",
+                "arguments": {}
+              }
+            }
+          },
+          "arguments": {}
+        }
+      }
+    }
+  ],
+  "collection_relationships": {
+    "AlbumToArtist": {
+      "column_mapping": {
+        "ArtistId": "ArtistId"
+      },
+      "relationship_type": "object",
+      "target_collection": "Artist",
+      "arguments": {}
+    }
+  }
+}

--- a/crates/tests/tests-common/goldenfiles/mutations/select_specific_artist.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/select_specific_artist.json
@@ -1,0 +1,29 @@
+{
+  "collection": "Artist",
+  "query": {
+    "fields": {
+      "Name": {
+        "type": "column",
+        "column": "Name",
+        "arguments": {}
+      }
+    },
+    "where": {
+      "type": "binary_comparison_operator",
+      "column": {
+        "type": "column",
+        "name": "ArtistId",
+        "path": []
+      },
+      "operator": {
+        "type": "equal"
+      },
+      "value": {
+        "type": "scalar",
+        "value": 276
+      }
+    }
+  },
+  "arguments": {},
+  "collection_relationships": {}
+}

--- a/crates/tests/tests-common/src/request.rs
+++ b/crates/tests/tests-common/src/request.rs
@@ -7,7 +7,7 @@ use serde_derive::Deserialize;
 
 /// Run a query against the server, get the result, and compare against the snapshot.
 pub async fn run_query(router: axum::Router, testname: &str) -> ndc_sdk::models::QueryResponse {
-    run_against_server(router, "query", testname).await
+    run_against_server(router, "query", testname, StatusCode::OK).await
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize)]
@@ -25,7 +25,7 @@ pub struct ExplainDetails {
 
 /// Run a query against the server, get the result, and compare against the snapshot.
 pub async fn run_explain(router: axum::Router, testname: &str) -> ExactExplainResponse {
-    run_against_server(router, "explain", testname).await
+    run_against_server(router, "explain", testname, StatusCode::OK).await
 }
 
 /// Run a mutation against the server, get the result, and compare against the snapshot.
@@ -33,12 +33,33 @@ pub async fn run_mutation(
     router: axum::Router,
     testname: &str,
 ) -> ndc_sdk::models::MutationResponse {
-    run_against_server(router, "mutation", &format!("mutations/{}", testname)).await
+    run_against_server(
+        router,
+        "mutation",
+        &format!("mutations/{}", testname),
+        StatusCode::OK,
+    )
+    .await
+}
+
+/// Run a mutation that is expected to fail with 500 against the server,
+/// get the result, and compare against the snapshot.
+pub async fn run_mutation500(
+    router: axum::Router,
+    testname: &str,
+) -> ndc_sdk::models::ErrorResponse {
+    run_against_server(
+        router,
+        "mutation",
+        &format!("mutations/{}", testname),
+        StatusCode::INTERNAL_SERVER_ERROR,
+    )
+    .await
 }
 
 /// Run a query against the server, get the result, and compare against the snapshot.
 pub async fn get_schema(router: axum::Router) -> ndc_sdk::models::SchemaResponse {
-    make_request(router, |client| client.get("/schema")).await
+    make_request(router, |client| client.get("/schema"), StatusCode::OK).await
 }
 
 /// Run an action against the server, and get the response.
@@ -46,6 +67,7 @@ async fn run_against_server<Response: for<'a> serde::Deserialize<'a>>(
     router: axum::Router,
     action: &str,
     testname: &str,
+    expected_status: StatusCode,
 ) -> Response {
     let path = format!("/{}", action);
     let body = match fs::read_to_string(format!(
@@ -58,12 +80,16 @@ async fn run_against_server<Response: for<'a> serde::Deserialize<'a>>(
             panic!("error look up");
         }
     };
-    make_request(router, |client| {
-        client
-            .post(&path)
-            .header("Content-Type", "application/json")
-            .body(body)
-    })
+    make_request(
+        router,
+        |client| {
+            client
+                .post(&path)
+                .header("Content-Type", "application/json")
+                .body(body)
+        },
+        expected_status,
+    )
     .await
 }
 
@@ -71,6 +97,7 @@ async fn run_against_server<Response: for<'a> serde::Deserialize<'a>>(
 async fn make_request<Response: for<'a> serde::Deserialize<'a>>(
     router: axum::Router,
     request: impl FnOnce(axum_test_helper::TestClient) -> axum_test_helper::RequestBuilder,
+    expected_status: StatusCode,
 ) -> Response {
     let client = axum_test_helper::TestClient::new(router);
 
@@ -82,8 +109,9 @@ async fn make_request<Response: for<'a> serde::Deserialize<'a>>(
     // ensure we get a successful response
     assert_eq!(
         status,
-        StatusCode::OK,
-        "Expected a successful response but got status {}.\nBody:\n{}",
+        expected_status,
+        "Expected status code {} but got status {}.\nBody:\n{}",
+        expected_status,
         status,
         std::str::from_utf8(&body).unwrap()
     );


### PR DESCRIPTION
### What

We want to test that mutation requests are run as a transaction, and that if one mutation fails, the other mutations are rolled back.

### How

We add a test with a mutation request that tries to insert an album with an already existing id, which fails. We check that it fails, and we also verify that the artist we inserted before was not inserted to the db.
