### PR TITLE
Nix: Fix the build inputs for the shell and app.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,13 +83,15 @@
         formatter = pkgs.nixpkgs-fmt;
 
         devShells.default = pkgs.mkShell {
+          # include dependencies of the default package
+          inputsFrom = [ self.packages.${localSystem}.default ];
+
           # build-time inputs
           nativeBuildInputs = [
             # Development
             pkgs.just
             pkgs.nixpkgs-fmt
             pkgs.nodePackages.prettier
-            pkgs.pkg-config
 
             # Rust
             pkgs.cargo-edit
@@ -107,12 +109,6 @@
 
             # Deployment
             pkgs.skopeo
-          ];
-
-          # runtime inputs
-          buildInputs = [
-            pkgs.openssl
-            pkgs.protobuf
           ];
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -82,49 +82,51 @@
 
         formatter = pkgs.nixpkgs-fmt;
 
-        devShells.default = pkgs.mkShell {
-          # include dependencies of the default package
-          inputsFrom = [ self.packages.${localSystem}.default ];
+        devShells = {
+          default = pkgs.mkShell {
+            # include dependencies of the default package
+            inputsFrom = [ self.packages.${localSystem}.default ];
 
-          # build-time inputs
-          nativeBuildInputs = [
-            # Development
-            pkgs.just
-            pkgs.nixpkgs-fmt
-            pkgs.nodePackages.prettier
+            # build-time inputs
+            nativeBuildInputs = [
+              # Development
+              pkgs.just
+              pkgs.nixpkgs-fmt
+              pkgs.nodePackages.prettier
 
-            # Rust
-            pkgs.cargo-edit
-            pkgs.cargo-expand
-            pkgs.cargo-flamegraph
-            pkgs.cargo-insta
-            pkgs.cargo-machete
-            pkgs.cargo-nextest
-            pkgs.cargo-watch
-            pkgs.rnix-lsp
-            rust.rustToolchain
+              # Rust
+              pkgs.cargo-edit
+              pkgs.cargo-expand
+              pkgs.cargo-flamegraph
+              pkgs.cargo-insta
+              pkgs.cargo-machete
+              pkgs.cargo-nextest
+              pkgs.cargo-watch
+              pkgs.rnix-lsp
+              rust.rustToolchain
 
-            # Benchmarks
-            pkgs.k6
+              # Benchmarks
+              pkgs.k6
 
-            # Deployment
-            pkgs.skopeo
-          ];
-        };
+              # Deployment
+              pkgs.skopeo
+            ];
+          };
+        } // pkgs.lib.attrsets.optionalAttrs pkgs.hostPlatform.isLinux {
+          # This performance-testing shell will only work on Linux.
+          perf = pkgs.mkShell {
+            inputsFrom = [
+              self.devShells.${localSystem}.default
+            ];
 
-        # This performance-testing shell will only work on Linux.
-        devShells.perf = pkgs.mkShell {
-          inputsFrom = [
-            self.devShells.${localSystem}.default
-          ];
-
-          # build-time inputs
-          nativeBuildInputs = [
-            pkgs.heaptrack
-            pkgs.linuxPackages_latest.perf
-            pkgs.mold-wrapped
-            pkgs.valgrind
-          ];
+            # build-time inputs
+            nativeBuildInputs = [
+              pkgs.heaptrack
+              pkgs.linuxPackages_latest.perf
+              pkgs.mold-wrapped
+              pkgs.valgrind
+            ];
+          };
         };
       }
     );

--- a/nix/app.nix
+++ b/nix/app.nix
@@ -28,6 +28,7 @@ let
 
     buildInputs = [
       openssl # required for TLS connection to PostgreSQL
+      pkg-config # required to find OpenSSL
       protobuf # required by opentelemetry-proto, a dependency of axum-tracing-opentelemetry
     ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # macOS-specific dependencies

--- a/nix/app.nix
+++ b/nix/app.nix
@@ -1,7 +1,7 @@
 # This is a function that returns a derivation for the compiled Rust project.
 { craneLib
 , lib
-, stdenv
+, hostPlatform
 , openssl
 , libiconv
 , pkg-config
@@ -30,7 +30,7 @@ let
       openssl # required for TLS connection to PostgreSQL
       pkg-config # required to find OpenSSL
       protobuf # required by opentelemetry-proto, a dependency of axum-tracing-opentelemetry
-    ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    ] ++ lib.optionals hostPlatform.isDarwin [
       # macOS-specific dependencies
       libiconv
       darwin.apple_sdk.frameworks.CoreFoundation

--- a/nix/app.nix
+++ b/nix/app.nix
@@ -26,9 +26,14 @@ let
 
     strictDeps = true;
 
-    buildInputs = [
+    # build-time inputs
+    nativeBuildInputs = [
       openssl # required for TLS connection to PostgreSQL
       pkg-config # required to find OpenSSL
+    ];
+
+    # runtime inputs
+    buildInputs = [
       protobuf # required by opentelemetry-proto, a dependency of axum-tracing-opentelemetry
     ] ++ lib.optionals hostPlatform.isDarwin [
       # macOS-specific dependencies

--- a/nix/app.nix
+++ b/nix/app.nix
@@ -24,17 +24,17 @@ let
       in
       lib.cleanSourceWith { src = craneLib.path ./..; filter = isSourceFile; };
 
+    strictDeps = true;
+
     buildInputs = [
-      openssl
+      openssl # required for TLS connection to PostgreSQL
+      protobuf # required by opentelemetry-proto, a dependency of axum-tracing-opentelemetry
     ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # macOS-specific dependencies
       libiconv
+      darwin.apple_sdk.frameworks.CoreFoundation
       darwin.apple_sdk.frameworks.Security
       darwin.apple_sdk.frameworks.SystemConfiguration
-    ];
-
-    nativeBuildInputs = [
-      pkg-config # required for non-static builds
-      protobuf # required by opentelemetry-proto, a dependency of axum-tracing-opentelemetry
     ];
   };
 

--- a/nix/app.nix
+++ b/nix/app.nix
@@ -28,12 +28,13 @@ let
 
     # build-time inputs
     nativeBuildInputs = [
-      openssl # required for TLS connection to PostgreSQL
+      openssl.dev # required to build Rust crates that can conduct TLS connections
       pkg-config # required to find OpenSSL
     ];
 
     # runtime inputs
     buildInputs = [
+      openssl # required for TLS connections
       protobuf # required by opentelemetry-proto, a dependency of axum-tracing-opentelemetry
     ] ++ lib.optionals hostPlatform.isDarwin [
       # macOS-specific dependencies


### PR DESCRIPTION
This makes a few changes to the Nix flake to get things building on my machine.

1. On macOS, add `CoreFoundation` to the list of dependencies.
2. Adds `strictDeps = true` to the package, which means we need to add `openssl.dev` (and `pkg-config`) to `nativeBuildInputs` as they're required at build-time.
3. Move `openssl` and `protobuf` to `buildInputs` as they're required at runtime.
4. Reuse inputs from the default package in the shell.
5. Hide the `perf` shell from macOS so `nix flake check` works.

The last point is partially undoing a change I made earlier, where the shell brought in inputs from all flake checks. This was way too broad; this narrows it a lot.