### PR TITLE
Better error codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,7 +1509,7 @@ dependencies = [
 [[package]]
 name = "ndc-sdk"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-hub.git?rev=d9689a2d8bb1bfad90bac7654c2d4fbb1310a8bc#d9689a2d8bb1bfad90bac7654c2d4fbb1310a8bc"
+source = "git+https://github.com/hasura/ndc-hub.git?rev=3b6c480#3b6c48016473ce3369da76269a6e1c03f8af7b22"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,7 +604,7 @@ dependencies = [
  "axum",
  "insta",
  "ndc-postgres",
- "ndc-test 0.1.0 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.13)",
+ "ndc-test",
  "schemars",
  "serde_json",
  "test-each",
@@ -1460,23 +1460,6 @@ dependencies = [
 [[package]]
 name = "ndc-client"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.12#0e84462f98fdf77e1f25ab905e33918aaef4cee9"
-dependencies = [
- "async-trait",
- "indexmap 2.1.0",
- "opentelemetry",
- "reqwest",
- "schemars",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with 2.3.3",
- "url",
-]
-
-[[package]]
-name = "ndc-client"
-version = "0.1.0"
 source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.13#1f9b2a996ad74ac4bc97a783c4d014a3fd46b08e"
 dependencies = [
  "async-trait",
@@ -1501,9 +1484,9 @@ dependencies = [
  "env_logger",
  "hyper",
  "insta",
- "ndc-client 0.1.0 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.13)",
+ "ndc-client",
  "ndc-sdk",
- "ndc-test 0.1.0 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.13)",
+ "ndc-test",
  "percent-encoding",
  "prometheus",
  "query-engine-execution",
@@ -1526,7 +1509,7 @@ dependencies = [
 [[package]]
 name = "ndc-sdk"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-hub.git?rev=ae09995#ae09995eedfb3dbe9bbdae91e08be88f5cc540d6"
+source = "git+https://github.com/hasura/ndc-hub.git?rev=d9689a2d8bb1bfad90bac7654c2d4fbb1310a8bc#d9689a2d8bb1bfad90bac7654c2d4fbb1310a8bc"
 dependencies = [
  "async-trait",
  "axum",
@@ -1538,8 +1521,8 @@ dependencies = [
  "http",
  "indexmap 2.1.0",
  "mime",
- "ndc-client 0.1.0 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.12)",
- "ndc-test 0.1.0 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.12)",
+ "ndc-client",
+ "ndc-test",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-otlp",
@@ -1563,32 +1546,13 @@ dependencies = [
 [[package]]
 name = "ndc-test"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.12#0e84462f98fdf77e1f25ab905e33918aaef4cee9"
-dependencies = [
- "async-trait",
- "clap",
- "colored",
- "indexmap 2.1.0",
- "ndc-client 0.1.0 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.12)",
- "proptest",
- "reqwest",
- "semver",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "ndc-test"
-version = "0.1.0"
 source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.13#1f9b2a996ad74ac4bc97a783c4d014a3fd46b08e"
 dependencies = [
  "async-trait",
  "clap",
  "colored",
  "indexmap 2.1.0",
- "ndc-client 0.1.0 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.13)",
+ "ndc-client",
  "proptest",
  "reqwest",
  "semver",
@@ -3182,10 +3146,10 @@ dependencies = [
  "env_logger",
  "hyper",
  "jsonschema",
- "ndc-client 0.1.0 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.13)",
+ "ndc-client",
  "ndc-postgres",
  "ndc-sdk",
- "ndc-test 0.1.0 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.13)",
+ "ndc-test",
  "reqwest",
  "schemars",
  "serde",

--- a/crates/connectors/ndc-postgres/Cargo.toml
+++ b/crates/connectors/ndc-postgres/Cargo.toml
@@ -15,7 +15,7 @@ name = "ndc-postgres"
 path = "bin/main.rs"
 
 [dependencies]
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "ae09995" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "d9689a2d8bb1bfad90bac7654c2d4fbb1310a8bc" }
 query-engine-execution = { path = "../../query-engine/execution" }
 query-engine-metadata = { path = "../../query-engine/metadata" }
 query-engine-sql = { path = "../../query-engine/sql" }

--- a/crates/connectors/ndc-postgres/Cargo.toml
+++ b/crates/connectors/ndc-postgres/Cargo.toml
@@ -15,7 +15,7 @@ name = "ndc-postgres"
 path = "bin/main.rs"
 
 [dependencies]
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "d9689a2d8bb1bfad90bac7654c2d4fbb1310a8bc" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "3b6c480" }
 query-engine-execution = { path = "../../query-engine/execution" }
 query-engine-metadata = { path = "../../query-engine/metadata" }
 query-engine-sql = { path = "../../query-engine/sql" }

--- a/crates/connectors/ndc-postgres/src/explain.rs
+++ b/crates/connectors/ndc-postgres/src/explain.rs
@@ -63,7 +63,7 @@ pub async fn explain<'a>(
                     }
                     query_engine_execution::query::QueryError::DBError(_) => {
                         state.metrics.error_metrics.record_invalid_request();
-                        connector::ExplainError::InvalidRequest(err.to_string())
+                        connector::ExplainError::UnprocessableContent(err.to_string())
                     }
                 }
             }

--- a/crates/connectors/ndc-postgres/src/explain.rs
+++ b/crates/connectors/ndc-postgres/src/explain.rs
@@ -50,17 +50,22 @@ pub async fn explain<'a>(
                 // log error metric
                 match &err {
                     query_engine_execution::query::QueryError::ReservedVariableName(_) => {
-                        state.metrics.error_metrics.record_invalid_request()
+                        state.metrics.error_metrics.record_invalid_request();
+                        connector::ExplainError::InvalidRequest(err.to_string().into())
                     }
                     query_engine_execution::query::QueryError::VariableNotFound(_) => {
-                        state.metrics.error_metrics.record_invalid_request()
+                        state.metrics.error_metrics.record_invalid_request();
+                        connector::ExplainError::InvalidRequest(err.to_string().into())
                     }
                     query_engine_execution::query::QueryError::NotSupported(_) => {
-                        state.metrics.error_metrics.record_unsupported_feature()
+                        state.metrics.error_metrics.record_unsupported_feature();
+                        connector::ExplainError::UnsupportedOperation(err.to_string().into())
+                    }
+                    query_engine_execution::query::QueryError::DBError(_) => {
+                        state.metrics.error_metrics.record_invalid_request();
+                        connector::ExplainError::InvalidRequest(err.to_string().into())
                     }
                 }
-
-                connector::ExplainError::Other(err.to_string().into())
             }
             query_engine_execution::query::Error::DB(err) => {
                 tracing::error!("{}", err);

--- a/crates/connectors/ndc-postgres/src/explain.rs
+++ b/crates/connectors/ndc-postgres/src/explain.rs
@@ -51,19 +51,19 @@ pub async fn explain<'a>(
                 match &err {
                     query_engine_execution::query::QueryError::ReservedVariableName(_) => {
                         state.metrics.error_metrics.record_invalid_request();
-                        connector::ExplainError::InvalidRequest(err.to_string().into())
+                        connector::ExplainError::InvalidRequest(err.to_string())
                     }
                     query_engine_execution::query::QueryError::VariableNotFound(_) => {
                         state.metrics.error_metrics.record_invalid_request();
-                        connector::ExplainError::InvalidRequest(err.to_string().into())
+                        connector::ExplainError::InvalidRequest(err.to_string())
                     }
                     query_engine_execution::query::QueryError::NotSupported(_) => {
                         state.metrics.error_metrics.record_unsupported_feature();
-                        connector::ExplainError::UnsupportedOperation(err.to_string().into())
+                        connector::ExplainError::UnsupportedOperation(err.to_string())
                     }
                     query_engine_execution::query::QueryError::DBError(_) => {
                         state.metrics.error_metrics.record_invalid_request();
-                        connector::ExplainError::InvalidRequest(err.to_string().into())
+                        connector::ExplainError::InvalidRequest(err.to_string())
                     }
                 }
             }

--- a/crates/connectors/ndc-postgres/src/mutation.rs
+++ b/crates/connectors/ndc-postgres/src/mutation.rs
@@ -125,7 +125,7 @@ fn log_err_metrics_and_convert_error(
             }
             query_engine_execution::mutation::QueryError::DBError(_) => {
                 state.metrics.error_metrics.record_invalid_request();
-                connector::MutationError::InvalidRequest(err.to_string())
+                connector::MutationError::UnprocessableContent(err.to_string())
             }
             query_engine_execution::mutation::QueryError::DBConstraintError(_) => {
                 state.metrics.error_metrics.record_invalid_request();

--- a/crates/connectors/ndc-postgres/src/mutation.rs
+++ b/crates/connectors/ndc-postgres/src/mutation.rs
@@ -121,15 +121,15 @@ fn log_err_metrics_and_convert_error(
         query_engine_execution::mutation::Error::Query(err) => match &err {
             query_engine_execution::mutation::QueryError::NotSupported(_) => {
                 state.metrics.error_metrics.record_unsupported_feature();
-                connector::MutationError::UnsupportedOperation(err.to_string().into())
+                connector::MutationError::UnsupportedOperation(err.to_string())
             }
             query_engine_execution::mutation::QueryError::DBError(_) => {
                 state.metrics.error_metrics.record_invalid_request();
-                connector::MutationError::InvalidRequest(err.to_string().into())
+                connector::MutationError::InvalidRequest(err.to_string())
             }
             query_engine_execution::mutation::QueryError::DBConstraintError(_) => {
                 state.metrics.error_metrics.record_invalid_request();
-                connector::MutationError::ConstraintNotMet(err.to_string().into())
+                connector::MutationError::ConstraintNotMet(err.to_string())
             }
         },
         query_engine_execution::mutation::Error::DB(_) => {

--- a/crates/connectors/ndc-postgres/src/mutation.rs
+++ b/crates/connectors/ndc-postgres/src/mutation.rs
@@ -109,24 +109,37 @@ async fn execute_mutation(
     .map(JsonResponse::Serialized)
     .map_err(|err| {
         tracing::error!("{}", err);
-        log_err_metrics(state, &err);
-        connector::MutationError::Other(err.to_string().into())
+        log_err_metrics_and_convert_error(state, &err)
     })
 }
 
-fn log_err_metrics(state: &state::State, err: &query_engine_execution::mutation::Error) {
+fn log_err_metrics_and_convert_error(
+    state: &state::State,
+    err: &query_engine_execution::mutation::Error,
+) -> connector::MutationError {
     match err {
         query_engine_execution::mutation::Error::Query(err) => match &err {
             query_engine_execution::mutation::QueryError::NotSupported(_) => {
-                state.metrics.error_metrics.record_unsupported_feature()
+                state.metrics.error_metrics.record_unsupported_feature();
+                connector::MutationError::UnsupportedOperation(err.to_string().into())
+            }
+            query_engine_execution::mutation::QueryError::DBError(_) => {
+                state.metrics.error_metrics.record_invalid_request();
+                connector::MutationError::InvalidRequest(err.to_string().into())
+            }
+            query_engine_execution::mutation::QueryError::DBConstraintError(_) => {
+                state.metrics.error_metrics.record_invalid_request();
+                connector::MutationError::ConstraintNotMet(err.to_string().into())
             }
         },
         query_engine_execution::mutation::Error::DB(_) => {
             state.metrics.error_metrics.record_database_error();
+            connector::MutationError::Other(err.to_string().into())
         }
         query_engine_execution::mutation::Error::Multiple(err1, err2) => {
-            log_err_metrics(state, err1);
-            log_err_metrics(state, err2);
+            log_err_metrics_and_convert_error(state, err1);
+            log_err_metrics_and_convert_error(state, err2);
+            connector::MutationError::Other(err.to_string().into())
         }
     }
 }

--- a/crates/connectors/ndc-postgres/src/query.rs
+++ b/crates/connectors/ndc-postgres/src/query.rs
@@ -107,7 +107,7 @@ async fn execute_query(
                     }
                     query_engine_execution::query::QueryError::DBError(_) => {
                         state.metrics.error_metrics.record_invalid_request();
-                        connector::QueryError::InvalidRequest(err.to_string())
+                        connector::QueryError::UnprocessableContent(err.to_string())
                     }
                 }
             }

--- a/crates/connectors/ndc-postgres/src/query.rs
+++ b/crates/connectors/ndc-postgres/src/query.rs
@@ -95,19 +95,19 @@ async fn execute_query(
                 match &err {
                     query_engine_execution::query::QueryError::ReservedVariableName(_) => {
                         state.metrics.error_metrics.record_invalid_request();
-                        connector::QueryError::InvalidRequest(err.to_string().into())
+                        connector::QueryError::InvalidRequest(err.to_string())
                     }
                     query_engine_execution::query::QueryError::VariableNotFound(_) => {
                         state.metrics.error_metrics.record_invalid_request();
-                        connector::QueryError::InvalidRequest(err.to_string().into())
+                        connector::QueryError::InvalidRequest(err.to_string())
                     }
                     query_engine_execution::query::QueryError::NotSupported(_) => {
                         state.metrics.error_metrics.record_unsupported_feature();
-                        connector::QueryError::UnsupportedOperation(err.to_string().into())
+                        connector::QueryError::UnsupportedOperation(err.to_string())
                     }
                     query_engine_execution::query::QueryError::DBError(_) => {
                         state.metrics.error_metrics.record_invalid_request();
-                        connector::QueryError::InvalidRequest(err.to_string().into())
+                        connector::QueryError::InvalidRequest(err.to_string())
                     }
                 }
             }

--- a/crates/connectors/ndc-postgres/src/query.rs
+++ b/crates/connectors/ndc-postgres/src/query.rs
@@ -94,16 +94,22 @@ async fn execute_query(
                 // log error metric
                 match &err {
                     query_engine_execution::query::QueryError::ReservedVariableName(_) => {
-                        state.metrics.error_metrics.record_invalid_request()
+                        state.metrics.error_metrics.record_invalid_request();
+                        connector::QueryError::InvalidRequest(err.to_string().into())
                     }
                     query_engine_execution::query::QueryError::VariableNotFound(_) => {
-                        state.metrics.error_metrics.record_invalid_request()
+                        state.metrics.error_metrics.record_invalid_request();
+                        connector::QueryError::InvalidRequest(err.to_string().into())
                     }
                     query_engine_execution::query::QueryError::NotSupported(_) => {
-                        state.metrics.error_metrics.record_unsupported_feature()
+                        state.metrics.error_metrics.record_unsupported_feature();
+                        connector::QueryError::UnsupportedOperation(err.to_string().into())
+                    }
+                    query_engine_execution::query::QueryError::DBError(_) => {
+                        state.metrics.error_metrics.record_invalid_request();
+                        connector::QueryError::InvalidRequest(err.to_string().into())
                     }
                 }
-                connector::QueryError::Other(err.to_string().into())
             }
             query_engine_execution::query::Error::DB(err) => {
                 tracing::error!("{}", err);

--- a/crates/query-engine/translation/Cargo.toml
+++ b/crates/query-engine/translation/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "d9689a2d8bb1bfad90bac7654c2d4fbb1310a8bc" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "3b6c480" }
 query-engine-metadata = { path = "../metadata" }
 query-engine-sql = { path = "../sql" }
 

--- a/crates/query-engine/translation/Cargo.toml
+++ b/crates/query-engine/translation/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "ae09995" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "d9689a2d8bb1bfad90bac7654c2d4fbb1310a8bc" }
 query-engine-metadata = { path = "../metadata" }
 query-engine-sql = { path = "../sql" }
 

--- a/crates/tests/databases-tests/src/postgres/mutation_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/mutation_tests.rs
@@ -71,7 +71,7 @@ mod basic {
 mod negative {
     use super::super::common;
     use tests_common::deployment::{clean_up_deployment, create_fresh_deployment};
-    use tests_common::request::{run_mutation500, run_query};
+    use tests_common::request::{run_mutation403, run_query};
 
     #[tokio::test]
     /// Check that the second statement fails on duplicate key constraint,
@@ -87,7 +87,7 @@ mod negative {
         let router =
             tests_common::router::create_router_from_deployment(&deployment.deployment_path).await;
 
-        let mutation_result = run_mutation500(router.clone(), "insert_artist_album_bad").await;
+        let mutation_result = run_mutation403(router.clone(), "insert_artist_album_bad").await;
 
         // expect no rows returned because first operation was rolled back.
         let selection_result = run_query(router, "mutations/select_specific_artist").await;

--- a/crates/tests/databases-tests/src/postgres/query_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/query_tests.rs
@@ -467,3 +467,15 @@ mod types {
         insta::assert_json_snapshot!(result);
     }
 }
+
+#[cfg(test)]
+mod negative {
+    use super::super::common::create_router;
+    use tests_common::request::run_query422;
+
+    #[tokio::test]
+    async fn select_by_pk() {
+        let result = run_query422(create_router().await, "select_by_pk_bad").await;
+        insta::assert_json_snapshot!(result);
+    }
+}

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__negative__insert_artist_album_bad.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__negative__insert_artist_album_bad.snap
@@ -4,9 +4,9 @@ expression: result
 ---
 [
   {
-    "message": "Internal error",
+    "message": "Constraint not met",
     "details": {
-      "cause": "error returned from database: duplicate key value violates unique constraint \"PK_Album\""
+      "detail": "error returned from database: duplicate key value violates unique constraint \"PK_Album\""
     }
   },
   [

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__negative__select_by_pk.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__negative__select_by_pk.snap
@@ -1,0 +1,10 @@
+---
+source: crates/tests/databases-tests/src/postgres/query_tests.rs
+expression: result
+---
+{
+  "message": "Unprocessable content",
+  "details": {
+    "detail": "error returned from database: invalid input syntax for type integer: \"\""
+  }
+}

--- a/crates/tests/tests-common/Cargo.toml
+++ b/crates/tests/tests-common/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/lib.rs"
 [dependencies]
 ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.13" }
 ndc-postgres = { path = "../../connectors/ndc-postgres" }
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "d9689a2d8bb1bfad90bac7654c2d4fbb1310a8bc" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "3b6c480" }
 ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.13" }
 
 axum = "0.6.20"

--- a/crates/tests/tests-common/Cargo.toml
+++ b/crates/tests/tests-common/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/lib.rs"
 [dependencies]
 ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.13" }
 ndc-postgres = { path = "../../connectors/ndc-postgres" }
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "ae09995" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "d9689a2d8bb1bfad90bac7654c2d4fbb1310a8bc" }
 ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.13" }
 
 axum = "0.6.20"

--- a/crates/tests/tests-common/goldenfiles/select_by_pk_bad.json
+++ b/crates/tests/tests-common/goldenfiles/select_by_pk_bad.json
@@ -1,0 +1,34 @@
+{
+  "collection": "Album",
+  "query": {
+    "fields": {
+      "Title": {
+        "type": "column",
+        "column": "Title",
+        "arguments": {}
+      }
+    },
+    "where": {
+      "type": "and",
+      "expressions": [
+        {
+          "type": "binary_comparison_operator",
+          "column": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          },
+          "operator": {
+            "type": "equal"
+          },
+          "value": {
+            "type": "scalar",
+            "value": ""
+          }
+        }
+      ]
+    }
+  },
+  "arguments": {},
+  "collection_relationships": {}
+}

--- a/crates/tests/tests-common/src/request.rs
+++ b/crates/tests/tests-common/src/request.rs
@@ -42,9 +42,9 @@ pub async fn run_mutation(
     .await
 }
 
-/// Run a mutation that is expected to fail with 500 against the server,
+/// Run a mutation that is expected to fail with 403 against the server,
 /// get the result, and compare against the snapshot.
-pub async fn run_mutation500(
+pub async fn run_mutation403(
     router: axum::Router,
     testname: &str,
 ) -> ndc_sdk::models::ErrorResponse {
@@ -52,7 +52,7 @@ pub async fn run_mutation500(
         router,
         "mutation",
         &format!("mutations/{}", testname),
-        StatusCode::INTERNAL_SERVER_ERROR,
+        StatusCode::FORBIDDEN,
     )
     .await
 }

--- a/crates/tests/tests-common/src/request.rs
+++ b/crates/tests/tests-common/src/request.rs
@@ -10,7 +10,8 @@ pub async fn run_query(router: axum::Router, testname: &str) -> ndc_sdk::models:
     run_against_server(router, "query", testname, StatusCode::OK).await
 }
 
-/// Run a query against the server, get the result, and compare against the snapshot.
+/// Run a query that is expected to fail with error 422 against the server,
+/// get the result, and compare against the snapshot.
 pub async fn run_query422(router: axum::Router, testname: &str) -> ndc_sdk::models::ErrorResponse {
     run_against_server(router, "query", testname, StatusCode::UNPROCESSABLE_ENTITY).await
 }

--- a/crates/tests/tests-common/src/request.rs
+++ b/crates/tests/tests-common/src/request.rs
@@ -10,6 +10,11 @@ pub async fn run_query(router: axum::Router, testname: &str) -> ndc_sdk::models:
     run_against_server(router, "query", testname, StatusCode::OK).await
 }
 
+/// Run a query against the server, get the result, and compare against the snapshot.
+pub async fn run_query422(router: axum::Router, testname: &str) -> ndc_sdk::models::ErrorResponse {
+    run_against_server(router, "query", testname, StatusCode::UNPROCESSABLE_ENTITY).await
+}
+
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 pub struct ExactExplainResponse {
     pub details: ExplainDetails,


### PR DESCRIPTION
### What

Currently we return 500 internal error whenever there's an error.
Some errors should return different errors such as 400 or 422.

### How

See the changes to the code in `crates/connectors/src/*.rs` to see which error is mapped to which ndc-hub error.

We also catch specific errors from postgres now, if the code in of the `22` class we return a 422 error, if it is from the `23` class we return a 403 error (for mutations).