### PR TITLE
Support variables of composite type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,7 +2165,6 @@ dependencies = [
 name = "query-engine-sql"
 version = "0.1.0"
 dependencies = [
- "itertools 0.12.0",
  "schemars",
  "serde",
  "serde_json",

--- a/crates/connectors/ndc-postgres/src/explain.rs
+++ b/crates/connectors/ndc-postgres/src/explain.rs
@@ -49,10 +49,6 @@ pub async fn explain<'a>(
                 tracing::error!("{}", err);
                 // log error metric
                 match &err {
-                    query_engine_execution::query::QueryError::ReservedVariableName(_) => {
-                        state.metrics.error_metrics.record_invalid_request();
-                        connector::ExplainError::InvalidRequest(err.to_string())
-                    }
                     query_engine_execution::query::QueryError::VariableNotFound(_) => {
                         state.metrics.error_metrics.record_invalid_request();
                         connector::ExplainError::InvalidRequest(err.to_string())

--- a/crates/connectors/ndc-postgres/src/query.rs
+++ b/crates/connectors/ndc-postgres/src/query.rs
@@ -93,10 +93,6 @@ async fn execute_query(
                 tracing::error!("{}", err);
                 // log error metric
                 match &err {
-                    query_engine_execution::query::QueryError::ReservedVariableName(_) => {
-                        state.metrics.error_metrics.record_invalid_request();
-                        connector::QueryError::InvalidRequest(err.to_string())
-                    }
                     query_engine_execution::query::QueryError::VariableNotFound(_) => {
                         state.metrics.error_metrics.record_invalid_request();
                         connector::QueryError::InvalidRequest(err.to_string())

--- a/crates/query-engine/execution/src/query.rs
+++ b/crates/query-engine/execution/src/query.rs
@@ -248,8 +248,8 @@ fn variables_to_json(
 
                 let variables_field = serde_json::Value::Object(
                     varset
-                        .clone()
-                        .into_iter()
+                        .iter()
+                        .cloned()
                         .collect::<serde_json::Map<String, serde_json::Value>>(),
                 );
                 row.insert(sql::helpers::VARIABLES_FIELD.to_string(), variables_field);

--- a/crates/query-engine/execution/src/query.rs
+++ b/crates/query-engine/execution/src/query.rs
@@ -248,8 +248,8 @@ fn variables_to_json(
 
                 let variables_field = serde_json::Value::Object(
                     varset
-                        .iter()
-                        .cloned()
+                        .clone()
+                        .into_iter()
                         .collect::<serde_json::Map<String, serde_json::Value>>(),
                 );
                 row.insert(sql::helpers::VARIABLES_FIELD.to_string(), variables_field);

--- a/crates/query-engine/sql/Cargo.toml
+++ b/crates/query-engine/sql/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-itertools = "^0.12.0"
 schemars = { version = "0.8.16", features = ["smol_str", "preserve_order"] }
 serde = "1.0.195"
 serde_json = "1.0.109"

--- a/crates/query-engine/sql/src/sql/ast.rs
+++ b/crates/query-engine/sql/src/sql/ast.rs
@@ -86,8 +86,8 @@ pub enum From {
         alias: TableAlias,
     },
     /// Convert a json array of objects to a relation.
-    /// Should probably be of the form `json_to_recordset(cast($1 as json))`
-    JsonToRecordset {
+    /// Should probably be of the form `jsonb_to_recordset(cast($1 as json))`
+    JsonbToRecordset {
         expression: Expression,
         alias: TableAlias,
         columns: Vec<(ColumnAlias, ScalarType)>,

--- a/crates/query-engine/sql/src/sql/convert.rs
+++ b/crates/query-engine/sql/src/sql/convert.rs
@@ -166,12 +166,12 @@ impl From {
                 sql.append_syntax(" AS ");
                 alias.to_sql(sql);
             }
-            From::JsonToRecordset {
+            From::JsonbToRecordset {
                 expression,
                 alias,
                 columns,
             } => {
-                sql.append_syntax("json_to_recordset");
+                sql.append_syntax("jsonb_to_recordset");
                 sql.append_syntax("(");
                 expression.to_sql(sql);
                 sql.append_syntax(")");

--- a/crates/query-engine/sql/src/sql/helpers.rs
+++ b/crates/query-engine/sql/src/sql/helpers.rs
@@ -558,7 +558,7 @@ pub fn select_row_as_json_with_default(
 /// ```sql
 /// FROM
 ///   json_to_recordset(cast('[{"%variable_order": 1, "%variables": {"search": "%Good%", ...}}]' as json))
-///     AS "%0_variables"("%variables" json, "%variable_order" int)
+///     AS "%0_variables"("%variable_order" int, "%variables" jsonb)
 /// ```
 pub fn from_variables(alias: TableAlias) -> From {
     let expression = Expression::Value(Value::Variable(VARIABLES_OBJECT_PLACEHOLDER.to_string()));

--- a/crates/query-engine/sql/src/sql/helpers.rs
+++ b/crates/query-engine/sql/src/sql/helpers.rs
@@ -1,6 +1,5 @@
 //! Helpers for building sql::ast types in certain shapes and patterns.
 
-use itertools::Itertools;
 use std::collections::BTreeMap;
 
 use super::ast::*;
@@ -558,40 +557,23 @@ pub fn select_row_as_json_with_default(
 ///
 /// ```sql
 /// FROM
-///   json_to_recordset(cast('[{"%variable_order": 1, "search": "%Good%"}]' as json))
-///     AS "%0_variables"("search" varchar, "%variable_order" int)
+///   json_to_recordset(cast('[{"%variable_order": 1, "%variables": {"search": "%Good%", ...}}]' as json))
+///     AS "%0_variables"("%variables" json, "%variable_order" int)
 /// ```
-pub fn from_variables(
-    alias: TableAlias,
-    variables: &[BTreeMap<String, serde_json::Value>],
-) -> From {
-    let expression = Expression::Cast {
-        expression: Box::new(Expression::Value(Value::Variable(
-            VARIABLES_OBJECT_PLACEHOLDER.to_string(),
-        ))),
-        r#type: ScalarType("json".to_string()),
-    };
-    // we want to include all possible keys in our columns schema and give them all the type varchar.
-    // they will be cast to the expected type later.
-    let mut columns: Vec<(ColumnAlias, ScalarType)> = variables
-        .iter()
-        .flat_map(|variable_map| variable_map.keys().collect::<Vec<&String>>())
-        .unique()
-        .map(|col| {
-            (
-                make_column_alias(col.to_string()),
-                ScalarType("varchar".to_string()),
-            )
-        })
-        .collect();
+pub fn from_variables(alias: TableAlias) -> From {
+    let expression = Expression::Value(Value::Variable(VARIABLES_OBJECT_PLACEHOLDER.to_string()));
+    let columns: Vec<(ColumnAlias, ScalarType)> = vec![
+        (
+            make_column_alias(VARIABLE_ORDER_FIELD.to_string()),
+            ScalarType("int".to_string()),
+        ),
+        (
+            make_column_alias(VARIABLES_FIELD.to_string()),
+            ScalarType("jsonb".to_string()),
+        ),
+    ];
 
-    // we add a column that can be used for ordering our results set
-    columns.push((
-        make_column_alias(VARIABLE_ORDER_FIELD.to_string()),
-        ScalarType("int".to_string()),
-    ));
-
-    From::JsonToRecordset {
+    From::JsonbToRecordset {
         expression,
         alias,
         columns,
@@ -618,6 +600,9 @@ pub const VARIABLES_OBJECT_PLACEHOLDER: &str = "%VARIABLES_OBJECT_PLACEHOLDER";
 
 /// SQL field name to be used for ordering results with multiple variable sets.
 pub const VARIABLE_ORDER_FIELD: &str = "%variable_order";
+
+/// SQL field name to be used for keeping the values of variable sets.
+pub const VARIABLES_FIELD: &str = "%variables";
 
 pub fn begin(
     isolation_level: &transaction::IsolationLevel,

--- a/crates/query-engine/translation/src/translation/helpers.rs
+++ b/crates/query-engine/translation/src/translation/helpers.rs
@@ -238,13 +238,13 @@ impl State {
     ) -> Option<(sql::ast::From, sql::ast::TableReference)> {
         match variables {
             None => None,
-            Some(variables) => {
+            Some(_variables) => {
                 let variables_table_alias = self.make_table_alias("%variables_table".to_string());
                 let table_reference =
                     sql::ast::TableReference::AliasedTable(variables_table_alias.clone());
                 self.variables_table = Some(table_reference.clone());
                 Some((
-                    sql::helpers::from_variables(variables_table_alias, variables),
+                    sql::helpers::from_variables(variables_table_alias),
                     table_reference,
                 ))
             }

--- a/crates/query-engine/translation/tests/goldenfiles/select_composite_variable/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/select_composite_variable/request.json
@@ -1,0 +1,45 @@
+{
+  "collection": "make_person",
+  "query": {
+    "fields": {
+      "result": {
+        "type": "column",
+        "column": "result",
+        "arguments": {}
+      }
+    }
+  },
+  "arguments": {
+    "name": {
+      "type": "variable",
+      "name": "variable_name"
+    },
+    "address": {
+      "type": "variable",
+      "name": "variable_address"
+    }
+  },
+  "collection_relationships": {},
+  "variables": [
+    {
+      "variable_name": {
+        "first_name": "John",
+        "last_name": "Doe"
+      },
+      "variable_address": {
+        "address_line_1": "Somstreet 159",
+        "address_line_2": "Second door to the right"
+      }
+    },
+    {
+      "variable_name": {
+        "first_name": "Jane",
+        "last_name": "Doe"
+      },
+      "variable_address": {
+        "address_line_1": "Somstreet 159",
+        "address_line_2": "Second door to the right"
+      }
+    }
+  ]
+}

--- a/crates/query-engine/translation/tests/goldenfiles/select_composite_variable/tables.json
+++ b/crates/query-engine/translation/tests/goldenfiles/select_composite_variable/tables.json
@@ -1,0 +1,87 @@
+{
+  "compositeTypes": {
+    "person": {
+      "name": "person",
+      "fields": {
+        "name": {
+          "name": "name",
+          "type": {
+            "compositeType": "person_name"
+          }
+        },
+        "address": {
+          "name": "address",
+          "type": {
+            "compositeType": "person_address"
+          }
+        }
+      }
+    },
+    "person_name": {
+      "name": "person_name",
+      "fields": {
+        "first_name": {
+          "name": "first_name",
+          "type": {
+            "scalarType": "text"
+          }
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": {
+            "scalarType": "text"
+          }
+        }
+      }
+    },
+    "person_address": {
+      "name": "person_address",
+      "fields": {
+        "address_line_1": {
+          "name": "address_line_1",
+          "type": {
+            "scalarType": "text"
+          }
+        },
+        "address_line_2": {
+          "name": "address_line_2",
+          "type": {
+            "scalarType": "text"
+          }
+        }
+      }
+    }
+  },
+  "nativeQueries": {
+    "make_person": {
+      "sql": "SELECT ROW({{name}}, {{address}})::person as result",
+      "columns": {
+        "result": {
+          "name": "result",
+          "type": {
+            "compositeType": "person"
+          },
+          "nullable": "nullable",
+          "description": null
+        }
+      },
+      "arguments": {
+        "name": {
+          "name": "name",
+          "type": {
+            "compositeType": "person_name"
+          },
+          "nullable": "nullable"
+        },
+        "address": {
+          "name": "address",
+          "type": {
+            "compositeType": "person_address"
+          },
+          "nullable": "nullable"
+        }
+      },
+      "description": "A native query used to test support for composite types"
+    }
+  }
+}

--- a/crates/query-engine/translation/tests/snapshots/tests__select_composite_column.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_composite_column.snap
@@ -5,8 +5,8 @@ expression: result
 WITH "%1_NATIVE_QUERY_make_person" AS (
   SELECT
     ROW(
-      jsonb_populate_record(cast(null as person_name), cast($1 as jsonb)),
-      jsonb_populate_record(cast(null as person_address), cast($2 as jsonb))
+      jsonb_populate_record(cast(null as person_name), $1),
+      jsonb_populate_record(cast(null as person_address), $2)
     ) :: person as result
 )
 SELECT

--- a/crates/query-engine/translation/tests/snapshots/tests__select_composite_variable.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_composite_variable.snap
@@ -1,0 +1,46 @@
+---
+source: crates/query-engine/translation/tests/tests.rs
+expression: result
+---
+SELECT
+  coalesce(json_agg("%6_universe_agg"."universe"), '[]') AS "universe"
+FROM
+  (
+    SELECT
+      row_to_json("%3_universe") AS "universe"
+    FROM
+      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" int, "%variables" jsonb)
+      CROSS JOIN LATERAL (
+        WITH "%2_NATIVE_QUERY_make_person" AS (
+          SELECT
+            ROW(
+              jsonb_populate_record(
+                cast(null as person_name),
+                ("%0_%variables_table"."%variables" -> $2)
+              ),
+              jsonb_populate_record(
+                cast(null as person_address),
+                ("%0_%variables_table"."%variables" -> $3)
+              )
+            ) :: person as result
+        )
+        SELECT
+          *
+        FROM
+          (
+            SELECT
+              coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
+            FROM
+              (
+                SELECT
+                  "%1_make_person"."result" AS "result"
+                FROM
+                  "%2_NATIVE_QUERY_make_person" AS "%1_make_person"
+              ) AS "%4_rows"
+          ) AS "%4_rows"
+      ) AS "%3_universe"
+    ORDER BY
+      "%0_%variables_table"."%variable_order" ASC
+  ) AS "%6_universe_agg"
+
+[(1, Variable("%VARIABLES_OBJECT_PLACEHOLDER")), (2, String("variable_name")), (3, String("variable_address"))]

--- a/crates/query-engine/translation/tests/tests.rs
+++ b/crates/query-engine/translation/tests/tests.rs
@@ -19,6 +19,12 @@ fn select_composite_column() {
 }
 
 #[test]
+fn select_composite_variable() {
+    let result = common::test_translation("select_composite_variable").unwrap();
+    insta::assert_snapshot!(result);
+}
+
+#[test]
 fn select_array_column_reverse() {
     let result = common::test_translation("select_array_column_reverse").unwrap();
     insta::assert_snapshot!(result);

--- a/crates/tests/databases-tests/src/citus/query_tests.rs
+++ b/crates/tests/databases-tests/src/citus/query_tests.rs
@@ -44,6 +44,12 @@ mod basic {
         let result = run_query(create_router().await, "select_composite_column").await;
         insta::assert_json_snapshot!(result);
     }
+
+    #[tokio::test]
+    async fn select_composite_variable() {
+        let result = run_query(create_router().await, "select_composite_variable").await;
+        insta::assert_json_snapshot!(result);
+    }
 }
 
 #[cfg(test)]

--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__explain_tests__explain__select_where_variable.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__explain_tests__explain__select_where_variable.snap
@@ -10,7 +10,7 @@ FROM
     SELECT
       row_to_json("%2_universe") AS "universe"
     FROM
-      json_to_recordset(cast($1 as json)) AS "%0_%variables_table"("search" varchar, "%variable_order" int)
+      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" int, "%variables" jsonb)
       CROSS JOIN LATERAL (
         SELECT
           *
@@ -26,7 +26,9 @@ FROM
                   "public"."Album" AS "%1_Album"
                 WHERE
                   (
-                    "%1_Album"."Title" ~~ cast("%0_%variables_table"."search" as varchar)
+                    "%1_Album"."Title" ~~ cast(
+                      ("%0_%variables_table"."%variables" ->> $2) as varchar
+                    )
                   )
                 ORDER BY
                   "%1_Album"."AlbumId" ASC

--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__query_tests__basic__select_composite_variable.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__query_tests__basic__select_composite_variable.snap
@@ -1,0 +1,38 @@
+---
+source: crates/tests/databases-tests/src/citus/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": [
+      {
+        "result": {
+          "name": {
+            "first_name": "John",
+            "last_name": "Doe"
+          },
+          "address": {
+            "address_line_1": "Somstreet 159",
+            "address_line_2": "Second door to the right"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "rows": [
+      {
+        "result": {
+          "name": {
+            "first_name": "Jane",
+            "last_name": "Doe"
+          },
+          "address": {
+            "address_line_1": "Somstreet 159",
+            "address_line_2": "Second door to the right"
+          }
+        }
+      }
+    ]
+  }
+]

--- a/crates/tests/databases-tests/src/cockroach/query_tests.rs
+++ b/crates/tests/databases-tests/src/cockroach/query_tests.rs
@@ -46,6 +46,7 @@ mod basic {
         insta::assert_json_snapshot!(result);
     }
 
+    #[ignore = "Cockroach v23.1.10 does not support nested user defined types which this test uses."]
     #[tokio::test]
     async fn select_composite_variable() {
         let result = run_query(create_router().await, "select_composite_variable").await;

--- a/crates/tests/databases-tests/src/cockroach/query_tests.rs
+++ b/crates/tests/databases-tests/src/cockroach/query_tests.rs
@@ -45,6 +45,12 @@ mod basic {
         let result = run_query(create_router().await, "native_queries/embedded_variable").await;
         insta::assert_json_snapshot!(result);
     }
+
+    #[tokio::test]
+    async fn select_composite_variable() {
+        let result = run_query(create_router().await, "select_composite_variable").await;
+        insta::assert_json_snapshot!(result);
+    }
 }
 
 #[cfg(test)]

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__explain_tests__explain__select_where_variable.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__explain_tests__explain__select_where_variable.snap
@@ -10,7 +10,7 @@ FROM
     SELECT
       row_to_json("%2_universe") AS "universe"
     FROM
-      json_to_recordset(cast($1 as json)) AS "%0_%variables_table"("search" varchar, "%variable_order" int)
+      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" int, "%variables" jsonb)
       CROSS JOIN LATERAL (
         SELECT
           *
@@ -26,7 +26,9 @@ FROM
                   "public"."Album" AS "%1_Album"
                 WHERE
                   (
-                    "%1_Album"."Title" LIKE cast("%0_%variables_table"."search" as varchar)
+                    "%1_Album"."Title" LIKE cast(
+                      ("%0_%variables_table"."%variables" ->> $2) as varchar
+                    )
                   )
                 ORDER BY
                   "%1_Album"."AlbumId" ASC

--- a/crates/tests/databases-tests/src/postgres/query_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/query_tests.rs
@@ -44,6 +44,12 @@ mod basic {
         let result = run_query(create_router().await, "select_composite_column").await;
         insta::assert_json_snapshot!(result);
     }
+
+    #[tokio::test]
+    async fn select_composite_variable() {
+        let result = run_query(create_router().await, "select_composite_variable").await;
+        insta::assert_json_snapshot!(result);
+    }
 }
 
 #[cfg(test)]

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__explain__native_queries__embedded_variable.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__explain__native_queries__embedded_variable.snap
@@ -10,7 +10,7 @@ FROM
     SELECT
       row_to_json("%3_universe") AS "universe"
     FROM
-      json_to_recordset(cast($1 as json)) AS "%0_%variables_table"("search" varchar, "%variable_order" int)
+      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" int, "%variables" jsonb)
       CROSS JOIN LATERAL (
         WITH "%2_NATIVE_QUERY_album_by_title" AS (
           SELECT
@@ -18,7 +18,9 @@ FROM
           FROM
             public."Album"
           WHERE
-            "Title" LIKE cast("%0_%variables_table"."search" as varchar)
+            "Title" LIKE cast(
+              ("%0_%variables_table"."%variables" ->> $2) as varchar
+            )
             AND "AlbumId" < 500
         )
         SELECT

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__explain__select_where_no_variable.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__explain__select_where_no_variable.snap
@@ -10,7 +10,7 @@ FROM
     SELECT
       row_to_json("%2_universe") AS "universe"
     FROM
-      json_to_recordset(cast($1 as json)) AS "%0_%variables_table"("%variable_order" int)
+      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" int, "%variables" jsonb)
       CROSS JOIN LATERAL (
         SELECT
           *
@@ -26,7 +26,9 @@ FROM
                   "public"."Album" AS "%1_Album"
                 WHERE
                   (
-                    "%1_Album"."Title" ~~ cast("%0_%variables_table"."search" as varchar)
+                    "%1_Album"."Title" ~~ cast(
+                      ("%0_%variables_table"."%variables" ->> $2) as varchar
+                    )
                   )
                 ORDER BY
                   "%1_Album"."AlbumId" ASC

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__explain__select_where_variable.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__explain__select_where_variable.snap
@@ -10,7 +10,7 @@ FROM
     SELECT
       row_to_json("%2_universe") AS "universe"
     FROM
-      json_to_recordset(cast($1 as json)) AS "%0_%variables_table"("search" varchar, "%variable_order" int)
+      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" int, "%variables" jsonb)
       CROSS JOIN LATERAL (
         SELECT
           *
@@ -26,7 +26,9 @@ FROM
                   "public"."Album" AS "%1_Album"
                 WHERE
                   (
-                    "%1_Album"."Title" ~~ cast("%0_%variables_table"."search" as varchar)
+                    "%1_Album"."Title" ~~ cast(
+                      ("%0_%variables_table"."%variables" ->> $2) as varchar
+                    )
                   )
                 ORDER BY
                   "%1_Album"."AlbumId" ASC

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__basic__select_composite_variable.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__basic__select_composite_variable.snap
@@ -1,0 +1,38 @@
+---
+source: crates/tests/databases-tests/src/postgres/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": [
+      {
+        "result": {
+          "name": {
+            "first_name": "John",
+            "last_name": "Doe"
+          },
+          "address": {
+            "address_line_1": "Somstreet 159",
+            "address_line_2": "Second door to the right"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "rows": [
+      {
+        "result": {
+          "name": {
+            "first_name": "Jane",
+            "last_name": "Doe"
+          },
+          "address": {
+            "address_line_1": "Somstreet 159",
+            "address_line_2": "Second door to the right"
+          }
+        }
+      }
+    ]
+  }
+]

--- a/crates/tests/databases-tests/src/yugabyte/query_tests.rs
+++ b/crates/tests/databases-tests/src/yugabyte/query_tests.rs
@@ -38,6 +38,12 @@ mod basic {
         let result = run_query(create_router().await, "select_composite_column").await;
         insta::assert_json_snapshot!(result);
     }
+
+    #[tokio::test]
+    async fn select_composite_variable() {
+        let result = run_query(create_router().await, "select_composite_variable").await;
+        insta::assert_json_snapshot!(result);
+    }
 }
 
 #[cfg(test)]

--- a/crates/tests/databases-tests/src/yugabyte/snapshots/databases_tests__yugabyte__query_tests__basic__select_composite_variable.snap
+++ b/crates/tests/databases-tests/src/yugabyte/snapshots/databases_tests__yugabyte__query_tests__basic__select_composite_variable.snap
@@ -1,0 +1,38 @@
+---
+source: crates/tests/databases-tests/src/yugabyte/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": [
+      {
+        "result": {
+          "name": {
+            "first_name": "John",
+            "last_name": "Doe"
+          },
+          "address": {
+            "address_line_1": "Somstreet 159",
+            "address_line_2": "Second door to the right"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "rows": [
+      {
+        "result": {
+          "name": {
+            "first_name": "Jane",
+            "last_name": "Doe"
+          },
+          "address": {
+            "address_line_1": "Somstreet 159",
+            "address_line_2": "Second door to the right"
+          }
+        }
+      }
+    ]
+  }
+]

--- a/crates/tests/tests-common/goldenfiles/select_composite_variable.json
+++ b/crates/tests/tests-common/goldenfiles/select_composite_variable.json
@@ -1,0 +1,45 @@
+{
+  "collection": "make_person",
+  "query": {
+    "fields": {
+      "result": {
+        "type": "column",
+        "column": "result",
+        "arguments": {}
+      }
+    }
+  },
+  "arguments": {
+    "name": {
+      "type": "variable",
+      "name": "variable_name"
+    },
+    "address": {
+      "type": "variable",
+      "name": "variable_address"
+    }
+  },
+  "collection_relationships": {},
+  "variables": [
+    {
+      "variable_name": {
+        "first_name": "John",
+        "last_name": "Doe"
+      },
+      "variable_address": {
+        "address_line_1": "Somstreet 159",
+        "address_line_2": "Second door to the right"
+      }
+    },
+    {
+      "variable_name": {
+        "first_name": "Jane",
+        "last_name": "Doe"
+      },
+      "variable_address": {
+        "address_line_1": "Somstreet 159",
+        "address_line_2": "Second door to the right"
+      }
+    }
+  ]
+}

--- a/crates/tests/tests-common/src/request.rs
+++ b/crates/tests/tests-common/src/request.rs
@@ -76,14 +76,14 @@ async fn run_against_server<Response: for<'a> serde::Deserialize<'a>>(
     expected_status: StatusCode,
 ) -> Response {
     let path = format!("/{}", action);
-    let body = match fs::read_to_string(format!(
+    let goldenfile_path = format!(
         "../../../crates/tests/tests-common/goldenfiles/{}.json",
         testname
-    )) {
+    );
+    let body = match fs::read_to_string(&goldenfile_path) {
         Ok(body) => body,
         Err(err) => {
-            println!("Error: {}", err);
-            panic!("error look up");
+            panic!("Error reading {} : {}", &goldenfile_path, err);
         }
     };
     make_request(


### PR DESCRIPTION
### What

This PR changes how the `variables` field of a request is translated, such that variables of composite types are now supported.

Array types require a some treatment of their own, which will be dealt with in a follow-up PR.

### How

Prior to this PR, incoming variables (bound to `$1` in this example) were translated in the style of:

```
  ... FROM json_to_recordset($1) as "%variables_table"("%variable_order" int, "variable1" varchar, "variable2" varchar, "variable3" varchar, ...)
```

All the variables used in the request (`variable1`, `variable2`, etc) all become columns of `%variables_table`, and all of type `varchar`.

Usage sites would rely on casts to interpret the variables as the relevant scalar type:

```
 cast("%variables_table"."variable1" as int4)
```

On this approach we can observe a few things:

* We can only support plain scalar types, since we cannot canonically represent an array or object as a string through `json_to_recordset`.
* "%variable_order" is a reserved name that can conflict with user variable names.
* We don't need to do any bookkeeping of what type a variable has. Usage context takes care of this to the extent that queries without type errors execute correctly.

In order to support composite (and array) types, we change the translation scheme:

```
  ... FROM json_to_recordset($1) as "%variables_table"("%variable_order" int, "%variables" jsonb)
```

All the variables used in the request (`variable1`, `variable2`, etc) all become fields of the "%variables" column, which remains yet a json value.

Usage sites still rely on casts to interpret the variables as the relevant scalar type, but now have to rely on the `->>` operator to project a variable from the `%variables` object as a plain `text` scalar:

```
 cast("%variables_table"."%variables" ->> "variable1" as int4)
```

In the case of composite types we use the function `jsonb_populate_record` to construct the composite value from the json-valued variable-field, and the operator `->` to extract the field value as `jsonb` (c.f. `->>` for `text`)

```
jsonb_populate_record(null::person, "%variables_table"."%variables" -> "variable2")
```

On this updated approach we can observe a few things:

* We can support both scalars, arrays, and composite types.
* "%variable_order" is no longer a reserved name.
* We still don't need to do any bookkeeping of what type a variable has.
* `jsonb_populate_record` does all the heavy lifting, which means that we don't need to generate more than a single call to this function to handle any level of nested types.