### PR TITLE
Use the auth hook image rather than building it, for testing.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -208,7 +208,7 @@ services:
       COLLECTOR_ZIPKIN_HOST_PORT: "9411"
 
   auth-hook:
-    build: ${HGE_V3_DIRECTORY:-../v3-engine}/hasura-authn-webhook/dev-auth-webhook
+    image: ghcr.io/hasura/v3-dev-auth-webhook:latest
     init: true
     ports:
       - 3050:3050


### PR DESCRIPTION
### What

We build an auth hook for testing in CI; we can just reuse it here.

### How

Trivially.