### PR TITLE
Support variables of array type

### DIFF
--- a/crates/query-engine/sql/src/sql/ast.rs
+++ b/crates/query-engine/sql/src/sql/ast.rs
@@ -103,6 +103,11 @@ pub enum From {
         alias: TableAlias,
         columns: Vec<(ColumnAlias, ScalarType)>,
     },
+    JsonbArrayElements {
+        expression: Expression,
+        alias: TableAlias,
+        column: ColumnAlias,
+    },
 }
 
 /// A JOIN clause
@@ -234,6 +239,7 @@ pub enum Expression {
     /// A COUNT clause
     Count(CountType),
     ArrayConstructor(Vec<Expression>),
+    CorrelatedSubSelect(Box<Select>),
 }
 
 /// An unary operator

--- a/crates/query-engine/sql/src/sql/convert.rs
+++ b/crates/query-engine/sql/src/sql/convert.rs
@@ -222,6 +222,21 @@ impl From {
                 }
                 sql.append_syntax(")");
             }
+            From::JsonbArrayElements {
+                expression,
+                alias,
+                column,
+            } => {
+                sql.append_syntax("jsonb_array_elements");
+                sql.append_syntax("(");
+                expression.to_sql(sql);
+                sql.append_syntax(")");
+                sql.append_syntax(" AS ");
+                alias.to_sql(sql);
+                sql.append_syntax("(");
+                column.to_sql(sql);
+                sql.append_syntax(")");
+            }
         }
     }
 }
@@ -406,6 +421,11 @@ impl Expression {
                     }
                 }
                 sql.append_syntax("]");
+            }
+            Expression::CorrelatedSubSelect(select) => {
+                sql.append_syntax("(");
+                select.to_sql(sql);
+                sql.append_syntax(")");
             }
         }
     }

--- a/crates/query-engine/translation/src/translation/query/filtering.rs
+++ b/crates/query-engine/translation/src/translation/query/filtering.rs
@@ -380,6 +380,7 @@ fn translate_comparison_value(
         )),
         models::ComparisonValue::Variable { name: var } => Ok((
             values::translate_variable(
+                state,
                 env.get_variables_table()?,
                 var.clone(),
                 &database::Type::ScalarType(typ.clone()),

--- a/crates/query-engine/translation/src/translation/query/native_queries.rs
+++ b/crates/query-engine/translation/src/translation/query/native_queries.rs
@@ -38,6 +38,15 @@ pub fn translate(env: &Env, state: State) -> Result<Vec<sql::ast::CommonTableExp
                             models::Argument::Variable { name } => match &variables_table {
                                 Err(err) => Err(err.clone()),
                                 Ok(variables_table) => Ok(values::translate_variable(
+                                    // We need a 'State' value when translating variables in order
+                                    // to be able to generate fresh names for bound relational
+                                    // expressions.
+                                    // However, we cannot readily re-use the 'state' argument we're
+                                    // given, since that is an "owned" value which is "moved" in
+                                    // the course of iterating over the native queries accumulated
+                                    // within.
+                                    // Ideally we should resolve this by tracking native queries
+                                    // separately from the fresh table name counter.
                                     &mut State::new(),
                                     variables_table.clone(),
                                     name.clone(),

--- a/crates/query-engine/translation/src/translation/query/native_queries.rs
+++ b/crates/query-engine/translation/src/translation/query/native_queries.rs
@@ -38,6 +38,7 @@ pub fn translate(env: &Env, state: State) -> Result<Vec<sql::ast::CommonTableExp
                             models::Argument::Variable { name } => match &variables_table {
                                 Err(err) => Err(err.clone()),
                                 Ok(variables_table) => Ok(values::translate_variable(
+                                    &mut State::new(),
                                     variables_table.clone(),
                                     name.clone(),
                                     &typ,

--- a/crates/query-engine/translation/src/translation/query/values.rs
+++ b/crates/query-engine/translation/src/translation/query/values.rs
@@ -104,7 +104,7 @@ pub fn translate_variable(
                 ))),
             }
         }
-        _ => sql::ast::Expression::BinaryOperation {
+        database::Type::ScalarType(_) => sql::ast::Expression::BinaryOperation {
             left: Box::new(variables_reference),
             operator: sql::ast::BinaryOperator("->>".to_string()),
             right: Box::new(sql::ast::Expression::Value(sql::ast::Value::String(

--- a/crates/query-engine/translation/src/translation/query/values.rs
+++ b/crates/query-engine/translation/src/translation/query/values.rs
@@ -131,6 +131,16 @@ pub fn translate_projected_variable(
                 exp,
             ],
         },
+        // We translate projection of array types into the following sql:
+        // ```
+        // ( SELECT
+        //     array_agg(
+        //       jsonb_populate_record(cast(null as <type>), "array"."element")
+        //     ) AS "element"
+        //   FROM
+        //    jsonb_array_elements((<variable_table> -> <label>)) AS "array"("element")
+        // )
+        // ```
         database::Type::ArrayType(type_name) => {
             let array_table = state.make_table_alias("array".to_string());
             let element_column = sql::ast::ColumnAlias {

--- a/crates/query-engine/translation/tests/goldenfiles/select_array_variable/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/select_array_variable/request.json
@@ -1,0 +1,27 @@
+{
+  "collection": "count_elements",
+  "query": {
+    "fields": {
+      "result": {
+        "type": "column",
+        "column": "result",
+        "arguments": {}
+      }
+    }
+  },
+  "arguments": {
+    "array_argument": {
+      "type": "variable",
+      "name": "variable_array_argument"
+    }
+  },
+  "collection_relationships": {},
+  "variables": [
+    {
+      "variable_array_argument": ["one", "two"]
+    },
+    {
+      "variable_array_argument": ["one", "two", "three"]
+    }
+  ]
+}

--- a/crates/query-engine/translation/tests/goldenfiles/select_array_variable/tables.json
+++ b/crates/query-engine/translation/tests/goldenfiles/select_array_variable/tables.json
@@ -1,0 +1,27 @@
+{
+  "nativeQueries": {
+    "count_elements": {
+      "sql": "SELECT array_length({{array_argument}}, 1) as result",
+      "columns": {
+        "result": {
+          "name": "result",
+          "type": {
+            "scalarType": "int4"
+          },
+          "nullable": "nullable",
+          "description": null
+        }
+      },
+      "arguments": {
+        "array_argument": {
+          "name": "array_argument",
+          "type": {
+            "arrayType": { "scalarType": "text" }
+          },
+          "nullable": "nullable"
+        }
+      },
+      "description": "A native query used to test support array-valued variables"
+    }
+  }
+}

--- a/crates/query-engine/translation/tests/goldenfiles/select_array_variable_nested_types/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/select_array_variable_nested_types/request.json
@@ -1,0 +1,107 @@
+{
+  "collection": "summarize_organizations",
+  "query": {
+    "fields": {
+      "result": {
+        "type": "column",
+        "column": "result",
+        "arguments": {}
+      }
+    }
+  },
+  "arguments": {
+    "organizations": {
+      "type": "variable",
+      "name": "variable_organizations"
+    }
+  },
+  "collection_relationships": {},
+  "variables": [
+    {
+      "variable_organizations": []
+    },
+    {
+      "variable_organizations": [
+        {
+          "name": "Federation of United Solipsists",
+          "committees": [
+            {
+              "name": "Positively existing entities",
+              "members": [
+                {
+                  "first_name": "Yo",
+                  "last_name": "El mismo"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "variable_organizations": [
+        {
+          "name": "RC Model Airplane Enthusiasts",
+          "committees": [
+            {
+              "name": "Founders",
+              "members": [
+                {
+                  "first_name": "Orville",
+                  "last_name": "Wright"
+                },
+                {
+                  "first_name": "Wilbur",
+                  "last_name": "Wright"
+                }
+              ]
+            },
+            {
+              "name": "Parts supply management",
+              "members": [
+                {
+                  "first_name": "Orville",
+                  "last_name": "Wright"
+                },
+                {
+                  "first_name": "Wilbur",
+                  "last_name": "Wright"
+                },
+                {
+                  "first_name": "Guybrush",
+                  "last_name": "Threepwood"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Argonauts' Alumni Association",
+          "committees": [
+            {
+              "name": "Crew",
+              "members": [
+                {
+                  "first_name": "Jason",
+                  "last_name": "(The)"
+                },
+                {
+                  "first_name": "Heracles",
+                  "last_name": "(The)"
+                },
+                {
+                  "first_name": "Castor",
+                  "last_name": "(The)"
+                },
+                {
+                  "first_name": "Polydeuces",
+                  "last_name": "(The)"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/crates/query-engine/translation/tests/goldenfiles/select_array_variable_nested_types/tables.json
+++ b/crates/query-engine/translation/tests/goldenfiles/select_array_variable_nested_types/tables.json
@@ -1,0 +1,86 @@
+{
+  "compositeTypes": {
+    "person_name": {
+      "name": "person_name",
+      "fields": {
+        "first_name": {
+          "name": "first_name",
+          "type": {
+            "scalarType": "text"
+          }
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": {
+            "scalarType": "text"
+          }
+        }
+      }
+    },
+    "committee": {
+      "name": "committee",
+      "fields": {
+        "name": {
+          "name": "name",
+          "type": {
+            "scalarType": "text"
+          }
+        },
+        "members": {
+          "name": "members",
+          "type": {
+            "arrayType": {
+              "scalarType": "text"
+            }
+          }
+        }
+      }
+    },
+    "organization": {
+      "name": "organization",
+      "fields": {
+        "name": {
+          "name": "name",
+          "type": {
+            "scalarType": "text"
+          }
+        },
+        "members": {
+          "name": "committees",
+          "type": {
+            "arrayType": {
+              "compositeType": "committee"
+            }
+          }
+        }
+      }
+    }
+  },
+  "nativeQueries": {
+    "summarize_organizations": {
+      "sql": "SELECT 'The organization ' || org.name || ' has ' || no_committees::text || ' committees, ' || 'the largest of which has ' || max_members || ' members.' AS result FROM (SELECT orgs.* FROM unnest({{organizations}})) AS org JOIN LATERAL ( SELECT count(committee.*) AS no_committees, max(members_agg.no_members) AS max_members FROM unnest(org.committees) AS committee JOIN LATERAL ( SELECT count(*) as no_members FROM unnest(committee.members) AS members) AS members_agg ON true) AS coms ON true",
+      "columns": {
+        "result": {
+          "name": "result",
+          "type": {
+            "scalarType": "text"
+          },
+          "nullable": "nullable",
+          "description": null
+        }
+      },
+      "arguments": {
+        "organizations": {
+          "name": "organizations",
+          "type": {
+            "arrayType": {
+              "compositeType": "organization"
+            }
+          },
+          "nullable": "nullable"
+        }
+      },
+      "description": "A native query used to test support array-valued variables"
+    }
+  }
+}

--- a/crates/query-engine/translation/tests/snapshots/tests__select_array_variable.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_array_variable.snap
@@ -16,30 +16,28 @@ FROM
             array_length(
               (
                 SELECT
-                  array_agg(cast("%0_arr"."elem" as text)) AS "elem"
-                FROM
-                  jsonb_array_elements(("%0_%variables_table"."%variables" -> $2)) AS "%0_arr"("elem")
-              ),
-              1
-            ) as result
-        )
-        SELECT
-          *
-        FROM
-          (
-            SELECT
-              coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
-            FROM
-              (
-                SELECT
-                  "%1_count_elements"."result" AS "result"
-                FROM
-                  "%2_NATIVE_QUERY_count_elements" AS "%1_count_elements"
-              ) AS "%4_rows"
-          ) AS "%4_rows"
-      ) AS "%3_universe"
-    ORDER BY
-      "%0_%variables_table"."%variable_order" ASC
-  ) AS "%6_universe_agg"
+                  array_agg(
+                    cast(
+                      (
+                        "%0_arr"."elem" #>> cast(ARRAY [] as text[])) as text)) AS "elem" FROM jsonb_array_elements(("%0_%variables_table"."%variables" -> $2)) AS "%0_arr"("elem")), 1) as result
+                      )
+                      SELECT
+                        *
+                      FROM
+                        (
+                          SELECT
+                            coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
+                          FROM
+                            (
+                              SELECT
+                                "%1_count_elements"."result" AS "result"
+                              FROM
+                                "%2_NATIVE_QUERY_count_elements" AS "%1_count_elements"
+                            ) AS "%4_rows"
+                        ) AS "%4_rows"
+                    ) AS "%3_universe"
+                    ORDER BY
+                      "%0_%variables_table"."%variable_order" ASC
+                  ) AS "%6_universe_agg"
 
 [(1, Variable("%VARIABLES_OBJECT_PLACEHOLDER")), (2, String("variable_array_argument"))]

--- a/crates/query-engine/translation/tests/snapshots/tests__select_array_variable.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_array_variable.snap
@@ -19,7 +19,7 @@ FROM
                   array_agg(
                     cast(
                       (
-                        "%0_arr"."elem" #>> cast(ARRAY [] as text[])) as text)) AS "elem" FROM jsonb_array_elements(("%0_%variables_table"."%variables" -> $2)) AS "%0_arr"("elem")), 1) as result
+                        "%0_array"."element" #>> cast(ARRAY [] as text[])) as text)) AS "element" FROM jsonb_array_elements(("%0_%variables_table"."%variables" -> $2)) AS "%0_array"("element")), 1) as result
                       )
                       SELECT
                         *

--- a/crates/query-engine/translation/tests/snapshots/tests__select_array_variable.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_array_variable.snap
@@ -1,0 +1,45 @@
+---
+source: crates/query-engine/translation/tests/tests.rs
+expression: result
+---
+SELECT
+  coalesce(json_agg("%6_universe_agg"."universe"), '[]') AS "universe"
+FROM
+  (
+    SELECT
+      row_to_json("%3_universe") AS "universe"
+    FROM
+      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" int, "%variables" jsonb)
+      CROSS JOIN LATERAL (
+        WITH "%2_NATIVE_QUERY_count_elements" AS (
+          SELECT
+            array_length(
+              (
+                SELECT
+                  array_agg(cast("%0_arr"."elem" as text)) AS "elem"
+                FROM
+                  jsonb_array_elements(("%0_%variables_table"."%variables" -> $2)) AS "%0_arr"("elem")
+              ),
+              1
+            ) as result
+        )
+        SELECT
+          *
+        FROM
+          (
+            SELECT
+              coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
+            FROM
+              (
+                SELECT
+                  "%1_count_elements"."result" AS "result"
+                FROM
+                  "%2_NATIVE_QUERY_count_elements" AS "%1_count_elements"
+              ) AS "%4_rows"
+          ) AS "%4_rows"
+      ) AS "%3_universe"
+    ORDER BY
+      "%0_%variables_table"."%variable_order" ASC
+  ) AS "%6_universe_agg"
+
+[(1, Variable("%VARIABLES_OBJECT_PLACEHOLDER")), (2, String("variable_array_argument"))]

--- a/crates/query-engine/translation/tests/snapshots/tests__select_array_variable_nested_types.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_array_variable_nested_types.snap
@@ -23,10 +23,10 @@ FROM
                   (
                     SELECT
                       array_agg(
-                        jsonb_populate_record(cast(null as organization), "%0_arr"."elem")
-                      ) AS "elem"
+                        jsonb_populate_record(cast(null as organization), "%0_array"."element")
+                      ) AS "element"
                     FROM
-                      jsonb_array_elements(("%0_%variables_table"."%variables" -> $2)) AS "%0_arr"("elem")
+                      jsonb_array_elements(("%0_%variables_table"."%variables" -> $2)) AS "%0_array"("element")
                   )
                 )
             ) AS org

--- a/crates/query-engine/translation/tests/snapshots/tests__select_array_variable_nested_types.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_array_variable_nested_types.snap
@@ -1,0 +1,66 @@
+---
+source: crates/query-engine/translation/tests/tests.rs
+expression: result
+---
+SELECT
+  coalesce(json_agg("%6_universe_agg"."universe"), '[]') AS "universe"
+FROM
+  (
+    SELECT
+      row_to_json("%3_universe") AS "universe"
+    FROM
+      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" int, "%variables" jsonb)
+      CROSS JOIN LATERAL (
+        WITH "%2_NATIVE_QUERY_summarize_organizations" AS (
+          SELECT
+            'The organization ' || org.name || ' has ' || no_committees :: text || ' committees, ' || 'the largest of which has ' || max_members || ' members.' AS result
+          FROM
+            (
+              SELECT
+                orgs.*
+              FROM
+                unnest(
+                  (
+                    SELECT
+                      array_agg(
+                        jsonb_populate_record(cast(null as organization), "%0_arr"."elem")
+                      ) AS "elem"
+                    FROM
+                      jsonb_array_elements(("%0_%variables_table"."%variables" -> $2)) AS "%0_arr"("elem")
+                  )
+                )
+            ) AS org
+            JOIN LATERAL (
+              SELECT
+                count(committee.*) AS no_committees,
+                max(members_agg.no_members) AS max_members
+              FROM
+                unnest(org.committees) AS committee
+                JOIN LATERAL (
+                  SELECT
+                    count(*) as no_members
+                  FROM
+                    unnest(committee.members) AS members
+                ) AS members_agg ON true
+            ) AS coms ON true
+        )
+        SELECT
+          *
+        FROM
+          (
+            SELECT
+              coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
+            FROM
+              (
+                SELECT
+                  "%1_summarize_organizations"."result" AS "result"
+                FROM
+                  "%2_NATIVE_QUERY_summarize_organizations" AS "%1_summarize_organizations"
+              ) AS "%4_rows"
+          ) AS "%4_rows"
+      ) AS "%3_universe"
+    ORDER BY
+      "%0_%variables_table"."%variable_order" ASC
+  ) AS "%6_universe_agg"
+
+[(1, Variable("%VARIABLES_OBJECT_PLACEHOLDER")), (2, String("variable_organizations"))]

--- a/crates/query-engine/translation/tests/tests.rs
+++ b/crates/query-engine/translation/tests/tests.rs
@@ -13,6 +13,18 @@ fn select_array_column() {
 }
 
 #[test]
+fn select_array_variable() {
+    let result = common::test_translation("select_array_variable").unwrap();
+    insta::assert_snapshot!(result);
+}
+
+#[test]
+fn select_array_variable_nested_types() {
+    let result = common::test_translation("select_array_variable_nested_types").unwrap();
+    insta::assert_snapshot!(result);
+}
+
+#[test]
 fn select_composite_column_simple() {
     let result = common::test_translation("select_composite_column_simple").unwrap();
     insta::assert_snapshot!(result);

--- a/crates/tests/databases-tests/src/aurora/query_tests.rs
+++ b/crates/tests/databases-tests/src/aurora/query_tests.rs
@@ -34,6 +34,18 @@ mod basic {
     }
 
     #[tokio::test]
+    async fn select_array_variable() {
+        let result = run_query(create_router().await, "select_array_variable").await;
+        insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test]
+    async fn select_array_variable_nested_types() {
+        let result = run_query(create_router().await, "select_array_variable_nested_types").await;
+        insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test]
     async fn select_int_and_string() {
         let result = run_query(create_router().await, "select_int_and_string").await;
         insta::assert_json_snapshot!(result);

--- a/crates/tests/databases-tests/src/aurora/snapshots/databases_tests__aurora__query_tests__basic__select_array_variable.snap
+++ b/crates/tests/databases-tests/src/aurora/snapshots/databases_tests__aurora__query_tests__basic__select_array_variable.snap
@@ -1,0 +1,20 @@
+---
+source: crates/tests/databases-tests/src/aurora/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": [
+      {
+        "result": 2
+      }
+    ]
+  },
+  {
+    "rows": [
+      {
+        "result": 3
+      }
+    ]
+  }
+]

--- a/crates/tests/databases-tests/src/aurora/snapshots/databases_tests__aurora__query_tests__basic__select_array_variable_nested_types.snap
+++ b/crates/tests/databases-tests/src/aurora/snapshots/databases_tests__aurora__query_tests__basic__select_array_variable_nested_types.snap
@@ -1,0 +1,26 @@
+---
+source: crates/tests/databases-tests/src/aurora/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": []
+  },
+  {
+    "rows": [
+      {
+        "result": "The organization Federation of United Solipsists has 1 committees, the largest of which has 1 members."
+      }
+    ]
+  },
+  {
+    "rows": [
+      {
+        "result": "The organization RC Model Airplane Enthusiasts has 2 committees, the largest of which has 3 members."
+      },
+      {
+        "result": "The organization Argonauts' Alumni Association has 1 committees, the largest of which has 4 members."
+      }
+    ]
+  }
+]

--- a/crates/tests/databases-tests/src/citus/query_tests.rs
+++ b/crates/tests/databases-tests/src/citus/query_tests.rs
@@ -34,6 +34,18 @@ mod basic {
     }
 
     #[tokio::test]
+    async fn select_array_variable() {
+        let result = run_query(create_router().await, "select_array_variable").await;
+        insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test]
+    async fn select_array_variable_nested_types() {
+        let result = run_query(create_router().await, "select_array_variable_nested_types").await;
+        insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test]
     async fn select_int_and_string() {
         let result = run_query(create_router().await, "select_int_and_string").await;
         insta::assert_json_snapshot!(result);

--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__explain_tests__explain__select_where_variable.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__explain_tests__explain__select_where_variable.snap
@@ -27,14 +27,5 @@ FROM
                 WHERE
                   (
                     "%1_Album"."Title" ~~ cast(
-                      ("%0_%variables_table"."%variables" ->> $2) as varchar
-                    )
-                  )
-                ORDER BY
-                  "%1_Album"."AlbumId" ASC
-              ) AS "%3_rows"
-          ) AS "%3_rows"
-      ) AS "%2_universe"
-    ORDER BY
-      "%0_%variables_table"."%variable_order" ASC
-  ) AS "%5_universe_agg"
+                      (
+                        ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as text[])) as varchar)) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%3_rows") AS "%3_rows") AS "%2_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%5_universe_agg"

--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__query_tests__basic__select_array_variable.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__query_tests__basic__select_array_variable.snap
@@ -1,0 +1,20 @@
+---
+source: crates/tests/databases-tests/src/citus/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": [
+      {
+        "result": 2
+      }
+    ]
+  },
+  {
+    "rows": [
+      {
+        "result": 3
+      }
+    ]
+  }
+]

--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__query_tests__basic__select_array_variable_nested_types.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__query_tests__basic__select_array_variable_nested_types.snap
@@ -1,0 +1,26 @@
+---
+source: crates/tests/databases-tests/src/citus/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": []
+  },
+  {
+    "rows": [
+      {
+        "result": "The organization Federation of United Solipsists has 1 committees, the largest of which has 1 members."
+      }
+    ]
+  },
+  {
+    "rows": [
+      {
+        "result": "The organization RC Model Airplane Enthusiasts has 2 committees, the largest of which has 3 members."
+      },
+      {
+        "result": "The organization Argonauts' Alumni Association has 1 committees, the largest of which has 4 members."
+      }
+    ]
+  }
+]

--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__schema_tests__schema_test__get_schema.snap
@@ -2024,6 +2024,39 @@ expression: result
         }
       }
     },
+    "committee": {
+      "fields": {
+        "members": {
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "text"
+            }
+          }
+        },
+        "name": {
+          "type": {
+            "type": "named",
+            "name": "text"
+          }
+        }
+      }
+    },
+    "count_elements": {
+      "description": "A native query used to test support array-valued variables",
+      "fields": {
+        "result": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        }
+      }
+    },
     "delete_playlist_track": {
       "fields": {
         "PlaylistId": {
@@ -2113,6 +2146,25 @@ expression: result
         }
       }
     },
+    "organization": {
+      "fields": {
+        "committees": {
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "committee"
+            }
+          }
+        },
+        "name": {
+          "type": {
+            "type": "named",
+            "name": "text"
+          }
+        }
+      }
+    },
     "person": {
       "fields": {
         "address": {
@@ -2161,532 +2213,16 @@ expression: result
         }
       }
     },
-    "v1_insert_Album_object": {
+    "summarize_organizations": {
+      "description": "A native query used to test support array-valued variables",
       "fields": {
-        "AlbumId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "ArtistId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "Title": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
-          }
-        }
-      }
-    },
-    "v1_insert_Artist_object": {
-      "fields": {
-        "ArtistId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "Name": {
+        "result": {
           "type": {
             "type": "nullable",
             "underlying_type": {
               "type": "named",
-              "name": "varchar"
+              "name": "text"
             }
-          }
-        }
-      }
-    },
-    "v1_insert_Customer_object": {
-      "fields": {
-        "Address": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "City": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "Company": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "Country": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "CustomerId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "Email": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
-          }
-        },
-        "Fax": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "FirstName": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
-          }
-        },
-        "LastName": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
-          }
-        },
-        "Phone": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "PostalCode": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "State": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "SupportRepId": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        }
-      }
-    },
-    "v1_insert_Employee_object": {
-      "fields": {
-        "Address": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "BirthDate": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "timestamp"
-            }
-          }
-        },
-        "City": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "Country": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "Email": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "EmployeeId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "Fax": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "FirstName": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
-          }
-        },
-        "HireDate": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "timestamp"
-            }
-          }
-        },
-        "LastName": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
-          }
-        },
-        "Phone": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "PostalCode": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "ReportsTo": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        },
-        "State": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "Title": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        }
-      }
-    },
-    "v1_insert_Genre_object": {
-      "fields": {
-        "GenreId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "Name": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        }
-      }
-    },
-    "v1_insert_InvoiceLine_object": {
-      "fields": {
-        "InvoiceId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "InvoiceLineId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "Quantity": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "TrackId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "UnitPrice": {
-          "type": {
-            "type": "named",
-            "name": "numeric"
-          }
-        }
-      }
-    },
-    "v1_insert_Invoice_object": {
-      "fields": {
-        "BillingAddress": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "BillingCity": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "BillingCountry": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "BillingPostalCode": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "BillingState": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "CustomerId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "InvoiceDate": {
-          "type": {
-            "type": "named",
-            "name": "timestamp"
-          }
-        },
-        "InvoiceId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "Total": {
-          "type": {
-            "type": "named",
-            "name": "numeric"
-          }
-        }
-      }
-    },
-    "v1_insert_MediaType_object": {
-      "fields": {
-        "MediaTypeId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "Name": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        }
-      }
-    },
-    "v1_insert_PlaylistTrack_object": {
-      "fields": {
-        "PlaylistId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "TrackId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        }
-      }
-    },
-    "v1_insert_Playlist_object": {
-      "fields": {
-        "Name": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "PlaylistId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        }
-      }
-    },
-    "v1_insert_Track_object": {
-      "fields": {
-        "AlbumId": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        },
-        "Bytes": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        },
-        "Composer": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "GenreId": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        },
-        "MediaTypeId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "Milliseconds": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "Name": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
-          }
-        },
-        "TrackId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "UnitPrice": {
-          "type": {
-            "type": "named",
-            "name": "numeric"
           }
         }
       }
@@ -3176,6 +2712,27 @@ expression: result
       "foreign_keys": {}
     },
     {
+      "name": "count_elements",
+      "description": "A native query used to test support array-valued variables",
+      "arguments": {
+        "array_argument": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "array",
+              "element_type": {
+                "type": "named",
+                "name": "text"
+              }
+            }
+          }
+        }
+      },
+      "type": "count_elements",
+      "uniqueness_constraints": {},
+      "foreign_keys": {}
+    },
+    {
       "name": "make_person",
       "description": "A native query used to test support for composite types",
       "arguments": {
@@ -3199,6 +2756,27 @@ expression: result
         }
       },
       "type": "make_person",
+      "uniqueness_constraints": {},
+      "foreign_keys": {}
+    },
+    {
+      "name": "summarize_organizations",
+      "description": "A native query used to test support array-valued variables",
+      "arguments": {
+        "organizations": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "array",
+              "element_type": {
+                "type": "named",
+                "name": "organization"
+              }
+            }
+          }
+        }
+      },
+      "type": "summarize_organizations",
       "uniqueness_constraints": {},
       "foreign_keys": {}
     },
@@ -3593,182 +3171,6 @@ expression: result
           "type": {
             "type": "named",
             "name": "int4"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "Track"
-      }
-    },
-    {
-      "name": "v1_insert_Album",
-      "description": "Insert into the Album table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_Album_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "Album"
-      }
-    },
-    {
-      "name": "v1_insert_Artist",
-      "description": "Insert into the Artist table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_Artist_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "Artist"
-      }
-    },
-    {
-      "name": "v1_insert_Customer",
-      "description": "Insert into the Customer table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_Customer_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "Customer"
-      }
-    },
-    {
-      "name": "v1_insert_Employee",
-      "description": "Insert into the Employee table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_Employee_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "Employee"
-      }
-    },
-    {
-      "name": "v1_insert_Genre",
-      "description": "Insert into the Genre table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_Genre_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "Genre"
-      }
-    },
-    {
-      "name": "v1_insert_Invoice",
-      "description": "Insert into the Invoice table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_Invoice_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "Invoice"
-      }
-    },
-    {
-      "name": "v1_insert_InvoiceLine",
-      "description": "Insert into the InvoiceLine table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_InvoiceLine_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "InvoiceLine"
-      }
-    },
-    {
-      "name": "v1_insert_MediaType",
-      "description": "Insert into the MediaType table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_MediaType_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "MediaType"
-      }
-    },
-    {
-      "name": "v1_insert_Playlist",
-      "description": "Insert into the Playlist table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_Playlist_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "Playlist"
-      }
-    },
-    {
-      "name": "v1_insert_PlaylistTrack",
-      "description": "Insert into the PlaylistTrack table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_PlaylistTrack_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "PlaylistTrack"
-      }
-    },
-    {
-      "name": "v1_insert_Track",
-      "description": "Insert into the Track table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_Track_object"
           }
         }
       },

--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__schema_tests__schema_test__get_schema.snap
@@ -2227,6 +2227,536 @@ expression: result
         }
       }
     },
+    "v1_insert_Album_object": {
+      "fields": {
+        "AlbumId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "ArtistId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "Title": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        }
+      }
+    },
+    "v1_insert_Artist_object": {
+      "fields": {
+        "ArtistId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "Name": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_Customer_object": {
+      "fields": {
+        "Address": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "City": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "Company": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "Country": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "CustomerId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "Email": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        },
+        "Fax": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "FirstName": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        },
+        "LastName": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        },
+        "Phone": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "PostalCode": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "State": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "SupportRepId": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_Employee_object": {
+      "fields": {
+        "Address": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "BirthDate": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "timestamp"
+            }
+          }
+        },
+        "City": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "Country": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "Email": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "EmployeeId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "Fax": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "FirstName": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        },
+        "HireDate": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "timestamp"
+            }
+          }
+        },
+        "LastName": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        },
+        "Phone": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "PostalCode": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "ReportsTo": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        },
+        "State": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "Title": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_Genre_object": {
+      "fields": {
+        "GenreId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "Name": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_InvoiceLine_object": {
+      "fields": {
+        "InvoiceId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "InvoiceLineId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "Quantity": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "TrackId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "UnitPrice": {
+          "type": {
+            "type": "named",
+            "name": "numeric"
+          }
+        }
+      }
+    },
+    "v1_insert_Invoice_object": {
+      "fields": {
+        "BillingAddress": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "BillingCity": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "BillingCountry": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "BillingPostalCode": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "BillingState": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "CustomerId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "InvoiceDate": {
+          "type": {
+            "type": "named",
+            "name": "timestamp"
+          }
+        },
+        "InvoiceId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "Total": {
+          "type": {
+            "type": "named",
+            "name": "numeric"
+          }
+        }
+      }
+    },
+    "v1_insert_MediaType_object": {
+      "fields": {
+        "MediaTypeId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "Name": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_PlaylistTrack_object": {
+      "fields": {
+        "PlaylistId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "TrackId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        }
+      }
+    },
+    "v1_insert_Playlist_object": {
+      "fields": {
+        "Name": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "PlaylistId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        }
+      }
+    },
+    "v1_insert_Track_object": {
+      "fields": {
+        "AlbumId": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        },
+        "Bytes": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        },
+        "Composer": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "GenreId": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        },
+        "MediaTypeId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "Milliseconds": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "Name": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        },
+        "TrackId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "UnitPrice": {
+          "type": {
+            "type": "named",
+            "name": "numeric"
+          }
+        }
+      }
+    },
     "value_types": {
       "fields": {
         "bool": {
@@ -3171,6 +3701,182 @@ expression: result
           "type": {
             "type": "named",
             "name": "int4"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "Track"
+      }
+    },
+    {
+      "name": "v1_insert_Album",
+      "description": "Insert into the Album table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_Album_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "Album"
+      }
+    },
+    {
+      "name": "v1_insert_Artist",
+      "description": "Insert into the Artist table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_Artist_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "Artist"
+      }
+    },
+    {
+      "name": "v1_insert_Customer",
+      "description": "Insert into the Customer table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_Customer_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "Customer"
+      }
+    },
+    {
+      "name": "v1_insert_Employee",
+      "description": "Insert into the Employee table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_Employee_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "Employee"
+      }
+    },
+    {
+      "name": "v1_insert_Genre",
+      "description": "Insert into the Genre table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_Genre_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "Genre"
+      }
+    },
+    {
+      "name": "v1_insert_Invoice",
+      "description": "Insert into the Invoice table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_Invoice_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "Invoice"
+      }
+    },
+    {
+      "name": "v1_insert_InvoiceLine",
+      "description": "Insert into the InvoiceLine table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_InvoiceLine_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "InvoiceLine"
+      }
+    },
+    {
+      "name": "v1_insert_MediaType",
+      "description": "Insert into the MediaType table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_MediaType_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "MediaType"
+      }
+    },
+    {
+      "name": "v1_insert_Playlist",
+      "description": "Insert into the Playlist table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_Playlist_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "Playlist"
+      }
+    },
+    {
+      "name": "v1_insert_PlaylistTrack",
+      "description": "Insert into the PlaylistTrack table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_PlaylistTrack_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "PlaylistTrack"
+      }
+    },
+    {
+      "name": "v1_insert_Track",
+      "description": "Insert into the Track table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_Track_object"
           }
         }
       },

--- a/crates/tests/databases-tests/src/cockroach/query_tests.rs
+++ b/crates/tests/databases-tests/src/cockroach/query_tests.rs
@@ -35,6 +35,19 @@ mod basic {
     }
 
     #[tokio::test]
+    async fn select_array_variable() {
+        let result = run_query(create_router().await, "select_array_variable").await;
+        insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test]
+    #[ignore = "Cockroach v23.1.10 does not support nested user defined types which this test uses."]
+    async fn select_array_variable_nested_types() {
+        let result = run_query(create_router().await, "select_array_variable_nested_types").await;
+        insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test]
     async fn select_int_and_string() {
         let result = run_query(create_router().await, "select_int_and_string").await;
         insta::assert_json_snapshot!(result);

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__explain_tests__explain__select_where_variable.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__explain_tests__explain__select_where_variable.snap
@@ -27,14 +27,5 @@ FROM
                 WHERE
                   (
                     "%1_Album"."Title" LIKE cast(
-                      ("%0_%variables_table"."%variables" ->> $2) as varchar
-                    )
-                  )
-                ORDER BY
-                  "%1_Album"."AlbumId" ASC
-              ) AS "%3_rows"
-          ) AS "%3_rows"
-      ) AS "%2_universe"
-    ORDER BY
-      "%0_%variables_table"."%variable_order" ASC
-  ) AS "%5_universe_agg"
+                      (
+                        ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as text[])) as varchar)) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%3_rows") AS "%3_rows") AS "%2_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%5_universe_agg"

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__query_tests__basic__select_array_variable.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__query_tests__basic__select_array_variable.snap
@@ -1,0 +1,20 @@
+---
+source: crates/tests/databases-tests/src/cockroach/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": [
+      {
+        "result": 2
+      }
+    ]
+  },
+  {
+    "rows": [
+      {
+        "result": 3
+      }
+    ]
+  }
+]

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__schema_tests__schema_test__get_schema.snap
@@ -1783,6 +1783,20 @@ expression: result
         }
       }
     },
+    "count_elements": {
+      "description": "A native query used to test support array-valued variables",
+      "fields": {
+        "result": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        }
+      }
+    },
     "delete_playlist_track": {
       "fields": {
         "PlaylistId": {
@@ -3003,6 +3017,27 @@ expression: result
         }
       },
       "type": "artist_below_id",
+      "uniqueness_constraints": {},
+      "foreign_keys": {}
+    },
+    {
+      "name": "count_elements",
+      "description": "A native query used to test support array-valued variables",
+      "arguments": {
+        "array_argument": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "array",
+              "element_type": {
+                "type": "named",
+                "name": "text"
+              }
+            }
+          }
+        }
+      },
+      "type": "count_elements",
       "uniqueness_constraints": {},
       "foreign_keys": {}
     },

--- a/crates/tests/databases-tests/src/postgres/query_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/query_tests.rs
@@ -34,6 +34,18 @@ mod basic {
     }
 
     #[tokio::test]
+    async fn select_array_variable() {
+        let result = run_query(create_router().await, "select_array_variable").await;
+        insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test]
+    async fn select_array_variable_nested_types() {
+        let result = run_query(create_router().await, "select_array_variable_nested_types").await;
+        insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test]
     async fn select_int_and_string() {
         let result = run_query(create_router().await, "select_int_and_string").await;
         insta::assert_json_snapshot!(result);

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__explain__native_queries__embedded_variable.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__explain__native_queries__embedded_variable.snap
@@ -19,27 +19,26 @@ FROM
             public."Album"
           WHERE
             "Title" LIKE cast(
-              ("%0_%variables_table"."%variables" ->> $2) as varchar
-            )
-            AND "AlbumId" < 500
-        )
-        SELECT
-          *
-        FROM
-          (
-            SELECT
-              coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
-            FROM
               (
-                SELECT
-                  "%1_album_by_title"."Title" AS "Title"
-                FROM
-                  "%2_NATIVE_QUERY_album_by_title" AS "%1_album_by_title"
-                ORDER BY
-                  "%1_album_by_title"."AlbumId" ASC
-              ) AS "%4_rows"
-          ) AS "%4_rows"
-      ) AS "%3_universe"
-    ORDER BY
-      "%0_%variables_table"."%variable_order" ASC
-  ) AS "%6_universe_agg"
+                ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as text[])) as varchar) AND "AlbumId" < 500
+              )
+              SELECT
+                *
+              FROM
+                (
+                  SELECT
+                    coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
+                  FROM
+                    (
+                      SELECT
+                        "%1_album_by_title"."Title" AS "Title"
+                      FROM
+                        "%2_NATIVE_QUERY_album_by_title" AS "%1_album_by_title"
+                      ORDER BY
+                        "%1_album_by_title"."AlbumId" ASC
+                    ) AS "%4_rows"
+                ) AS "%4_rows"
+            ) AS "%3_universe"
+          ORDER BY
+            "%0_%variables_table"."%variable_order" ASC
+        ) AS "%6_universe_agg"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__explain__select_where_no_variable.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__explain__select_where_no_variable.snap
@@ -27,14 +27,5 @@ FROM
                 WHERE
                   (
                     "%1_Album"."Title" ~~ cast(
-                      ("%0_%variables_table"."%variables" ->> $2) as varchar
-                    )
-                  )
-                ORDER BY
-                  "%1_Album"."AlbumId" ASC
-              ) AS "%3_rows"
-          ) AS "%3_rows"
-      ) AS "%2_universe"
-    ORDER BY
-      "%0_%variables_table"."%variable_order" ASC
-  ) AS "%5_universe_agg"
+                      (
+                        ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as text[])) as varchar)) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%3_rows") AS "%3_rows") AS "%2_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%5_universe_agg"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__explain__select_where_variable.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__explain__select_where_variable.snap
@@ -27,14 +27,5 @@ FROM
                 WHERE
                   (
                     "%1_Album"."Title" ~~ cast(
-                      ("%0_%variables_table"."%variables" ->> $2) as varchar
-                    )
-                  )
-                ORDER BY
-                  "%1_Album"."AlbumId" ASC
-              ) AS "%3_rows"
-          ) AS "%3_rows"
-      ) AS "%2_universe"
-    ORDER BY
-      "%0_%variables_table"."%variable_order" ASC
-  ) AS "%5_universe_agg"
+                      (
+                        ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as text[])) as varchar)) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%3_rows") AS "%3_rows") AS "%2_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%5_universe_agg"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__basic__select_array_variable.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__basic__select_array_variable.snap
@@ -1,0 +1,20 @@
+---
+source: crates/tests/databases-tests/src/postgres/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": [
+      {
+        "result": 2
+      }
+    ]
+  },
+  {
+    "rows": [
+      {
+        "result": 3
+      }
+    ]
+  }
+]

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__basic__select_array_variable_nested_types.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__basic__select_array_variable_nested_types.snap
@@ -1,0 +1,26 @@
+---
+source: crates/tests/databases-tests/src/postgres/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": []
+  },
+  {
+    "rows": [
+      {
+        "result": "The organization Federation of United Solipsists has 1 committees, the largest of which has 1 members."
+      }
+    ]
+  },
+  {
+    "rows": [
+      {
+        "result": "The organization RC Model Airplane Enthusiasts has 2 committees, the largest of which has 3 members."
+      },
+      {
+        "result": "The organization Argonauts' Alumni Association has 1 committees, the largest of which has 4 members."
+      }
+    ]
+  }
+]

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
@@ -2096,48 +2096,35 @@ expression: result
         }
       }
     },
-    "custom_dog": {
+    "committee": {
       "fields": {
-        "adopter_name": {
+        "members": {
           "type": {
-            "type": "nullable",
-            "underlying_type": {
+            "type": "array",
+            "element_type": {
               "type": "named",
               "name": "text"
             }
-          }
-        },
-        "birthday": {
-          "type": {
-            "type": "named",
-            "name": "date"
-          }
-        },
-        "height_cm": {
-          "type": {
-            "type": "named",
-            "name": "numeric"
-          }
-        },
-        "height_in": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "numeric"
-            }
-          }
-        },
-        "id": {
-          "type": {
-            "type": "named",
-            "name": "int8"
           }
         },
         "name": {
           "type": {
             "type": "named",
             "name": "text"
+          }
+        }
+      }
+    },
+    "count_elements": {
+      "description": "A native query used to test support array-valued variables",
+      "fields": {
+        "result": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
           }
         }
       }
@@ -2227,6 +2214,25 @@ expression: result
               "type": "named",
               "name": "person"
             }
+          }
+        }
+      }
+    },
+    "organization": {
+      "fields": {
+        "committees": {
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "committee"
+            }
+          }
+        },
+        "name": {
+          "type": {
+            "type": "named",
+            "name": "text"
           }
         }
       }
@@ -2325,6 +2331,20 @@ expression: result
         }
       }
     },
+    "summarize_organizations": {
+      "description": "A native query used to test support array-valued variables",
+      "fields": {
+        "result": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "text"
+            }
+          }
+        }
+      }
+    },
     "topology_layer": {
       "fields": {
         "child_id": {
@@ -2381,702 +2401,6 @@ expression: result
       }
     },
     "topology_topology": {
-      "fields": {
-        "hasz": {
-          "type": {
-            "type": "named",
-            "name": "bool"
-          }
-        },
-        "id": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "name": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
-          }
-        },
-        "precision": {
-          "type": {
-            "type": "named",
-            "name": "float8"
-          }
-        },
-        "srid": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        }
-      }
-    },
-    "v1_insert_Album_object": {
-      "fields": {
-        "AlbumId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "ArtistId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "Title": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
-          }
-        }
-      }
-    },
-    "v1_insert_Artist_object": {
-      "fields": {
-        "ArtistId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "Name": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        }
-      }
-    },
-    "v1_insert_Customer_object": {
-      "fields": {
-        "Address": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "City": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "Company": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "Country": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "CustomerId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "Email": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
-          }
-        },
-        "Fax": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "FirstName": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
-          }
-        },
-        "LastName": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
-          }
-        },
-        "Phone": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "PostalCode": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "State": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "SupportRepId": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        }
-      }
-    },
-    "v1_insert_Employee_object": {
-      "fields": {
-        "Address": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "BirthDate": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "timestamp"
-            }
-          }
-        },
-        "City": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "Country": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "Email": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "EmployeeId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "Fax": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "FirstName": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
-          }
-        },
-        "HireDate": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "timestamp"
-            }
-          }
-        },
-        "LastName": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
-          }
-        },
-        "Phone": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "PostalCode": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "ReportsTo": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        },
-        "State": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "Title": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        }
-      }
-    },
-    "v1_insert_Genre_object": {
-      "fields": {
-        "GenreId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "Name": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        }
-      }
-    },
-    "v1_insert_InvoiceLine_object": {
-      "fields": {
-        "InvoiceId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "InvoiceLineId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "Quantity": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "TrackId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "UnitPrice": {
-          "type": {
-            "type": "named",
-            "name": "numeric"
-          }
-        }
-      }
-    },
-    "v1_insert_Invoice_object": {
-      "fields": {
-        "BillingAddress": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "BillingCity": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "BillingCountry": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "BillingPostalCode": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "BillingState": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "CustomerId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "InvoiceDate": {
-          "type": {
-            "type": "named",
-            "name": "timestamp"
-          }
-        },
-        "InvoiceId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "Total": {
-          "type": {
-            "type": "named",
-            "name": "numeric"
-          }
-        }
-      }
-    },
-    "v1_insert_MediaType_object": {
-      "fields": {
-        "MediaTypeId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "Name": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        }
-      }
-    },
-    "v1_insert_PlaylistTrack_object": {
-      "fields": {
-        "PlaylistId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "TrackId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        }
-      }
-    },
-    "v1_insert_Playlist_object": {
-      "fields": {
-        "Name": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "PlaylistId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        }
-      }
-    },
-    "v1_insert_Track_object": {
-      "fields": {
-        "AlbumId": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        },
-        "Bytes": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        },
-        "Composer": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "GenreId": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        },
-        "MediaTypeId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "Milliseconds": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "Name": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
-          }
-        },
-        "TrackId": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "UnitPrice": {
-          "type": {
-            "type": "named",
-            "name": "numeric"
-          }
-        }
-      }
-    },
-    "v1_insert_custom_dog_object": {
-      "fields": {
-        "adopter_name": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "text"
-            }
-          }
-        },
-        "birthday": {
-          "type": {
-            "type": "named",
-            "name": "date"
-          }
-        },
-        "height_cm": {
-          "type": {
-            "type": "named",
-            "name": "numeric"
-          }
-        },
-        "name": {
-          "type": {
-            "type": "named",
-            "name": "text"
-          }
-        }
-      }
-    },
-    "v1_insert_spatial_ref_sys_object": {
-      "fields": {
-        "auth_name": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "auth_srid": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        },
-        "proj4text": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        },
-        "srid": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "srtext": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "varchar"
-            }
-          }
-        }
-      }
-    },
-    "v1_insert_topology_layer_object": {
-      "fields": {
-        "child_id": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "type": "named",
-              "name": "int4"
-            }
-          }
-        },
-        "feature_column": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
-          }
-        },
-        "feature_type": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "layer_id": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "level": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
-        "schema_name": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
-          }
-        },
-        "table_name": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
-          }
-        },
-        "topology_id": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        }
-      }
-    },
-    "v1_insert_topology_topology_object": {
       "fields": {
         "hasz": {
           "type": {
@@ -3481,19 +2805,6 @@ expression: result
       }
     },
     {
-      "name": "custom_dog",
-      "arguments": {},
-      "type": "custom_dog",
-      "uniqueness_constraints": {
-        "dog_pkey": {
-          "unique_columns": [
-            "id"
-          ]
-        }
-      },
-      "foreign_keys": {}
-    },
-    {
       "name": "spatial_ref_sys",
       "arguments": {},
       "type": "spatial_ref_sys",
@@ -3667,6 +2978,27 @@ expression: result
       "foreign_keys": {}
     },
     {
+      "name": "count_elements",
+      "description": "A native query used to test support array-valued variables",
+      "arguments": {
+        "array_argument": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "array",
+              "element_type": {
+                "type": "named",
+                "name": "text"
+              }
+            }
+          }
+        }
+      },
+      "type": "count_elements",
+      "uniqueness_constraints": {},
+      "foreign_keys": {}
+    },
+    {
       "name": "make_person",
       "description": "A native query used to test support for composite types",
       "arguments": {
@@ -3690,6 +3022,27 @@ expression: result
         }
       },
       "type": "make_person",
+      "uniqueness_constraints": {},
+      "foreign_keys": {}
+    },
+    {
+      "name": "summarize_organizations",
+      "description": "A native query used to test support array-valued variables",
+      "arguments": {
+        "organizations": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "array",
+              "element_type": {
+                "type": "named",
+                "name": "organization"
+              }
+            }
+          }
+        }
+      },
+      "type": "summarize_organizations",
       "uniqueness_constraints": {},
       "foreign_keys": {}
     },
@@ -4093,22 +3446,6 @@ expression: result
       }
     },
     {
-      "name": "v1_delete_custom_dog_by_id",
-      "description": "Delete any value on the custom_dog table using the id key",
-      "arguments": {
-        "id": {
-          "type": {
-            "type": "named",
-            "name": "int8"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "custom_dog"
-      }
-    },
-    {
       "name": "v1_delete_spatial_ref_sys_by_srid",
       "description": "Delete any value on the spatial_ref_sys table using the srid key",
       "arguments": {
@@ -4148,246 +3485,6 @@ expression: result
           "type": {
             "type": "named",
             "name": "varchar"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "topology_topology"
-      }
-    },
-    {
-      "name": "v1_insert_Album",
-      "description": "Insert into the Album table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_Album_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "Album"
-      }
-    },
-    {
-      "name": "v1_insert_Artist",
-      "description": "Insert into the Artist table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_Artist_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "Artist"
-      }
-    },
-    {
-      "name": "v1_insert_Customer",
-      "description": "Insert into the Customer table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_Customer_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "Customer"
-      }
-    },
-    {
-      "name": "v1_insert_Employee",
-      "description": "Insert into the Employee table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_Employee_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "Employee"
-      }
-    },
-    {
-      "name": "v1_insert_Genre",
-      "description": "Insert into the Genre table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_Genre_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "Genre"
-      }
-    },
-    {
-      "name": "v1_insert_Invoice",
-      "description": "Insert into the Invoice table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_Invoice_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "Invoice"
-      }
-    },
-    {
-      "name": "v1_insert_InvoiceLine",
-      "description": "Insert into the InvoiceLine table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_InvoiceLine_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "InvoiceLine"
-      }
-    },
-    {
-      "name": "v1_insert_MediaType",
-      "description": "Insert into the MediaType table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_MediaType_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "MediaType"
-      }
-    },
-    {
-      "name": "v1_insert_Playlist",
-      "description": "Insert into the Playlist table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_Playlist_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "Playlist"
-      }
-    },
-    {
-      "name": "v1_insert_PlaylistTrack",
-      "description": "Insert into the PlaylistTrack table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_PlaylistTrack_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "PlaylistTrack"
-      }
-    },
-    {
-      "name": "v1_insert_Track",
-      "description": "Insert into the Track table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_Track_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "Track"
-      }
-    },
-    {
-      "name": "v1_insert_custom_dog",
-      "description": "Insert into the custom_dog table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_custom_dog_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "custom_dog"
-      }
-    },
-    {
-      "name": "v1_insert_spatial_ref_sys",
-      "description": "Insert into the spatial_ref_sys table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_spatial_ref_sys_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "spatial_ref_sys"
-      }
-    },
-    {
-      "name": "v1_insert_topology_layer",
-      "description": "Insert into the topology_layer table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_topology_layer_object"
-          }
-        }
-      },
-      "result_type": {
-        "type": "named",
-        "name": "topology_layer"
-      }
-    },
-    {
-      "name": "v1_insert_topology_topology",
-      "description": "Insert into the topology_topology table",
-      "arguments": {
-        "_object": {
-          "type": {
-            "type": "named",
-            "name": "v1_insert_topology_topology_object"
           }
         }
       },

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
@@ -2129,6 +2129,52 @@ expression: result
         }
       }
     },
+    "custom_dog": {
+      "fields": {
+        "adopter_name": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "text"
+            }
+          }
+        },
+        "birthday": {
+          "type": {
+            "type": "named",
+            "name": "date"
+          }
+        },
+        "height_cm": {
+          "type": {
+            "type": "named",
+            "name": "numeric"
+          }
+        },
+        "height_in": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "numeric"
+            }
+          }
+        },
+        "id": {
+          "type": {
+            "type": "named",
+            "name": "int8"
+          }
+        },
+        "name": {
+          "type": {
+            "type": "named",
+            "name": "text"
+          }
+        }
+      }
+    },
     "delete_playlist_track": {
       "fields": {
         "PlaylistId": {
@@ -2401,6 +2447,702 @@ expression: result
       }
     },
     "topology_topology": {
+      "fields": {
+        "hasz": {
+          "type": {
+            "type": "named",
+            "name": "bool"
+          }
+        },
+        "id": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "name": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        },
+        "precision": {
+          "type": {
+            "type": "named",
+            "name": "float8"
+          }
+        },
+        "srid": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        }
+      }
+    },
+    "v1_insert_Album_object": {
+      "fields": {
+        "AlbumId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "ArtistId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "Title": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        }
+      }
+    },
+    "v1_insert_Artist_object": {
+      "fields": {
+        "ArtistId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "Name": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_Customer_object": {
+      "fields": {
+        "Address": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "City": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "Company": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "Country": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "CustomerId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "Email": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        },
+        "Fax": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "FirstName": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        },
+        "LastName": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        },
+        "Phone": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "PostalCode": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "State": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "SupportRepId": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_Employee_object": {
+      "fields": {
+        "Address": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "BirthDate": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "timestamp"
+            }
+          }
+        },
+        "City": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "Country": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "Email": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "EmployeeId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "Fax": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "FirstName": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        },
+        "HireDate": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "timestamp"
+            }
+          }
+        },
+        "LastName": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        },
+        "Phone": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "PostalCode": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "ReportsTo": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        },
+        "State": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "Title": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_Genre_object": {
+      "fields": {
+        "GenreId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "Name": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_InvoiceLine_object": {
+      "fields": {
+        "InvoiceId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "InvoiceLineId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "Quantity": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "TrackId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "UnitPrice": {
+          "type": {
+            "type": "named",
+            "name": "numeric"
+          }
+        }
+      }
+    },
+    "v1_insert_Invoice_object": {
+      "fields": {
+        "BillingAddress": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "BillingCity": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "BillingCountry": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "BillingPostalCode": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "BillingState": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "CustomerId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "InvoiceDate": {
+          "type": {
+            "type": "named",
+            "name": "timestamp"
+          }
+        },
+        "InvoiceId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "Total": {
+          "type": {
+            "type": "named",
+            "name": "numeric"
+          }
+        }
+      }
+    },
+    "v1_insert_MediaType_object": {
+      "fields": {
+        "MediaTypeId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "Name": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_PlaylistTrack_object": {
+      "fields": {
+        "PlaylistId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "TrackId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        }
+      }
+    },
+    "v1_insert_Playlist_object": {
+      "fields": {
+        "Name": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "PlaylistId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        }
+      }
+    },
+    "v1_insert_Track_object": {
+      "fields": {
+        "AlbumId": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        },
+        "Bytes": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        },
+        "Composer": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "GenreId": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        },
+        "MediaTypeId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "Milliseconds": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "Name": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        },
+        "TrackId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "UnitPrice": {
+          "type": {
+            "type": "named",
+            "name": "numeric"
+          }
+        }
+      }
+    },
+    "v1_insert_custom_dog_object": {
+      "fields": {
+        "adopter_name": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "text"
+            }
+          }
+        },
+        "birthday": {
+          "type": {
+            "type": "named",
+            "name": "date"
+          }
+        },
+        "height_cm": {
+          "type": {
+            "type": "named",
+            "name": "numeric"
+          }
+        },
+        "name": {
+          "type": {
+            "type": "named",
+            "name": "text"
+          }
+        }
+      }
+    },
+    "v1_insert_spatial_ref_sys_object": {
+      "fields": {
+        "auth_name": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "auth_srid": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        },
+        "proj4text": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        },
+        "srid": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "srtext": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_topology_layer_object": {
+      "fields": {
+        "child_id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "int4"
+            }
+          }
+        },
+        "feature_column": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        },
+        "feature_type": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "layer_id": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "level": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "schema_name": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        },
+        "table_name": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        },
+        "topology_id": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        }
+      }
+    },
+    "v1_insert_topology_topology_object": {
       "fields": {
         "hasz": {
           "type": {
@@ -2803,6 +3545,19 @@ expression: result
           "foreign_collection": "MediaType"
         }
       }
+    },
+    {
+      "name": "custom_dog",
+      "arguments": {},
+      "type": "custom_dog",
+      "uniqueness_constraints": {
+        "dog_pkey": {
+          "unique_columns": [
+            "id"
+          ]
+        }
+      },
+      "foreign_keys": {}
     },
     {
       "name": "spatial_ref_sys",
@@ -3446,6 +4201,22 @@ expression: result
       }
     },
     {
+      "name": "v1_delete_custom_dog_by_id",
+      "description": "Delete any value on the custom_dog table using the id key",
+      "arguments": {
+        "id": {
+          "type": {
+            "type": "named",
+            "name": "int8"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "custom_dog"
+      }
+    },
+    {
       "name": "v1_delete_spatial_ref_sys_by_srid",
       "description": "Delete any value on the spatial_ref_sys table using the srid key",
       "arguments": {
@@ -3485,6 +4256,246 @@ expression: result
           "type": {
             "type": "named",
             "name": "varchar"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "topology_topology"
+      }
+    },
+    {
+      "name": "v1_insert_Album",
+      "description": "Insert into the Album table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_Album_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "Album"
+      }
+    },
+    {
+      "name": "v1_insert_Artist",
+      "description": "Insert into the Artist table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_Artist_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "Artist"
+      }
+    },
+    {
+      "name": "v1_insert_Customer",
+      "description": "Insert into the Customer table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_Customer_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "Customer"
+      }
+    },
+    {
+      "name": "v1_insert_Employee",
+      "description": "Insert into the Employee table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_Employee_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "Employee"
+      }
+    },
+    {
+      "name": "v1_insert_Genre",
+      "description": "Insert into the Genre table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_Genre_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "Genre"
+      }
+    },
+    {
+      "name": "v1_insert_Invoice",
+      "description": "Insert into the Invoice table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_Invoice_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "Invoice"
+      }
+    },
+    {
+      "name": "v1_insert_InvoiceLine",
+      "description": "Insert into the InvoiceLine table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_InvoiceLine_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "InvoiceLine"
+      }
+    },
+    {
+      "name": "v1_insert_MediaType",
+      "description": "Insert into the MediaType table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_MediaType_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "MediaType"
+      }
+    },
+    {
+      "name": "v1_insert_Playlist",
+      "description": "Insert into the Playlist table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_Playlist_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "Playlist"
+      }
+    },
+    {
+      "name": "v1_insert_PlaylistTrack",
+      "description": "Insert into the PlaylistTrack table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_PlaylistTrack_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "PlaylistTrack"
+      }
+    },
+    {
+      "name": "v1_insert_Track",
+      "description": "Insert into the Track table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_Track_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "Track"
+      }
+    },
+    {
+      "name": "v1_insert_custom_dog",
+      "description": "Insert into the custom_dog table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_custom_dog_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "custom_dog"
+      }
+    },
+    {
+      "name": "v1_insert_spatial_ref_sys",
+      "description": "Insert into the spatial_ref_sys table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_spatial_ref_sys_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "spatial_ref_sys"
+      }
+    },
+    {
+      "name": "v1_insert_topology_layer",
+      "description": "Insert into the topology_layer table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_topology_layer_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "topology_layer"
+      }
+    },
+    {
+      "name": "v1_insert_topology_topology",
+      "description": "Insert into the topology_topology table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_topology_topology_object"
           }
         }
       },

--- a/crates/tests/databases-tests/src/yugabyte/query_tests.rs
+++ b/crates/tests/databases-tests/src/yugabyte/query_tests.rs
@@ -28,6 +28,18 @@ mod basic {
     }
 
     #[tokio::test]
+    async fn select_array_variable() {
+        let result = run_query(create_router().await, "select_array_variable").await;
+        insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test]
+    async fn select_array_variable_nested_types() {
+        let result = run_query(create_router().await, "select_array_variable_nested_types").await;
+        insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test]
     async fn select_int_and_string() {
         let result = run_query(create_router().await, "select_int_and_string").await;
         insta::assert_json_snapshot!(result);

--- a/crates/tests/databases-tests/src/yugabyte/snapshots/databases_tests__yugabyte__query_tests__basic__select_array_variable.snap
+++ b/crates/tests/databases-tests/src/yugabyte/snapshots/databases_tests__yugabyte__query_tests__basic__select_array_variable.snap
@@ -1,0 +1,20 @@
+---
+source: crates/tests/databases-tests/src/yugabyte/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": [
+      {
+        "result": 2
+      }
+    ]
+  },
+  {
+    "rows": [
+      {
+        "result": 3
+      }
+    ]
+  }
+]

--- a/crates/tests/databases-tests/src/yugabyte/snapshots/databases_tests__yugabyte__query_tests__basic__select_array_variable_nested_types.snap
+++ b/crates/tests/databases-tests/src/yugabyte/snapshots/databases_tests__yugabyte__query_tests__basic__select_array_variable_nested_types.snap
@@ -1,0 +1,26 @@
+---
+source: crates/tests/databases-tests/src/yugabyte/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": []
+  },
+  {
+    "rows": [
+      {
+        "result": "The organization Federation of United Solipsists has 1 committees, the largest of which has 1 members."
+      }
+    ]
+  },
+  {
+    "rows": [
+      {
+        "result": "The organization RC Model Airplane Enthusiasts has 2 committees, the largest of which has 3 members."
+      },
+      {
+        "result": "The organization Argonauts' Alumni Association has 1 committees, the largest of which has 4 members."
+      }
+    ]
+  }
+]

--- a/crates/tests/tests-common/goldenfiles/select_array_variable.json
+++ b/crates/tests/tests-common/goldenfiles/select_array_variable.json
@@ -1,0 +1,27 @@
+{
+  "collection": "count_elements",
+  "query": {
+    "fields": {
+      "result": {
+        "type": "column",
+        "column": "result",
+        "arguments": {}
+      }
+    }
+  },
+  "arguments": {
+    "array_argument": {
+      "type": "variable",
+      "name": "variable_array_argument"
+    }
+  },
+  "collection_relationships": {},
+  "variables": [
+    {
+      "variable_array_argument": ["one", "two"]
+    },
+    {
+      "variable_array_argument": ["one", "two", "three"]
+    }
+  ]
+}

--- a/crates/tests/tests-common/goldenfiles/select_array_variable_nested_types.json
+++ b/crates/tests/tests-common/goldenfiles/select_array_variable_nested_types.json
@@ -1,0 +1,107 @@
+{
+  "collection": "summarize_organizations",
+  "query": {
+    "fields": {
+      "result": {
+        "type": "column",
+        "column": "result",
+        "arguments": {}
+      }
+    }
+  },
+  "arguments": {
+    "organizations": {
+      "type": "variable",
+      "name": "variable_organizations"
+    }
+  },
+  "collection_relationships": {},
+  "variables": [
+    {
+      "variable_organizations": []
+    },
+    {
+      "variable_organizations": [
+        {
+          "name": "Federation of United Solipsists",
+          "committees": [
+            {
+              "name": "Positively existing entities",
+              "members": [
+                {
+                  "first_name": "Yo",
+                  "last_name": "El mismo"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "variable_organizations": [
+        {
+          "name": "RC Model Airplane Enthusiasts",
+          "committees": [
+            {
+              "name": "Founders",
+              "members": [
+                {
+                  "first_name": "Orville",
+                  "last_name": "Wright"
+                },
+                {
+                  "first_name": "Wilbur",
+                  "last_name": "Wright"
+                }
+              ]
+            },
+            {
+              "name": "Parts supply management",
+              "members": [
+                {
+                  "first_name": "Orville",
+                  "last_name": "Wright"
+                },
+                {
+                  "first_name": "Wilbur",
+                  "last_name": "Wright"
+                },
+                {
+                  "first_name": "Guybrush",
+                  "last_name": "Threepwood"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Argonauts' Alumni Association",
+          "committees": [
+            {
+              "name": "Crew",
+              "members": [
+                {
+                  "first_name": "Jason",
+                  "last_name": "(The)"
+                },
+                {
+                  "first_name": "Heracles",
+                  "last_name": "(The)"
+                },
+                {
+                  "first_name": "Castor",
+                  "last_name": "(The)"
+                },
+                {
+                  "first_name": "Polydeuces",
+                  "last_name": "(The)"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/static/aurora/v2-chinook-deployment-template.json
+++ b/static/aurora/v2-chinook-deployment-template.json
@@ -743,6 +743,50 @@
       }
     },
     "compositeTypes": {
+      "committee": {
+        "name": "committee",
+        "fields": {
+          "members": {
+            "name": "members",
+            "type": {
+              "arrayType": {
+                "scalarType": "text"
+              }
+            },
+            "description": null
+          },
+          "name": {
+            "name": "name",
+            "type": {
+              "scalarType": "text"
+            },
+            "description": null
+          }
+        },
+        "description": null
+      },
+      "organization": {
+        "name": "organization",
+        "fields": {
+          "members": {
+            "name": "committees",
+            "type": {
+              "arrayType": {
+                "compositeType": "committee"
+              }
+            },
+            "description": null
+          },
+          "name": {
+            "name": "name",
+            "type": {
+              "scalarType": "text"
+            },
+            "description": null
+          }
+        },
+        "description": null
+      },
       "person": {
         "name": "person",
         "fields": {
@@ -994,6 +1038,32 @@
         },
         "description": null
       },
+      "count_elements": {
+        "sql": "SELECT array_length({{array_argument}}, 1) as result",
+        "columns": {
+          "result": {
+            "name": "result",
+            "type": {
+              "scalarType": "int4"
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "arguments": {
+          "array_argument": {
+            "name": "array_argument",
+            "type": {
+              "arrayType": {
+                "scalarType": "text"
+              }
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "description": "A native query used to test support array-valued variables"
+      },
       "delete_playlist_track": {
         "sql": "DELETE FROM public.\"PlaylistTrack\" WHERE \"TrackId\" = {{track_id}} RETURNING *",
         "columns": {
@@ -1156,6 +1226,32 @@
           }
         },
         "description": "A native query used to test support for composite types"
+      },
+      "summarize_organizations": {
+        "sql": "SELECT 'The organization ' || org.name || ' has ' || no_committees::text || ' committees, ' || 'the largest of which has ' || max_members || ' members.' AS result FROM (SELECT orgs.* FROM unnest({{organizations}}) as orgs) AS org JOIN LATERAL ( SELECT count(committee.*) AS no_committees, max(members_agg.no_members) AS max_members FROM unnest(org.committees) AS committee JOIN LATERAL ( SELECT count(*) as no_members FROM unnest(committee.members) AS members) AS members_agg ON true) AS coms ON true",
+        "columns": {
+          "result": {
+            "name": "result",
+            "type": {
+              "scalarType": "text"
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "arguments": {
+          "organizations": {
+            "name": "organizations",
+            "type": {
+              "arrayType": {
+                "compositeType": "organization"
+              }
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "description": "A native query used to test support array-valued variables"
       },
       "value_types": {
         "sql": "SELECT {{bool}} as bool, {{int4}} as int4, {{int2}} as int2, {{int8}} as int8, {{float4}} as float4, {{float8}} as \"float8\", {{numeric}} as numeric, {{char}} as char, {{varchar}} as \"varchar\", {{text}} as text, {{date}} as date, {{time}} as time, {{timetz}} as timetz, {{timestamp}} as timestamp, {{timestamptz}} as timestamptz, {{uuid}} as uuid",

--- a/static/citus/v2-chinook-deployment.json
+++ b/static/citus/v2-chinook-deployment.json
@@ -727,6 +727,50 @@
       }
     },
     "compositeTypes": {
+      "committee": {
+        "name": "committee",
+        "fields": {
+          "members": {
+            "name": "members",
+            "type": {
+              "arrayType": {
+                "scalarType": "text"
+              }
+            },
+            "description": null
+          },
+          "name": {
+            "name": "name",
+            "type": {
+              "scalarType": "text"
+            },
+            "description": null
+          }
+        },
+        "description": null
+      },
+      "organization": {
+        "name": "organization",
+        "fields": {
+          "members": {
+            "name": "committees",
+            "type": {
+              "arrayType": {
+                "compositeType": "committee"
+              }
+            },
+            "description": null
+          },
+          "name": {
+            "name": "name",
+            "type": {
+              "scalarType": "text"
+            },
+            "description": null
+          }
+        },
+        "description": null
+      },
       "person": {
         "name": "person",
         "fields": {
@@ -978,6 +1022,32 @@
         },
         "description": null
       },
+      "count_elements": {
+        "sql": "SELECT array_length({{array_argument}}, 1) as result",
+        "columns": {
+          "result": {
+            "name": "result",
+            "type": {
+              "scalarType": "int4"
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "arguments": {
+          "array_argument": {
+            "name": "array_argument",
+            "type": {
+              "arrayType": {
+                "scalarType": "text"
+              }
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "description": "A native query used to test support array-valued variables"
+      },
       "delete_playlist_track": {
         "sql": "DELETE FROM public.\"PlaylistTrack\" WHERE \"TrackId\" = {{track_id}} RETURNING *",
         "columns": {
@@ -1140,6 +1210,32 @@
           }
         },
         "description": "A native query used to test support for composite types"
+      },
+      "summarize_organizations": {
+        "sql": "SELECT 'The organization ' || org.name || ' has ' || no_committees::text || ' committees, ' || 'the largest of which has ' || max_members || ' members.' AS result FROM (SELECT orgs.* FROM unnest({{organizations}}) as orgs) AS org JOIN LATERAL ( SELECT count(committee.*) AS no_committees, max(members_agg.no_members) AS max_members FROM unnest(org.committees) AS committee JOIN LATERAL ( SELECT count(*) as no_members FROM unnest(committee.members) AS members) AS members_agg ON true) AS coms ON true",
+        "columns": {
+          "result": {
+            "name": "result",
+            "type": {
+              "scalarType": "text"
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "arguments": {
+          "organizations": {
+            "name": "organizations",
+            "type": {
+              "arrayType": {
+                "compositeType": "organization"
+              }
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "description": "A native query used to test support array-valued variables"
       },
       "value_types": {
         "sql": "SELECT {{bool}} as bool, {{int4}} as int4, {{int2}} as int2, {{int8}} as int8, {{float4}} as float4, {{float8}} as \"float8\", {{numeric}} as numeric, {{char}} as char, {{varchar}} as \"varchar\", {{text}} as text, {{date}} as date, {{time}} as time, {{timetz}} as timetz, {{timestamp}} as timestamp, {{timestamptz}} as timestamptz, {{uuid}} as uuid",

--- a/static/cockroach/v2-chinook-deployment.json
+++ b/static/cockroach/v2-chinook-deployment.json
@@ -1007,6 +1007,32 @@
         },
         "description": null
       },
+      "count_elements": {
+        "sql": "SELECT array_length({{array_argument}}, 1) as result",
+        "columns": {
+          "result": {
+            "name": "result",
+            "type": {
+              "scalarType": "int4"
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "arguments": {
+          "array_argument": {
+            "name": "array_argument",
+            "type": {
+              "arrayType": {
+                "scalarType": "text"
+              }
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "description": "A native query used to test support array-valued variables"
+      },
       "delete_playlist_track": {
         "sql": "DELETE FROM public.\"PlaylistTrack\" WHERE \"TrackId\" = {{track_id}} RETURNING *",
         "columns": {

--- a/static/composite-types-complex.sql
+++ b/static/composite-types-complex.sql
@@ -7,3 +7,16 @@ CREATE TYPE person AS
     name person_name,
     address person_address
   );
+
+CREATE TYPE committee AS
+  (
+    name text,
+    members person_name[]
+  );
+
+CREATE TYPE organization AS
+  (
+    name text,
+    committees committee[]
+  );
+

--- a/static/postgres/v2-chinook-deployment.json
+++ b/static/postgres/v2-chinook-deployment.json
@@ -984,6 +984,50 @@
       }
     },
     "compositeTypes": {
+      "committee": {
+        "name": "committee",
+        "fields": {
+          "members": {
+            "name": "members",
+            "type": {
+              "arrayType": {
+                "scalarType": "text"
+              }
+            },
+            "description": null
+          },
+          "name": {
+            "name": "name",
+            "type": {
+              "scalarType": "text"
+            },
+            "description": null
+          }
+        },
+        "description": null
+      },
+      "organization": {
+        "name": "organization",
+        "fields": {
+          "members": {
+            "name": "committees",
+            "type": {
+              "arrayType": {
+                "compositeType": "committee"
+              }
+            },
+            "description": null
+          },
+          "name": {
+            "name": "name",
+            "type": {
+              "scalarType": "text"
+            },
+            "description": null
+          }
+        },
+        "description": null
+      },
       "person": {
         "name": "person",
         "fields": {
@@ -1235,6 +1279,32 @@
         },
         "description": null
       },
+      "count_elements": {
+        "sql": "SELECT array_length({{array_argument}}, 1) as result",
+        "columns": {
+          "result": {
+            "name": "result",
+            "type": {
+              "scalarType": "int4"
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "arguments": {
+          "array_argument": {
+            "name": "array_argument",
+            "type": {
+              "arrayType": {
+                "scalarType": "text"
+              }
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "description": "A native query used to test support array-valued variables"
+      },
       "delete_playlist_track": {
         "sql": "DELETE FROM public.\"PlaylistTrack\" WHERE \"TrackId\" = {{track_id}} RETURNING *",
         "columns": {
@@ -1397,6 +1467,32 @@
           }
         },
         "description": "A native query used to test support for composite types"
+      },
+      "summarize_organizations": {
+        "sql": "SELECT 'The organization ' || org.name || ' has ' || no_committees::text || ' committees, ' || 'the largest of which has ' || max_members || ' members.' AS result FROM (SELECT orgs.* FROM unnest({{organizations}}) as orgs) AS org JOIN LATERAL ( SELECT count(committee.*) AS no_committees, max(members_agg.no_members) AS max_members FROM unnest(org.committees) AS committee JOIN LATERAL ( SELECT count(*) as no_members FROM unnest(committee.members) AS members) AS members_agg ON true) AS coms ON true",
+        "columns": {
+          "result": {
+            "name": "result",
+            "type": {
+              "scalarType": "text"
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "arguments": {
+          "organizations": {
+            "name": "organizations",
+            "type": {
+              "arrayType": {
+                "compositeType": "organization"
+              }
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "description": "A native query used to test support array-valued variables"
       },
       "value_types": {
         "sql": "SELECT {{bool}} as bool, {{int4}} as int4, {{int2}} as int2, {{int8}} as int8, {{float4}} as float4, {{float8}} as \"float8\", {{numeric}} as numeric, {{char}} as char, {{varchar}} as \"varchar\", {{text}} as text, {{date}} as date, {{time}} as time, {{timetz}} as timetz, {{timestamp}} as timestamp, {{timestamptz}} as timestamptz, {{uuid}} as uuid",

--- a/static/yugabyte/v2-chinook-deployment.json
+++ b/static/yugabyte/v2-chinook-deployment.json
@@ -727,6 +727,50 @@
       }
     },
     "compositeTypes": {
+      "committee": {
+        "name": "committee",
+        "fields": {
+          "members": {
+            "name": "members",
+            "type": {
+              "arrayType": {
+                "scalarType": "text"
+              }
+            },
+            "description": null
+          },
+          "name": {
+            "name": "name",
+            "type": {
+              "scalarType": "text"
+            },
+            "description": null
+          }
+        },
+        "description": null
+      },
+      "organization": {
+        "name": "organization",
+        "fields": {
+          "members": {
+            "name": "committees",
+            "type": {
+              "arrayType": {
+                "compositeType": "committee"
+              }
+            },
+            "description": null
+          },
+          "name": {
+            "name": "name",
+            "type": {
+              "scalarType": "text"
+            },
+            "description": null
+          }
+        },
+        "description": null
+      },
       "person": {
         "name": "person",
         "fields": {
@@ -978,6 +1022,32 @@
         },
         "description": null
       },
+      "count_elements": {
+        "sql": "SELECT array_length({{array_argument}}, 1) as result",
+        "columns": {
+          "result": {
+            "name": "result",
+            "type": {
+              "scalarType": "int4"
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "arguments": {
+          "array_argument": {
+            "name": "array_argument",
+            "type": {
+              "arrayType": {
+                "scalarType": "text"
+              }
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "description": "A native query used to test support array-valued variables"
+      },
       "delete_playlist_track": {
         "sql": "DELETE FROM public.\"PlaylistTrack\" WHERE \"TrackId\" = {{track_id}} RETURNING *",
         "columns": {
@@ -1140,6 +1210,32 @@
           }
         },
         "description": "A native query used to test support for composite types"
+      },
+      "summarize_organizations": {
+        "sql": "SELECT 'The organization ' || org.name || ' has ' || no_committees::text || ' committees, ' || 'the largest of which has ' || max_members || ' members.' AS result FROM (SELECT orgs.* FROM unnest({{organizations}}) as orgs) AS org JOIN LATERAL ( SELECT count(committee.*) AS no_committees, max(members_agg.no_members) AS max_members FROM unnest(org.committees) AS committee JOIN LATERAL ( SELECT count(*) as no_members FROM unnest(committee.members) AS members) AS members_agg ON true) AS coms ON true",
+        "columns": {
+          "result": {
+            "name": "result",
+            "type": {
+              "scalarType": "text"
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "arguments": {
+          "organizations": {
+            "name": "organizations",
+            "type": {
+              "arrayType": {
+                "compositeType": "organization"
+              }
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "description": "A native query used to test support array-valued variables"
       },
       "value_types": {
         "sql": "SELECT {{bool}} as bool, {{int4}} as int4, {{int2}} as int2, {{int8}} as int8, {{float4}} as float4, {{float8}} as \"float8\", {{numeric}} as numeric, {{char}} as char, {{varchar}} as \"varchar\", {{text}} as text, {{date}} as date, {{time}} as time, {{timetz}} as timetz, {{timestamp}} as timestamp, {{timestamptz}} as timestamptz, {{uuid}} as uuid",


### PR DESCRIPTION
### What

This PR extends the support for query variables to include arrays.

### How

We need to go a bit out of our way to be able to translate JSON arrays to Postgres arrays, since there is no single builtin function that does this.

As an example taken from the tests, a variable of type array-of-`organization` gets translated to the below SQL:

```
(
  SELECT
    array_agg(
      jsonb_populate_record(cast(null as organization), "%0_arr"."elem")
    ) AS "elem"
  FROM
    jsonb_array_elements(("%0_%variables_table"."%variables" -> $2)) AS "%0_arr"("elem")
)

```

Which, being a single-element set-returning expression, can feature both in a `FROM` clause and in a select-list or other expression.