### PR TITLE
Break dependencies through copying and pasting.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,7 +1513,6 @@ version = "0.1.0"
 dependencies = [
  "ndc-sdk",
  "query-engine-metadata",
- "query-engine-sql",
  "schemars",
  "serde",
  "serde_json",

--- a/crates/configuration/Cargo.toml
+++ b/crates/configuration/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 query-engine-metadata = { path = "../query-engine/metadata" }
-query-engine-sql = { path = "../query-engine/sql" }
 
 ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "3b6c480" }
 

--- a/crates/configuration/src/configuration.rs
+++ b/crates/configuration/src/configuration.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 use ndc_sdk::connector;
 
 use query_engine_metadata::metadata;
-use query_engine_sql::sql::ast::transaction::IsolationLevel;
 
 use crate::custom_trait_implementations::RawConfigurationCompat;
 use crate::version1;
@@ -80,7 +79,7 @@ pub struct RuntimeConfiguration {
     pub metadata: metadata::Metadata,
     pub pool_settings: version1::PoolSettings,
     pub connection_uri: String,
-    pub isolation_level: IsolationLevel,
+    pub isolation_level: version2::IsolationLevel,
     pub mutations_version: Option<metadata::mutations::MutationsVersion>,
 }
 
@@ -93,7 +92,7 @@ pub fn as_runtime_configuration(config: &Configuration) -> RuntimeConfiguration 
             connection_uri: match &v1_config.connection_uri {
                 version1::ConnectionUri::Uri(version1::ResolvedSecret(uri)) => uri.clone(),
             },
-            isolation_level: IsolationLevel::default(),
+            isolation_level: version2::IsolationLevel::default(),
             mutations_version: None,
         },
         RawConfiguration::Version2(v2_config) => RuntimeConfiguration {

--- a/crates/configuration/src/lib.rs
+++ b/crates/configuration/src/lib.rs
@@ -7,4 +7,6 @@ pub use configuration::{
     as_runtime_configuration, configure, set_connection_uri, validate_raw_configuration,
     Configuration, RawConfiguration, RuntimeConfiguration,
 };
-pub use version2::{occurring_scalar_types, ConnectionUri, PoolSettings, ResolvedSecret};
+pub use version2::{
+    occurring_scalar_types, ConnectionUri, IsolationLevel, PoolSettings, ResolvedSecret,
+};

--- a/crates/configuration/src/version2.rs
+++ b/crates/configuration/src/version2.rs
@@ -11,10 +11,8 @@ use tracing::{info_span, Instrument};
 use ndc_sdk::connector;
 
 use query_engine_metadata::metadata;
-use query_engine_sql::sql::ast::transaction::IsolationLevel;
 
 use crate::version1;
-
 pub use version1::{ConnectionUri, PoolSettings, ResolvedSecret};
 
 const CONFIGURATION_QUERY: &str = include_str!("version2.sql");
@@ -61,6 +59,20 @@ pub fn default_unqualified_schemas_for_types_and_procedures() -> Vec<String> {
         "pg_catalog".to_string(),
         "tiger".to_string(),
     ]
+}
+
+/// The isolation level of the transaction in which a query is executed.
+#[derive(
+    Debug, Clone, Copy, Default, serde::Deserialize, serde::Serialize, schemars::JsonSchema,
+)]
+pub enum IsolationLevel {
+    /// Prevents reading data from another uncommitted transaction.
+    #[default]
+    ReadCommitted,
+    /// Reading the same data twice is guaranteed to return the same result.
+    RepeatableRead,
+    /// Concurrent transactions behave identically to serializing them one at a time.
+    Serializable,
 }
 
 /// Options which only influence how the configuration server updates the configuration

--- a/crates/connectors/ndc-postgres/src/configuration_mapping.rs
+++ b/crates/connectors/ndc-postgres/src/configuration_mapping.rs
@@ -1,3 +1,8 @@
+//! A module for converting ndc-configuration data type into query-engine data types.
+
+/// Convert a user-specified configuration of the isolation level for transactions
+/// into a SQL data type representing that isolation level, which will be passed
+/// to the engine on requests.
 pub(crate) fn convert_isolation_level(
     input: ndc_postgres_configuration::IsolationLevel,
 ) -> query_engine_sql::sql::ast::transaction::IsolationLevel {

--- a/crates/connectors/ndc-postgres/src/configuration_mapping.rs
+++ b/crates/connectors/ndc-postgres/src/configuration_mapping.rs
@@ -1,0 +1,15 @@
+pub(crate) fn convert_isolation_level(
+    input: ndc_postgres_configuration::IsolationLevel,
+) -> query_engine_sql::sql::ast::transaction::IsolationLevel {
+    match input {
+        ndc_postgres_configuration::IsolationLevel::ReadCommitted => {
+            query_engine_sql::sql::ast::transaction::IsolationLevel::ReadCommitted
+        }
+        ndc_postgres_configuration::IsolationLevel::RepeatableRead => {
+            query_engine_sql::sql::ast::transaction::IsolationLevel::RepeatableRead
+        }
+        ndc_postgres_configuration::IsolationLevel::Serializable => {
+            query_engine_sql::sql::ast::transaction::IsolationLevel::Serializable
+        }
+    }
+}

--- a/crates/connectors/ndc-postgres/src/explain.rs
+++ b/crates/connectors/ndc-postgres/src/explain.rs
@@ -14,6 +14,7 @@ use query_engine_translation::translation;
 
 use ndc_postgres_configuration as configuration;
 
+use super::configuration_mapping;
 use super::state;
 
 /// Explain a query by creating an execution plan
@@ -93,7 +94,7 @@ fn plan_query(
     let timer = state.metrics.time_query_plan();
     let result = translation::query::translate(
         &configuration.metadata,
-        configuration.isolation_level,
+        configuration_mapping::convert_isolation_level(configuration.isolation_level),
         query_request,
     )
     .map_err(|err| {

--- a/crates/connectors/ndc-postgres/src/lib.rs
+++ b/crates/connectors/ndc-postgres/src/lib.rs
@@ -1,6 +1,7 @@
 //! A Hasura v3 PostgreSQL Native Data Connector.
 
 pub mod capabilities;
+pub mod configuration_mapping;
 pub mod connector;
 pub mod explain;
 pub mod health;

--- a/crates/connectors/ndc-postgres/src/mutation.rs
+++ b/crates/connectors/ndc-postgres/src/mutation.rs
@@ -14,6 +14,7 @@ use query_engine_translation::translation;
 
 use ndc_postgres_configuration as configuration;
 
+use super::configuration_mapping;
 use super::state;
 
 /// Execute a mutation
@@ -91,7 +92,7 @@ fn plan_mutation(
         })
         .collect::<Result<Vec<_>, connector::MutationError>>()?;
     timer.complete_with(Ok(sql::execution_plan::simple_mutations_execution_plan(
-        configuration.isolation_level,
+        configuration_mapping::convert_isolation_level(configuration.isolation_level),
         mutations,
     )))
 }

--- a/crates/connectors/ndc-postgres/src/query.rs
+++ b/crates/connectors/ndc-postgres/src/query.rs
@@ -13,6 +13,7 @@ use ndc_postgres_configuration as configuration;
 use query_engine_sql::sql;
 use query_engine_translation::translation;
 
+use super::configuration_mapping;
 use super::state;
 
 /// Execute a query
@@ -58,7 +59,7 @@ fn plan_query(
     let timer = state.metrics.time_query_plan();
     let result = translation::query::translate(
         &configuration.metadata,
-        configuration.isolation_level,
+        configuration_mapping::convert_isolation_level(configuration.isolation_level),
         query_request,
     )
     .map_err(|err| {

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__configuration_tests__get_configuration_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__configuration_tests__get_configuration_schema.snap
@@ -958,12 +958,29 @@ expression: schema
       }
     },
     "IsolationLevel": {
-      "description": "The isolation level of transactions",
-      "type": "string",
-      "enum": [
-        "ReadCommitted",
-        "RepeatableRead",
-        "Serializable"
+      "description": "The isolation level of the transaction in which a query is executed.",
+      "oneOf": [
+        {
+          "description": "Prevents reading data from another uncommitted transaction.",
+          "type": "string",
+          "enum": [
+            "ReadCommitted"
+          ]
+        },
+        {
+          "description": "Reading the same data twice is guaranteed to return the same result.",
+          "type": "string",
+          "enum": [
+            "RepeatableRead"
+          ]
+        },
+        {
+          "description": "Concurrent transactions behave identically to serializing them one at a time.",
+          "type": "string",
+          "enum": [
+            "Serializable"
+          ]
+        }
       ]
     },
     "Metadata2": {

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__configuration_tests__get_rawconfiguration_v2_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__configuration_tests__get_rawconfiguration_v2_schema.snap
@@ -369,12 +369,29 @@ expression: schema
       }
     },
     "IsolationLevel": {
-      "description": "The isolation level of transactions",
-      "type": "string",
-      "enum": [
-        "ReadCommitted",
-        "RepeatableRead",
-        "Serializable"
+      "description": "The isolation level of the transaction in which a query is executed.",
+      "oneOf": [
+        {
+          "description": "Prevents reading data from another uncommitted transaction.",
+          "type": "string",
+          "enum": [
+            "ReadCommitted"
+          ]
+        },
+        {
+          "description": "Reading the same data twice is guaranteed to return the same result.",
+          "type": "string",
+          "enum": [
+            "RepeatableRead"
+          ]
+        },
+        {
+          "description": "Concurrent transactions behave identically to serializing them one at a time.",
+          "type": "string",
+          "enum": [
+            "Serializable"
+          ]
+        }
       ]
     },
     "Metadata": {

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__openapi_tests__openapi__up_to_date_generated_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__openapi_tests__openapi__up_to_date_generated_schema.snap
@@ -934,12 +934,29 @@ expression: generated_schema_json
       }
     },
     "IsolationLevel": {
-      "description": "The isolation level of transactions",
-      "type": "string",
-      "enum": [
-        "ReadCommitted",
-        "RepeatableRead",
-        "Serializable"
+      "description": "The isolation level of the transaction in which a query is executed.",
+      "oneOf": [
+        {
+          "description": "Prevents reading data from another uncommitted transaction.",
+          "type": "string",
+          "enum": [
+            "ReadCommitted"
+          ]
+        },
+        {
+          "description": "Reading the same data twice is guaranteed to return the same result.",
+          "type": "string",
+          "enum": [
+            "RepeatableRead"
+          ]
+        },
+        {
+          "description": "Concurrent transactions behave identically to serializing them one at a time.",
+          "type": "string",
+          "enum": [
+            "Serializable"
+          ]
+        }
       ]
     },
     "Metadata2": {


### PR DESCRIPTION
### What

`ndc-postgres-configuration` had a dependency on `query-engine-sql` simply to use the `IsolationLevel` enum. This dependency is otherwise unnecessary and quite large.

### How

I have copied this enum into the configuration so that we can avoid this large dependency.

Of course, now we have two, so I've added a function inside the connector crate to convert from one to the other.

I have also improved the OpenAPI documentation on the `IsolationLevel` enum somewhat.
