### PR TITLE
Revert the connector reference for postgres-config-server E2E tests.

### DIFF
--- a/.github/workflows/ship.yaml
+++ b/.github/workflows/ship.yaml
@@ -162,7 +162,7 @@ jobs:
       - name: Dispatch Postgres Config Server E2E tests
         uses: aurelien-baudet/workflow-dispatch@v2
         with:
-          inputs: '{ "connector": "${{ steps.create-tag.outputs.docker_tag }}" }'
+          inputs: '{ "connector": "${{ github.sha }}" }'
           repo: hasura/v3-e2e-testing
           ref: main
           token: ${{ secrets.E2E_WORKFLOW_PAT }}


### PR DESCRIPTION
### What

I was a bit over-eager and overwrote this with the Docker tag. The config server tests do not need the Docker tag, they need the SHA, to clone the repository correctly.

### How

Reverted a line.