### PR TITLE
Move variables_table to Env

### DIFF
--- a/crates/query-engine/translation/src/translation/mutation/translate.rs
+++ b/crates/query-engine/translation/src/translation/mutation/translate.rs
@@ -19,7 +19,7 @@ pub fn translate(
     collection_relationships: BTreeMap<String, models::Relationship>,
     mutations_version: &Option<metadata::mutations::MutationsVersion>,
 ) -> Result<sql::execution_plan::Mutation, Error> {
-    let env = Env::new(metadata, collection_relationships, mutations_version);
+    let env = Env::new(metadata, collection_relationships, mutations_version, None);
 
     match operation {
         models::MutationOperation::Procedure {
@@ -237,7 +237,7 @@ fn translate_native_query(
 
     // add the procedure native query definition is a with clause.
     select.with = sql::ast::With {
-        common_table_expressions: crate::translation::query::native_queries::translate(state)?,
+        common_table_expressions: crate::translation::query::native_queries::translate(env, state)?,
     };
 
     // normalize ast

--- a/crates/query-engine/translation/src/translation/query/filtering.rs
+++ b/crates/query-engine/translation/src/translation/query/filtering.rs
@@ -380,7 +380,7 @@ fn translate_comparison_value(
         )),
         models::ComparisonValue::Variable { name: var } => Ok((
             values::translate_variable(
-                state.get_variables_table()?,
+                env.get_variables_table()?,
                 var.clone(),
                 &database::Type::ScalarType(typ.clone()),
             ),

--- a/crates/query-engine/translation/src/translation/query/native_queries.rs
+++ b/crates/query-engine/translation/src/translation/query/native_queries.rs
@@ -4,14 +4,14 @@ use ndc_sdk::models;
 
 use super::values;
 use crate::translation::error::Error;
-use crate::translation::helpers::State;
+use crate::translation::helpers::{Env, State};
 use query_engine_metadata::metadata;
 use query_engine_sql::sql;
 
 /// Translate native queries collected in State by the translation proccess into CTEs.
-pub fn translate(state: State) -> Result<Vec<sql::ast::CommonTableExpression>, Error> {
+pub fn translate(env: &Env, state: State) -> Result<Vec<sql::ast::CommonTableExpression>, Error> {
     let mut ctes = vec![];
-    let variables_table = state.get_variables_table();
+    let variables_table = env.get_variables_table();
     let native_queries = state.get_native_queries();
 
     // for each found table expression


### PR DESCRIPTION
### What

Since the table reference that binds the variables table cannot change in the course of query translation we move this to `Env` instead of `State`.