### PR TITLE
CI: Cap the benchmark history in charts to 50 items.

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -77,6 +77,7 @@ jobs:
           auto-push: true
           alert-threshold: 200%
           comment-on-alert: true
+          max-items-in-chart: 50
 
       # scream into Slack if something goes wrong
       - name: Report Status


### PR DESCRIPTION
### What

Each data point on the benchmark charts is so close to the next one it's hard to hover over.

In addition, a drastic change isn't even really visible until it's been a few commits.

### How

We cap the maximum items in each chart to 50.