### PR TITLE
Return the generated SQL of an explain request with empty variables

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,13 @@
 
 ### Added
 
+- Return the generated SQL on an explain request with empty variables
+  ([#241](https://github.com/hasura/ndc-postgres/pull/241))
+- Emit invalid request, constraint not met, and unprocessable content errors at the relevant scenarios
+  ([#239](https://github.com/hasura/ndc-postgres/pull/239))
+
+### Added
+
 - Support for introspecting prefix-functions as comparison operators ([#223](https://github.com/hasura/ndc-postgres/pull/223))
 - Support prefix functions as comparison operators ([#220](https://github.com/hasura/ndc-postgres/pull/223))
 - Support queries without fields specified. ([#209](https://github.com/hasura/ndc-postgres/pull/209))

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@
 
 ### Added
 
-- Return the generated SQL on an explain request with empty variables
+- Return the generated SQL of an explain request with empty variables
   ([#241](https://github.com/hasura/ndc-postgres/pull/241))
 - Emit invalid request, constraint not met, and unprocessable content errors at the relevant scenarios
   ([#239](https://github.com/hasura/ndc-postgres/pull/239))

--- a/crates/query-engine/execution/src/query.rs
+++ b/crates/query-engine/execution/src/query.rs
@@ -57,7 +57,7 @@ pub async fn explain(
         // One particular such use-case is explaining remote-joins.
         // In this case, we do not run an EXPLAIN query against postgres -
         // we just return the generated SQL.
-        if query.variables.is_some() && query.variables.as_ref().unwrap().len() == 0 {
+        if query.variables.is_some() && query.variables.as_ref().unwrap().is_empty() {
             tracing::info!(
                 generated_sql = query_sql.sql,
                 params = ?&query_sql.params,

--- a/crates/query-engine/execution/src/query.rs
+++ b/crates/query-engine/execution/src/query.rs
@@ -47,66 +47,87 @@ pub async fn explain(
     metrics: &metrics::Metrics,
     plan: sql::execution_plan::ExecutionPlan<sql::execution_plan::Query>,
 ) -> Result<(String, String), Error> {
-    let acquisition_timer = metrics.time_connection_acquisition_wait();
-    let connection_result = pool
-        .acquire()
-        .instrument(info_span!("Acquire connection"))
-        .await;
-    let mut connection = acquisition_timer
-        .complete_with(connection_result)
-        .map_err(|err| {
-            metrics.error_metrics.record_connection_acquisition_error();
-            err
-        })?;
-
-    for statement in plan.pre {
-        execute_statement(&mut connection, &statement).await?;
-    }
-
     let query = plan.query;
     let query_sql = query.explain_query_sql();
 
-    tracing::info!(
-        generated_sql = query_sql.sql,
-        params = ?&query_sql.params,
-        variables = ?&query.variables,
-    );
-
-    let sqlx_query = build_query_with_params(&query_sql, query.variables)
-        .instrument(info_span!("Build query with params"))
-        .await?;
-
-    let rows: Vec<sqlx::postgres::PgRow> = {
-        // run and fetch from the database
-        sqlx_query
-            .fetch_all(connection.as_mut())
-            .instrument(info_span!(
-                "Database request",
-                internal.visibility = "user",
-                db.system = database_info.system_name,
-                db.version_string = database_info.system_version.string,
-                db.version_number = database_info.system_version.number,
-                db.user = database_info.server_username,
-                db.name = database_info.server_database,
-                server.address = database_info.server_host,
-                server.port = database_info.server_port,
-            ))
-            .await?
-    };
-
-    let mut results: Vec<String> = vec![];
-    for row in rows.into_iter() {
-        match row.get(0) {
-            None => {}
-            Some(col) => {
-                results.push(col);
-            }
+    let results = {
+        // When we get a query that provides the variables field but it is empty,
+        // this is an indication that the user wants to see the query plan for this
+        // query that uses variables but without supplying the variables.
+        // One particular such use-case is explaining remote-joins.
+        // In this case, we do not run an EXPLAIN query against postgres -
+        // we just return the generated SQL.
+        if query.variables.is_some() && query.variables.as_ref().unwrap().len() == 0 {
+            tracing::info!(
+                generated_sql = query_sql.sql,
+                params = ?&query_sql.params,
+                variables = ?&query.variables,
+            );
+            Ok("".to_string())
         }
-    }
+        // Otherwise, we proceed as usual.
+        else {
+            let acquisition_timer = metrics.time_connection_acquisition_wait();
+            let connection_result = pool
+                .acquire()
+                .instrument(info_span!("Acquire connection"))
+                .await;
+            let mut connection =
+                acquisition_timer
+                    .complete_with(connection_result)
+                    .map_err(|err| {
+                        metrics.error_metrics.record_connection_acquisition_error();
+                        err
+                    })?;
 
-    for statement in plan.post {
-        execute_statement(&mut connection, &statement).await?
-    }
+            for statement in plan.pre {
+                execute_statement(&mut connection, &statement).await?;
+            }
+
+            tracing::info!(
+                generated_sql = query_sql.sql,
+                params = ?&query_sql.params,
+                variables = ?&query.variables,
+            );
+
+            let sqlx_query = build_query_with_params(&query_sql, query.variables)
+                .instrument(info_span!("Build query with params"))
+                .await?;
+
+            let rows: Vec<sqlx::postgres::PgRow> = {
+                // run and fetch from the database
+                sqlx_query
+                    .fetch_all(connection.as_mut())
+                    .instrument(info_span!(
+                        "Database request",
+                        internal.visibility = "user",
+                        db.system = database_info.system_name,
+                        db.version_string = database_info.system_version.string,
+                        db.version_number = database_info.system_version.number,
+                        db.user = database_info.server_username,
+                        db.name = database_info.server_database,
+                        server.address = database_info.server_host,
+                        server.port = database_info.server_port,
+                    ))
+                    .await?
+            };
+
+            let mut results: Vec<String> = vec![];
+            for row in rows.into_iter() {
+                match row.get(0) {
+                    None => {}
+                    Some(col) => {
+                        results.push(col);
+                    }
+                }
+            }
+
+            for statement in plan.post {
+                execute_statement(&mut connection, &statement).await?
+            }
+            Ok::<String, Error>(results.join("\n"))
+        }
+    }?;
 
     let pretty = sqlformat::format(
         &query_sql.sql,
@@ -114,7 +135,7 @@ pub async fn explain(
         sqlformat::FormatOptions::default(),
     );
 
-    Ok((pretty, results.join("\n")))
+    Ok((pretty, results))
 }
 
 /// Execute the query and return the result as bytes.

--- a/crates/tests/databases-tests/src/postgres/explain_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/explain_tests.rs
@@ -45,4 +45,11 @@ mod explain {
             insta::assert_snapshot!(result.details.query);
         }
     }
+
+    #[tokio::test]
+    async fn select_where_no_variable() {
+        let result = run_explain(create_router().await, "select_where_no_variables").await;
+        assert!(result.details.plan == "");
+        insta::assert_snapshot!(result.details.query);
+    }
 }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__explain__select_where_no_variable.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__explain__select_where_no_variable.snap
@@ -1,0 +1,38 @@
+---
+source: crates/tests/databases-tests/src/postgres/explain_tests.rs
+expression: result.details.query
+---
+EXPLAIN
+SELECT
+  coalesce(json_agg("%5_universe_agg"."universe"), '[]') AS "universe"
+FROM
+  (
+    SELECT
+      row_to_json("%2_universe") AS "universe"
+    FROM
+      json_to_recordset(cast($1 as json)) AS "%0_%variables_table"("%variable_order" int)
+      CROSS JOIN LATERAL (
+        SELECT
+          *
+        FROM
+          (
+            SELECT
+              coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
+            FROM
+              (
+                SELECT
+                  "%1_Album"."Title" AS "Title"
+                FROM
+                  "public"."Album" AS "%1_Album"
+                WHERE
+                  (
+                    "%1_Album"."Title" ~~ cast("%0_%variables_table"."search" as varchar)
+                  )
+                ORDER BY
+                  "%1_Album"."AlbumId" ASC
+              ) AS "%3_rows"
+          ) AS "%3_rows"
+      ) AS "%2_universe"
+    ORDER BY
+      "%0_%variables_table"."%variable_order" ASC
+  ) AS "%5_universe_agg"

--- a/crates/tests/tests-common/goldenfiles/select_where_no_variables.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_no_variables.json
@@ -1,0 +1,43 @@
+{
+  "collection": "Album",
+  "query": {
+    "fields": {
+      "Title": {
+        "type": "column",
+        "column": "Title",
+        "arguments": {}
+      }
+    },
+    "where": {
+      "type": "binary_comparison_operator",
+      "column": {
+        "type": "column",
+        "name": "Title",
+        "path": []
+      },
+      "operator": {
+        "type": "other",
+        "name": "_like"
+      },
+      "value": {
+        "type": "variable",
+        "name": "search"
+      }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "AlbumId",
+            "path": []
+          }
+        }
+      ]
+    }
+  },
+  "arguments": {},
+  "collection_relationships": {},
+  "variables": []
+}


### PR DESCRIPTION
### What

To support use cases such as explaining remote-relationships, we want to be able to view the generated SQL of a query that uses variables but does not provide variables (since those would need to be run first in order to be provided).
In this PR we allow explain requests on queries that provide empty variables (`variables: []`) to receive just the generated SQL, without the postgres explain part.

### How

We check that we receive an empty variables field and if that's the case we will skip querying postgres and just return the generated SQL.

Please read this PR with the `hide whitespace` setting.