### PR TITLE
Unify code path for json value translation with variables

### DIFF
--- a/crates/query-engine/translation/src/translation/mutation/delete.rs
+++ b/crates/query-engine/translation/src/translation/mutation/delete.rs
@@ -83,7 +83,7 @@ pub fn translate_delete(
                 .get(&by_column.name)
                 .ok_or(Error::ArgumentNotFound(by_column.name.clone()))?;
 
-            let key_value = translate_json_value(unique_key, &by_column.r#type).unwrap();
+            let key_value = translate_json_value(state, unique_key, &by_column.r#type).unwrap();
 
             let table = ast::TableReference::DBTable {
                 schema: schema_name.clone(),

--- a/crates/query-engine/translation/src/translation/mutation/insert.rs
+++ b/crates/query-engine/translation/src/translation/mutation/insert.rs
@@ -42,7 +42,7 @@ pub fn generate(
 /// Given the description of an insert mutation (ie, `InsertMutation`),
 /// and the arguments, output the SQL AST.
 pub fn translate(
-    // state: &mut crate::translation::helpers::State,
+    state: &mut crate::translation::helpers::State,
     mutation: &InsertMutation,
     arguments: BTreeMap<String, serde_json::Value>,
 ) -> Result<ast::Insert, Error> {
@@ -64,7 +64,7 @@ pub fn translate(
                         ))?;
 
                 columns.push(ast::ColumnName(column_info.name.clone()));
-                values.push(translate_json_value(value, &column_info.r#type)?);
+                values.push(translate_json_value(state, value, &column_info.r#type)?);
             }
         }
         _ => todo!(),

--- a/crates/query-engine/translation/src/translation/mutation/translate.rs
+++ b/crates/query-engine/translation/src/translation/mutation/translate.rs
@@ -95,7 +95,9 @@ fn translate_mutation(
             let return_collection = insert.collection_name.clone();
             (
                 return_collection,
-                sql::ast::CTExpr::Insert(mutation::insert::translate(&insert, arguments)?),
+                sql::ast::CTExpr::Insert(mutation::insert::translate(
+                    &mut state, &insert, arguments,
+                )?),
             )
         }
     };

--- a/crates/query-engine/translation/src/translation/query/filtering.rs
+++ b/crates/query-engine/translation/src/translation/query/filtering.rs
@@ -375,7 +375,11 @@ fn translate_comparison_value(
             translate_comparison_target(env, state, root_and_current_tables, &column)
         }
         models::ComparisonValue::Scalar { value: json_value } => Ok((
-            values::translate_json_value(&json_value, &database::Type::ScalarType(typ.clone()))?,
+            values::translate_json_value(
+                state,
+                &json_value,
+                &database::Type::ScalarType(typ.clone()),
+            )?,
             vec![],
         )),
         models::ComparisonValue::Variable { name: var } => Ok((

--- a/crates/query-engine/translation/src/translation/query/native_queries.rs
+++ b/crates/query-engine/translation/src/translation/query/native_queries.rs
@@ -33,7 +33,7 @@ pub fn translate(env: &Env, state: State) -> Result<Vec<sql::ast::CommonTableExp
                         None => Err(Error::ArgumentNotFound(param.clone())),
                         Some(argument) => match argument {
                             models::Argument::Literal { value } => {
-                                values::translate_json_value(value, &typ)
+                                values::translate_json_value(&mut State::new(), value, &typ)
                             }
                             models::Argument::Variable { name } => match &variables_table {
                                 Err(err) => Err(err.clone()),

--- a/crates/query-engine/translation/tests/goldenfiles/select_array_column_nested_types/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/select_array_column_nested_types/request.json
@@ -1,0 +1,81 @@
+{
+  "collection": "summarize_organizations",
+  "query": {
+    "fields": {
+      "result": {
+        "type": "column",
+        "column": "result",
+        "arguments": {}
+      }
+    }
+  },
+  "arguments": {
+    "organizations": {
+      "type": "literal",
+      "value": [
+        {
+          "name": "RC Model Airplane Enthusiasts",
+          "committees": [
+            {
+              "name": "Founders",
+              "members": [
+                {
+                  "first_name": "Orville",
+                  "last_name": "Wright"
+                },
+                {
+                  "first_name": "Wilbur",
+                  "last_name": "Wright"
+                }
+              ]
+            },
+            {
+              "name": "Parts supply management",
+              "members": [
+                {
+                  "first_name": "Orville",
+                  "last_name": "Wright"
+                },
+                {
+                  "first_name": "Wilbur",
+                  "last_name": "Wright"
+                },
+                {
+                  "first_name": "Guybrush",
+                  "last_name": "Threepwood"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Argonauts' Alumni Association",
+          "committees": [
+            {
+              "name": "Crew",
+              "members": [
+                {
+                  "first_name": "Jason",
+                  "last_name": "(The)"
+                },
+                {
+                  "first_name": "Heracles",
+                  "last_name": "(The)"
+                },
+                {
+                  "first_name": "Castor",
+                  "last_name": "(The)"
+                },
+                {
+                  "first_name": "Polydeuces",
+                  "last_name": "(The)"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "collection_relationships": {}
+}

--- a/crates/query-engine/translation/tests/goldenfiles/select_array_column_nested_types/tables.json
+++ b/crates/query-engine/translation/tests/goldenfiles/select_array_column_nested_types/tables.json
@@ -58,7 +58,7 @@
   },
   "nativeQueries": {
     "summarize_organizations": {
-      "sql": "SELECT 'The organization ' || org.name || ' has ' || no_committees::text || ' committees, ' || 'the largest of which has ' || max_members || ' members.' AS result FROM (SELECT orgs.* FROM unnest({{organizations}}) AS orgs) AS org JOIN LATERAL ( SELECT count(committee.*) AS no_committees, max(members_agg.no_members) AS max_members FROM unnest(org.committees) AS committee JOIN LATERAL ( SELECT count(*) as no_members FROM unnest(committee.members) AS members) AS members_agg ON true) AS coms ON true",
+      "sql": "SELECT 'The organization ' || org.name || ' has ' || no_committees::text || ' committees, ' || 'the largest of which has ' || max_members || ' members.' AS result FROM (SELECT orgs.* FROM unnest({{organizations}}) as orgs) AS org JOIN LATERAL ( SELECT count(committee.*) AS no_committees, max(members_agg.no_members) AS max_members FROM unnest(org.committees) AS committee JOIN LATERAL ( SELECT count(*) as no_members FROM unnest(committee.members) AS members) AS members_agg ON true) AS coms ON true",
       "columns": {
         "result": {
           "name": "result",

--- a/crates/query-engine/translation/tests/snapshots/tests__select_array_column_nested_types.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_array_column_nested_types.snap
@@ -1,0 +1,58 @@
+---
+source: crates/query-engine/translation/tests/tests.rs
+expression: result
+---
+WITH "%1_NATIVE_QUERY_summarize_organizations" AS (
+  SELECT
+    'The organization ' || org.name || ' has ' || no_committees :: text || ' committees, ' || 'the largest of which has ' || max_members || ' members.' AS result
+  FROM
+    (
+      SELECT
+        orgs.*
+      FROM
+        unnest(
+          (
+            SELECT
+              array_agg(
+                jsonb_populate_record(cast(null as organization), "%0_array"."element")
+              ) AS "element"
+            FROM
+              jsonb_array_elements($1) AS "%0_array"("element")
+          )
+        ) as orgs
+    ) AS org
+    JOIN LATERAL (
+      SELECT
+        count(committee.*) AS no_committees,
+        max(members_agg.no_members) AS max_members
+      FROM
+        unnest(org.committees) AS committee
+        JOIN LATERAL (
+          SELECT
+            count(*) as no_members
+          FROM
+            unnest(committee.members) AS members
+        ) AS members_agg ON true
+    ) AS coms ON true
+)
+SELECT
+  coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
+FROM
+  (
+    SELECT
+      *
+    FROM
+      (
+        SELECT
+          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
+        FROM
+          (
+            SELECT
+              "%0_summarize_organizations"."result" AS "result"
+            FROM
+              "%1_NATIVE_QUERY_summarize_organizations" AS "%0_summarize_organizations"
+          ) AS "%3_rows"
+      ) AS "%3_rows"
+  ) AS "%2_universe"
+
+[(1, Value(Array [Object {"name": String("RC Model Airplane Enthusiasts"), "committees": Array [Object {"name": String("Founders"), "members": Array [Object {"first_name": String("Orville"), "last_name": String("Wright")}, Object {"first_name": String("Wilbur"), "last_name": String("Wright")}]}, Object {"name": String("Parts supply management"), "members": Array [Object {"first_name": String("Orville"), "last_name": String("Wright")}, Object {"first_name": String("Wilbur"), "last_name": String("Wright")}, Object {"first_name": String("Guybrush"), "last_name": String("Threepwood")}]}]}, Object {"name": String("Argonauts' Alumni Association"), "committees": Array [Object {"name": String("Crew"), "members": Array [Object {"first_name": String("Jason"), "last_name": String("(The)")}, Object {"first_name": String("Heracles"), "last_name": String("(The)")}, Object {"first_name": String("Castor"), "last_name": String("(The)")}, Object {"first_name": String("Polydeuces"), "last_name": String("(The)")}]}]}]))]

--- a/crates/query-engine/translation/tests/snapshots/tests__select_array_column_reverse.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_array_column_reverse.snap
@@ -11,32 +11,31 @@ WITH "%1_NATIVE_QUERY_array_reverse" AS (
         x
       FROM
         unnest(
-          cast(
-            ARRAY [cast($1 as varchar), cast($2 as varchar), cast($3 as varchar)] as varchar []
-          )
-        ) WITH ORDINALITY AS t(x, ix)
-      ORDER BY
-        t.ix DESC
-    )
-)
-SELECT
-  coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
-FROM
-  (
-    SELECT
-      *
-    FROM
-      (
-        SELECT
-          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
-        FROM
           (
             SELECT
-              "%0_array_reverse"."reversed" AS "reversed"
-            FROM
-              "%1_NATIVE_QUERY_array_reverse" AS "%0_array_reverse"
-          ) AS "%3_rows"
-      ) AS "%3_rows"
-  ) AS "%2_universe"
+              array_agg(
+                cast(
+                  (
+                    "%0_array"."element" #>> cast(ARRAY [] as text[])) as varchar)) AS "element" FROM jsonb_array_elements($1) AS "%0_array"("element"))) WITH ORDINALITY AS t(x,ix) ORDER BY t.ix DESC)
+                  )
+                  SELECT
+                    coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
+                  FROM
+                    (
+                      SELECT
+                        *
+                      FROM
+                        (
+                          SELECT
+                            coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
+                          FROM
+                            (
+                              SELECT
+                                "%0_array_reverse"."reversed" AS "reversed"
+                              FROM
+                                "%1_NATIVE_QUERY_array_reverse" AS "%0_array_reverse"
+                            ) AS "%3_rows"
+                        ) AS "%3_rows"
+                    ) AS "%2_universe"
 
-[(1, String("a")), (2, String("b")), (3, String("c"))]
+[(1, Value(Array [String("a"), String("b"), String("c")]))]

--- a/crates/query-engine/translation/tests/snapshots/tests__select_array_variable_nested_types.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_array_variable_nested_types.snap
@@ -28,7 +28,7 @@ FROM
                     FROM
                       jsonb_array_elements(("%0_%variables_table"."%variables" -> $2)) AS "%0_array"("element")
                   )
-                )
+                ) AS orgs
             ) AS org
             JOIN LATERAL (
               SELECT

--- a/crates/query-engine/translation/tests/tests.rs
+++ b/crates/query-engine/translation/tests/tests.rs
@@ -13,6 +13,12 @@ fn select_array_column() {
 }
 
 #[test]
+fn select_array_column_nested_types() {
+    let result = common::test_translation("select_array_column_nested_types").unwrap();
+    insta::assert_snapshot!(result);
+}
+
+#[test]
 fn select_array_variable() {
     let result = common::test_translation("select_array_variable").unwrap();
     insta::assert_snapshot!(result);

--- a/crates/tests/databases-tests/src/postgres/query_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/query_tests.rs
@@ -28,6 +28,12 @@ mod basic {
     }
 
     #[tokio::test]
+    async fn select_array_column_nested_types() {
+        let result = run_query(create_router().await, "select_array_column_nested_types").await;
+        insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test]
     async fn select_array_column_reverse() {
         let result = run_query(create_router().await, "select_array_column_reverse").await;
         insta::assert_json_snapshot!(result);

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__basic__select_array_column_nested_types.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__basic__select_array_column_nested_types.snap
@@ -1,0 +1,16 @@
+---
+source: crates/tests/databases-tests/src/postgres/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": [
+      {
+        "result": "The organization RC Model Airplane Enthusiasts has 2 committees, the largest of which has 3 members."
+      },
+      {
+        "result": "The organization Argonauts' Alumni Association has 1 committees, the largest of which has 4 members."
+      }
+    ]
+  }
+]

--- a/crates/tests/tests-common/goldenfiles/select_array_column_nested_types.json
+++ b/crates/tests/tests-common/goldenfiles/select_array_column_nested_types.json
@@ -1,0 +1,81 @@
+{
+  "collection": "summarize_organizations",
+  "query": {
+    "fields": {
+      "result": {
+        "type": "column",
+        "column": "result",
+        "arguments": {}
+      }
+    }
+  },
+  "arguments": {
+    "organizations": {
+      "type": "literal",
+      "value": [
+        {
+          "name": "RC Model Airplane Enthusiasts",
+          "committees": [
+            {
+              "name": "Founders",
+              "members": [
+                {
+                  "first_name": "Orville",
+                  "last_name": "Wright"
+                },
+                {
+                  "first_name": "Wilbur",
+                  "last_name": "Wright"
+                }
+              ]
+            },
+            {
+              "name": "Parts supply management",
+              "members": [
+                {
+                  "first_name": "Orville",
+                  "last_name": "Wright"
+                },
+                {
+                  "first_name": "Wilbur",
+                  "last_name": "Wright"
+                },
+                {
+                  "first_name": "Guybrush",
+                  "last_name": "Threepwood"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Argonauts' Alumni Association",
+          "committees": [
+            {
+              "name": "Crew",
+              "members": [
+                {
+                  "first_name": "Jason",
+                  "last_name": "(The)"
+                },
+                {
+                  "first_name": "Heracles",
+                  "last_name": "(The)"
+                },
+                {
+                  "first_name": "Castor",
+                  "last_name": "(The)"
+                },
+                {
+                  "first_name": "Polydeuces",
+                  "last_name": "(The)"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "collection_relationships": {}
+}


### PR DESCRIPTION
### What

Rather than having two different ways to translate values (depending on whether they are literals or variables) we instead use the same method in both cases.

### How

As a consequence we need to have the `State` available in literal value translation as well as in variable translation, which requires some follow-up changes in the various other translation functions.

We also duplicate the test of nested array types from the variables-case to the literal values-case.