### PR TITLE
Add a trait for `to_sql`.

### DIFF
--- a/crates/query-engine/sql/src/sql/execution_plan.rs
+++ b/crates/query-engine/sql/src/sql/execution_plan.rs
@@ -1,6 +1,7 @@
 //! Describe the SQL execution plan.
 
 use crate::sql;
+use crate::sql::convert::ToSql;
 
 use std::collections::BTreeMap;
 

--- a/crates/query-engine/sql/src/sql/helpers.rs
+++ b/crates/query-engine/sql/src/sql/helpers.rs
@@ -2,6 +2,8 @@
 
 use std::collections::BTreeMap;
 
+use crate::sql::convert::ToSql;
+
 use super::ast::*;
 use super::string;
 

--- a/crates/query-engine/translation/src/translation/mutation/delete.rs
+++ b/crates/query-engine/translation/src/translation/mutation/delete.rs
@@ -1,11 +1,13 @@
 //! Auto-generate delete mutations and translate them into sql ast.
 
-use crate::translation::error::Error;
-use crate::translation::query::values::translate_json_value;
+use std::collections::BTreeMap;
+
 use query_engine_metadata::metadata;
 use query_engine_metadata::metadata::database;
 use query_engine_sql::sql::ast;
-use std::collections::BTreeMap;
+
+use crate::translation::error::Error;
+use crate::translation::query::values::translate_json_value;
 
 /// A representation of an auto-generated delete mutation.
 ///
@@ -119,13 +121,17 @@ pub fn translate_delete(
 
 #[cfg(test)]
 mod tests {
-    use super::ast;
-    use super::DeleteMutation;
+    use std::collections::BTreeMap;
+
+    use query_engine_metadata::metadata;
+    use query_engine_sql::sql::convert::ToSql;
+    use query_engine_sql::sql::string;
+
     use crate::translation::helpers::State;
     use crate::translation::mutation::delete::translate_delete;
-    use query_engine_metadata::metadata;
-    use query_engine_sql::sql::string;
-    use std::collections::BTreeMap;
+
+    use super::ast;
+    use super::DeleteMutation;
 
     fn sample_delete() -> DeleteMutation {
         DeleteMutation::DeleteByKey {


### PR DESCRIPTION
### What

This allows us to implement `to_sql` on types from a different package.

This is required to move `IsolationLevel` to a shared library, in order to stop `ndc-postgres-configuration` from depending on the entire `query-engine-sql` crate.

### How

We introduce the `ToSql` trait for all `fn to_sql` implementations. This means we need to import the trait in a few places.

This is only used in one place outside the `query-engine-sql` crate, in a snapshot test. I think this is probably a sign of a leaky abstraction, but I couldn't fix it quickly and it didn't seem like it should stop me from making this change.