### PR TITLE
Derive `Copy` for `IsolationLevel` so we don't have to clone it.

### DIFF
--- a/crates/connectors/ndc-postgres/src/configuration.rs
+++ b/crates/connectors/ndc-postgres/src/configuration.rs
@@ -103,7 +103,7 @@ pub fn as_runtime_configuration(config: &Configuration) -> RuntimeConfiguration 
             connection_uri: match &v2_config.connection_uri {
                 ConnectionUri::Uri(ResolvedSecret(uri)) => uri.clone(),
             },
-            isolation_level: v2_config.isolation_level.clone(),
+            isolation_level: v2_config.isolation_level,
             mutations_version: v2_config.configure_options.mutations_version.clone(),
         },
     }

--- a/crates/connectors/ndc-postgres/src/explain.rs
+++ b/crates/connectors/ndc-postgres/src/explain.rs
@@ -96,7 +96,7 @@ fn plan_query(
     let timer = state.metrics.time_query_plan();
     let result = translation::query::translate(
         &configuration.metadata,
-        &configuration.isolation_level,
+        configuration.isolation_level,
         query_request,
     )
     .map_err(|err| {

--- a/crates/connectors/ndc-postgres/src/mutation.rs
+++ b/crates/connectors/ndc-postgres/src/mutation.rs
@@ -90,7 +90,7 @@ fn plan_mutation(
         })
         .collect::<Result<Vec<_>, connector::MutationError>>()?;
     timer.complete_with(Ok(sql::execution_plan::simple_mutations_execution_plan(
-        &configuration.isolation_level,
+        configuration.isolation_level,
         mutations,
     )))
 }

--- a/crates/connectors/ndc-postgres/src/query.rs
+++ b/crates/connectors/ndc-postgres/src/query.rs
@@ -57,7 +57,7 @@ fn plan_query(
     let timer = state.metrics.time_query_plan();
     let result = translation::query::translate(
         &configuration.metadata,
-        &configuration.isolation_level,
+        configuration.isolation_level,
         query_request,
     )
     .map_err(|err| {

--- a/crates/query-engine/sql/src/sql/ast.rs
+++ b/crates/query-engine/sql/src/sql/ast.rs
@@ -346,7 +346,9 @@ pub mod transaction {
     /// Rollback a transaction
     pub struct Rollback {}
 
-    #[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+    #[derive(
+        Debug, Clone, Copy, Default, serde::Deserialize, serde::Serialize, schemars::JsonSchema,
+    )]
     /// The isolation level of transactions
     pub enum IsolationLevel {
         #[default]

--- a/crates/query-engine/sql/src/sql/execution_plan.rs
+++ b/crates/query-engine/sql/src/sql/execution_plan.rs
@@ -50,7 +50,7 @@ pub fn explain_to_sql(explain: &sql::ast::Explain) -> sql::string::SQL {
 
 /// A simple query execution plan with only a root field and a query.
 pub fn simple_query_execution_plan(
-    isolation_level: &sql::ast::transaction::IsolationLevel,
+    isolation_level: sql::ast::transaction::IsolationLevel,
     variables: Option<Vec<BTreeMap<String, serde_json::Value>>>,
     root_field: String,
     query: sql::ast::Select,
@@ -94,7 +94,7 @@ impl Mutation {
 
 /// A simple mutation execution plan with only a root field and a query.
 pub fn simple_mutations_execution_plan(
-    isolation_level: &sql::ast::transaction::IsolationLevel,
+    isolation_level: sql::ast::transaction::IsolationLevel,
     mutations: Vec<Mutation>,
 ) -> ExecutionPlan<Mutations> {
     ExecutionPlan {

--- a/crates/query-engine/sql/src/sql/helpers.rs
+++ b/crates/query-engine/sql/src/sql/helpers.rs
@@ -620,13 +620,13 @@ pub const VARIABLES_OBJECT_PLACEHOLDER: &str = "%VARIABLES_OBJECT_PLACEHOLDER";
 pub const VARIABLE_ORDER_FIELD: &str = "%variable_order";
 
 pub fn begin(
-    isolation_level: &transaction::IsolationLevel,
+    isolation_level: transaction::IsolationLevel,
     transaction_mode: transaction::TransactionMode,
 ) -> Vec<string::Statement> {
     vec![{
         let mut sql = string::SQL::new();
         transaction::Begin {
-            isolation_level: isolation_level.clone(),
+            isolation_level,
             transaction_mode,
         }
         .to_sql(&mut sql);

--- a/crates/query-engine/translation/src/translation/query/mod.rs
+++ b/crates/query-engine/translation/src/translation/query/mod.rs
@@ -18,7 +18,7 @@ use query_engine_sql::sql;
 /// Translate the incoming QueryRequest to an ExecutionPlan (SQL) to be run against the database.
 pub fn translate(
     metadata: &metadata::Metadata,
-    isolation_level: &sql::ast::transaction::IsolationLevel,
+    isolation_level: sql::ast::transaction::IsolationLevel,
     query_request: models::QueryRequest,
 ) -> Result<sql::execution_plan::ExecutionPlan<sql::execution_plan::Query>, Error> {
     let env = Env::new(metadata, query_request.collection_relationships, &None);

--- a/crates/query-engine/translation/tests/common/mod.rs
+++ b/crates/query-engine/translation/tests/common/mod.rs
@@ -4,12 +4,12 @@ use query_engine_sql::sql;
 use query_engine_translation::translation;
 
 pub fn test_translation(testname: &str) -> Result<String, translation::error::Error> {
-    test_query_translation(&None, testname)
+    test_query_translation(None, testname)
 }
 
 /// Translate a query to SQL and compare against the snapshot.
 pub fn test_query_translation(
-    isolation_level: &Option<sql::ast::transaction::IsolationLevel>,
+    isolation_level: Option<sql::ast::transaction::IsolationLevel>,
     testname: &str,
 ) -> Result<String, translation::error::Error> {
     let tables = serde_json::from_str(
@@ -25,13 +25,8 @@ pub fn test_query_translation(
     )
     .unwrap();
 
-    let plan = translation::query::translate(
-        &tables,
-        &isolation_level
-            .clone()
-            .unwrap_or(sql::ast::transaction::IsolationLevel::default()),
-        request,
-    )?;
+    let plan =
+        translation::query::translate(&tables, isolation_level.unwrap_or_default(), request)?;
 
     let mut sqls: Vec<String> = vec![];
 
@@ -78,7 +73,7 @@ pub fn test_query_translation(
 
 /// Translate a mutation to SQL and compare against the snapshot.
 pub fn test_mutation_translation(
-    isolation_level: &Option<sql::ast::transaction::IsolationLevel>,
+    isolation_level: Option<sql::ast::transaction::IsolationLevel>,
     testname: &str,
 ) -> Result<String, translation::error::Error> {
     let tables = serde_json::from_str(
@@ -114,9 +109,7 @@ pub fn test_mutation_translation(
         .collect::<Result<Vec<_>, translation::error::Error>>()?;
 
     let plan = sql::execution_plan::simple_mutations_execution_plan(
-        &isolation_level
-            .clone()
-            .unwrap_or(sql::ast::transaction::IsolationLevel::default()),
+        isolation_level.unwrap_or_default(),
         mutations,
     );
     let mut sqls: Vec<String> = vec![];

--- a/crates/query-engine/translation/tests/tests.rs
+++ b/crates/query-engine/translation/tests/tests.rs
@@ -254,7 +254,7 @@ mod mutations {
 
     #[test]
     fn simple() {
-        let result = common::test_mutation_translation(&None, "simple").unwrap();
+        let result = common::test_mutation_translation(None, "simple").unwrap();
         insta::assert_snapshot!(result);
     }
 }
@@ -265,7 +265,7 @@ mod transaction {
     #[test]
     fn select_with_limit() {
         let result = common::test_query_translation(
-            &Some(query_engine_sql::sql::ast::transaction::IsolationLevel::Serializable),
+            Some(query_engine_sql::sql::ast::transaction::IsolationLevel::Serializable),
             "select_with_limit",
         )
         .unwrap();


### PR DESCRIPTION
### What

Just making the code more Rust-y.

It's a little thing but it got in my way earlier.

### How

By adding `Copy` to `IsolationLevel`, we can freely pass it around by value, not by reference.