### PR TITLE
Borrow more when constructing `RuntimeConfiguration`.

### DIFF
--- a/crates/configuration/src/configuration.rs
+++ b/crates/configuration/src/configuration.rs
@@ -75,34 +75,34 @@ pub async fn validate_raw_configuration(
 /// since it consists of a sub-selection of components from the full Configuration, the fields are
 /// borrowed rather than owned.
 #[derive(Debug)]
-pub struct RuntimeConfiguration {
+pub struct RuntimeConfiguration<'request> {
     pub metadata: metadata::Metadata,
-    pub pool_settings: version1::PoolSettings,
-    pub connection_uri: String,
+    pub pool_settings: &'request version2::PoolSettings,
+    pub connection_uri: &'request str,
     pub isolation_level: version2::IsolationLevel,
     pub mutations_version: Option<metadata::mutations::MutationsVersion>,
 }
 
 /// Apply the common interpretations on the Configuration API type into an RuntimeConfiguration.
-pub fn as_runtime_configuration(config: &Configuration) -> RuntimeConfiguration {
+pub fn as_runtime_configuration(config: &Configuration) -> RuntimeConfiguration<'_> {
     match &config.config {
         RawConfiguration::Version1(v1_config) => RuntimeConfiguration {
             metadata: version1::metadata_to_current(&v1_config.metadata),
-            pool_settings: v1_config.pool_settings.clone(),
+            pool_settings: &v1_config.pool_settings,
             connection_uri: match &v1_config.connection_uri {
-                version1::ConnectionUri::Uri(version1::ResolvedSecret(uri)) => uri.clone(),
+                version1::ConnectionUri::Uri(version1::ResolvedSecret(uri)) => uri,
             },
             isolation_level: version2::IsolationLevel::default(),
             mutations_version: None,
         },
         RawConfiguration::Version2(v2_config) => RuntimeConfiguration {
             metadata: v2_config.metadata.clone(),
-            pool_settings: v2_config.pool_settings.clone(),
+            pool_settings: &v2_config.pool_settings,
             connection_uri: match &v2_config.connection_uri {
-                version2::ConnectionUri::Uri(version2::ResolvedSecret(uri)) => uri.clone(),
+                version2::ConnectionUri::Uri(version2::ResolvedSecret(uri)) => uri,
             },
             isolation_level: v2_config.isolation_level,
-            mutations_version: v2_config.configure_options.mutations_version.clone(),
+            mutations_version: v2_config.configure_options.mutations_version,
         },
     }
 }

--- a/crates/configuration/src/configuration.rs
+++ b/crates/configuration/src/configuration.rs
@@ -88,23 +88,23 @@ pub struct RuntimeConfiguration<'request> {
 /// Apply the common interpretations on the Configuration API type into an RuntimeConfiguration.
 pub fn as_runtime_configuration(config: &Configuration) -> RuntimeConfiguration<'_> {
     match &config.config {
-        RawConfiguration::Version1(v1_config) => RuntimeConfiguration {
-            metadata: Cow::Owned(version1::metadata_to_current(&v1_config.metadata)),
-            pool_settings: &v1_config.pool_settings,
-            connection_uri: match &v1_config.connection_uri {
+        RawConfiguration::Version1(v1) => RuntimeConfiguration {
+            metadata: Cow::Owned(version1::metadata_to_current(&v1.metadata)),
+            pool_settings: &v1.pool_settings,
+            connection_uri: match &v1.connection_uri {
                 version1::ConnectionUri::Uri(version1::ResolvedSecret(uri)) => uri,
             },
             isolation_level: version2::IsolationLevel::default(),
             mutations_version: None,
         },
-        RawConfiguration::Version2(v2_config) => RuntimeConfiguration {
-            metadata: Cow::Borrowed(&v2_config.metadata),
-            pool_settings: &v2_config.pool_settings,
-            connection_uri: match &v2_config.connection_uri {
+        RawConfiguration::Version2(v2) => RuntimeConfiguration {
+            metadata: Cow::Borrowed(&v2.metadata),
+            pool_settings: &v2.pool_settings,
+            connection_uri: match &v2.connection_uri {
                 version2::ConnectionUri::Uri(version2::ResolvedSecret(uri)) => uri,
             },
-            isolation_level: v2_config.isolation_level,
-            mutations_version: v2_config.configure_options.mutations_version,
+            isolation_level: v2.isolation_level,
+            mutations_version: v2.configure_options.mutations_version,
         },
     }
 }

--- a/crates/connectors/ndc-postgres/src/connector.rs
+++ b/crates/connectors/ndc-postgres/src/connector.rs
@@ -90,8 +90,8 @@ impl connector::Connector for Postgres {
         let runtime_configuration = configuration::as_runtime_configuration(configuration);
 
         state::create_state(
-            &runtime_configuration.connection_uri,
-            &runtime_configuration.pool_settings,
+            runtime_configuration.connection_uri,
+            runtime_configuration.pool_settings,
             metrics,
         )
         .instrument(info_span!("Initialise state"))
@@ -163,7 +163,7 @@ impl connector::Connector for Postgres {
         configuration: &Self::Configuration,
     ) -> Result<JsonResponse<models::SchemaResponse>, connector::SchemaError> {
         let runtime_configuration = configuration::as_runtime_configuration(configuration);
-        schema::get_schema(&runtime_configuration)
+        schema::get_schema(runtime_configuration)
             .await
             .map_err(|err| {
                 tracing::error!(
@@ -189,7 +189,7 @@ impl connector::Connector for Postgres {
         query_request: models::QueryRequest,
     ) -> Result<JsonResponse<models::ExplainResponse>, connector::ExplainError> {
         let runtime_configuration = configuration::as_runtime_configuration(configuration);
-        explain::explain(&runtime_configuration, state, query_request)
+        explain::explain(runtime_configuration, state, query_request)
             .await
             .map_err(|err| {
                 tracing::error!(
@@ -215,7 +215,7 @@ impl connector::Connector for Postgres {
         request: models::MutationRequest,
     ) -> Result<JsonResponse<models::MutationResponse>, connector::MutationError> {
         let runtime_configuration = configuration::as_runtime_configuration(configuration);
-        mutation::mutation(&runtime_configuration, state, request)
+        mutation::mutation(runtime_configuration, state, request)
             .await
             .map_err(|err| {
                 tracing::error!(
@@ -240,7 +240,7 @@ impl connector::Connector for Postgres {
         query_request: models::QueryRequest,
     ) -> Result<JsonResponse<models::QueryResponse>, connector::QueryError> {
         let runtime_configuration = configuration::as_runtime_configuration(configuration);
-        query::query(&runtime_configuration, state, query_request)
+        query::query(runtime_configuration, state, query_request)
             .await
             .map_err(|err| {
                 tracing::error!(

--- a/crates/connectors/ndc-postgres/src/explain.rs
+++ b/crates/connectors/ndc-postgres/src/explain.rs
@@ -21,8 +21,8 @@ use super::state;
 ///
 /// This function implements the [explain endpoint](https://hasura.github.io/ndc-spec/specification/explain.html)
 /// from the NDC specification.
-pub async fn explain<'a>(
-    configuration: &configuration::RuntimeConfiguration,
+pub async fn explain(
+    configuration: configuration::RuntimeConfiguration<'_>,
     state: &state::State,
     query_request: models::QueryRequest,
 ) -> Result<models::ExplainResponse, connector::ExplainError> {
@@ -86,7 +86,7 @@ pub async fn explain<'a>(
 }
 
 fn plan_query(
-    configuration: &configuration::RuntimeConfiguration,
+    configuration: configuration::RuntimeConfiguration<'_>,
     state: &state::State,
     query_request: models::QueryRequest,
 ) -> Result<sql::execution_plan::ExecutionPlan<sql::execution_plan::Query>, connector::ExplainError>

--- a/crates/connectors/ndc-postgres/src/mutation.rs
+++ b/crates/connectors/ndc-postgres/src/mutation.rs
@@ -21,8 +21,8 @@ use super::state;
 ///
 /// This function implements the [mutation endpoint](https://hasura.github.io/ndc-spec/specification/mutations/index.html)
 /// from the NDC specification.
-pub async fn mutation<'a>(
-    configuration: &configuration::RuntimeConfiguration,
+pub async fn mutation(
+    configuration: configuration::RuntimeConfiguration<'_>,
     state: &state::State,
     request: models::MutationRequest,
 ) -> Result<JsonResponse<models::MutationResponse>, connector::MutationError> {
@@ -53,7 +53,7 @@ pub async fn mutation<'a>(
 }
 
 fn plan_mutation(
-    configuration: &configuration::RuntimeConfiguration,
+    configuration: configuration::RuntimeConfiguration<'_>,
     state: &state::State,
     request: models::MutationRequest,
 ) -> Result<

--- a/crates/connectors/ndc-postgres/src/mutation.rs
+++ b/crates/connectors/ndc-postgres/src/mutation.rs
@@ -69,7 +69,7 @@ fn plan_mutation(
                 &configuration.metadata,
                 operation,
                 request.collection_relationships.clone(),
-                &configuration.mutations_version,
+                configuration.mutations_version,
             )
             .map_err(|err| {
                 tracing::error!("{}", err);

--- a/crates/connectors/ndc-postgres/src/query.rs
+++ b/crates/connectors/ndc-postgres/src/query.rs
@@ -20,8 +20,8 @@ use super::state;
 ///
 /// This function implements the [query endpoint](https://hasura.github.io/ndc-spec/specification/queries/index.html)
 /// from the NDC specification.
-pub async fn query<'a>(
-    configuration: &configuration::RuntimeConfiguration,
+pub async fn query(
+    configuration: configuration::RuntimeConfiguration<'_>,
     state: &state::State,
     query_request: models::QueryRequest,
 ) -> Result<JsonResponse<models::QueryResponse>, connector::QueryError> {
@@ -52,7 +52,7 @@ pub async fn query<'a>(
 }
 
 fn plan_query(
-    configuration: &configuration::RuntimeConfiguration,
+    configuration: configuration::RuntimeConfiguration<'_>,
     state: &state::State,
     query_request: models::QueryRequest,
 ) -> Result<sql::execution_plan::ExecutionPlan<sql::execution_plan::Query>, connector::QueryError> {

--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -17,7 +17,7 @@ use query_engine_translation::translation::mutation::{delete, generate, insert};
 /// This function implements the [schema endpoint](https://hasura.github.io/ndc-spec/specification/schema/index.html)
 /// from the NDC specification.
 pub async fn get_schema(
-    config: &configuration::RuntimeConfiguration,
+    config: configuration::RuntimeConfiguration<'_>,
 ) -> Result<models::SchemaResponse, connector::SchemaError> {
     let configuration::RuntimeConfiguration { metadata, .. } = config;
 

--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -257,7 +257,7 @@ pub async fn get_schema(
     let generated_procedures: Vec<models::ProcedureInfo> =
         query_engine_translation::translation::mutation::generate::generate(
             &metadata.tables,
-            &config.mutations_version,
+            config.mutations_version,
         )
         .iter()
         .map(|(name, mutation)| mutation_to_procedure(name, mutation, &mut more_object_types))

--- a/crates/query-engine/metadata/src/metadata/mutations.rs
+++ b/crates/query-engine/metadata/src/metadata/mutations.rs
@@ -4,7 +4,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Which version of the generated mutations will be included in the schema
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum MutationsVersion {
     V1,

--- a/crates/query-engine/translation/src/translation/helpers.rs
+++ b/crates/query-engine/translation/src/translation/helpers.rs
@@ -10,10 +10,10 @@ use query_engine_sql::sql;
 
 #[derive(Debug)]
 /// Static information from the query and metadata.
-pub struct Env<'a> {
-    metadata: &'a metadata::Metadata,
+pub struct Env<'request> {
+    metadata: &'request metadata::Metadata,
     relationships: BTreeMap<String, models::Relationship>,
-    mutations_version: &'a Option<metadata::mutations::MutationsVersion>,
+    mutations_version: Option<metadata::mutations::MutationsVersion>,
     variables_table: Option<sql::ast::TableReference>,
 }
 
@@ -88,14 +88,14 @@ pub enum CollectionInfo {
     },
 }
 
-impl<'a> Env<'a> {
+impl<'request> Env<'request> {
     /// Create a new Env by supplying the metadata and relationships.
     pub fn new(
-        metadata: &'a metadata::Metadata,
+        metadata: &'request metadata::Metadata,
         relationships: BTreeMap<String, models::Relationship>,
-        mutations_version: &'a Option<metadata::mutations::MutationsVersion>,
+        mutations_version: Option<metadata::mutations::MutationsVersion>,
         variables_table: Option<sql::ast::TableReference>,
-    ) -> Env<'a> {
+    ) -> Self {
         Env {
             metadata,
             relationships,
@@ -173,7 +173,7 @@ impl<'a> Env<'a> {
         &self,
         scalar_type: &metadata::ScalarType,
         name: &String,
-    ) -> Result<&'a metadata::ComparisonOperator, Error> {
+    ) -> Result<&'request metadata::ComparisonOperator, Error> {
         self.metadata
             .comparison_operators
             .0

--- a/crates/query-engine/translation/src/translation/mutation/translate.rs
+++ b/crates/query-engine/translation/src/translation/mutation/translate.rs
@@ -17,7 +17,7 @@ pub fn translate(
     metadata: &metadata::Metadata,
     operation: models::MutationOperation,
     collection_relationships: BTreeMap<String, models::Relationship>,
-    mutations_version: &Option<metadata::mutations::MutationsVersion>,
+    mutations_version: Option<metadata::mutations::MutationsVersion>,
 ) -> Result<sql::execution_plan::Mutation, Error> {
     let env = Env::new(metadata, collection_relationships, mutations_version, None);
 

--- a/crates/query-engine/translation/src/translation/query/mod.rs
+++ b/crates/query-engine/translation/src/translation/query/mod.rs
@@ -27,7 +27,7 @@ pub fn translate(
     let env = Env::new(
         metadata,
         query_request.collection_relationships,
-        &None,
+        None,
         variables_table_ref,
     );
     let (current_table, from_clause) = root::make_from_clause_and_reference(

--- a/crates/query-engine/translation/tests/common/mod.rs
+++ b/crates/query-engine/translation/tests/common/mod.rs
@@ -98,7 +98,7 @@ pub fn test_mutation_translation(
                 &tables,
                 operation,
                 request.collection_relationships.clone(),
-                &Some(query_engine_metadata::metadata::mutations::MutationsVersion::V1),
+                Some(query_engine_metadata::metadata::mutations::MutationsVersion::V1),
             )
         })
         .collect::<Result<Vec<_>, translation::error::Error>>()?;


### PR DESCRIPTION
### What

The documentation for `RuntimeConfiguration` states that it borrows whenever possible, which was false. I have made some changes to borrow (or copy, if copying is cheap) all fields.

### How

I introduced the `'request` lifetime and annotated fields with it. The metadata might be borrowed, or it might be converted from a v1 metadata, so this is wrapped in a `Cow` to abstract over this.

When possible, we now pass around a `RuntimeConfiguration` by value rather than by reference.

I also added `Copy` to `MutationsVersion` so that we can freely pass it around without having to worry about borrowing. `IsolationLevel` already implements `Copy`.