### PR TITLE
Use the new Postgres E2E stuff (sans Docker)

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -1,57 +1,36 @@
 name: E2E release compatibility
 
 on:
-  workflow_run:
-    workflows:
-      - deploy
-    types:
-      - completed
-    branches:
-      - main
+  merge_group:
+  push:
+  pull_request:
 
 jobs:
   end_to_end_release_compatibility:
-    name: Check PR against end-to-end tests
+    name: Postgres tests
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Install `just`
+        uses: extractions/setup-just@v1
 
-      # pull requests create a new merge commit so we have to work our way back
-      # to the actual commit so it matches the Docker image
-      - name: Generate short SHA
-        id: short-git-hash
-        run: |
-          if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
-            GITHUB_SHA=$(cat $GITHUB_EVENT_PATH | jq -r .pull_request.head.sha)
-          fi
-          echo "hash=$(git rev-parse --short=9 "$GITHUB_SHA")" >> $GITHUB_OUTPUT
-
-      - name: Dispatch Postgres E2E tests
-        uses: aurelien-baudet/workflow-dispatch@v2
+      - name: Check out `ndc-postgres`
+        uses: actions/checkout@v3
         with:
-          inputs: '{ "connector": "${{ steps.short-git-hash.outputs.hash }}" }'
-          repo: hasura/v3-e2e-testing
-          ref: main
-          token: ${{ secrets.E2E_WORKFLOW_PAT }}
-          workflow: "cargo test postgres"
+          repository: hasura/ndc-postgres
+          path: ndc-postgres
 
-      - name: Dispatch Postgres Config Server E2E tests
-        uses: aurelien-baudet/workflow-dispatch@v2
+      - name: Check out `v3-engine`
+        uses: actions/checkout@v3
         with:
-          inputs: '{ "connector": "${{ github.sha }}" }'
-          repo: hasura/v3-e2e-testing
-          ref: main
-          token: ${{ secrets.E2E_WORKFLOW_PAT }}
-          workflow: "cargo test postgres-config-server"
+          repository: hasura/v3-engine
+          path: v3-engine
 
-      - name: Report failures
-        if: always() && github.ref == 'refs/heads/main'
-        uses: ravsamhq/notify-slack-action@v2
+      - name: Check out `v3-e2e-testing`
+        uses: actions/checkout@v3
         with:
-          status: ${{ job.status }}
-          notify_when: failure
-          notification_title: "${{ github.actor }}, *nap time is over*! The following commit to <{repo_url}|{repo}> broke the end-to-end tests:"
-          message_format: "${{ github.event.head_commit.message }}"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.BROKEN_E2E_SLACK_WEBHOOK_URL }}
+          path: v3-e2e-testing
+
+      - name: Run the tests
+        run: just test-postgres-new
+        working-directory: v3-e2e-testing


### PR DESCRIPTION
Now [we don't need quite so much Docker](https://github.com/hasura/v3-e2e-testing/pull/167) to run the Postgres tests, we can check out the E2Es as a regular library and have a nice time.

This PR removes the workflow_run stuff from the Postgres job so that it can happen before the image has been deployed, and can thus happen as a PR-time check. This means we don't need the Slack bot anymore, as we can fail PRs that fail the E2Es.