### PR TITLE
Bring ndc-postgres in line with ndc-spec RC15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,7 +1523,7 @@ dependencies = [
 [[package]]
 name = "ndc-sdk"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-hub.git?rev=fc27ac5#fc27ac5e51d399cc86790b0fa0c912776e844923"
+source = "git+https://github.com/hasura/ndc-hub.git?rev=e0e9629#e0e9629dc176bb41ee1b4ca8498dc3d6372f6a28"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,7 +1462,7 @@ dependencies = [
 [[package]]
 name = "ndc-client"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.14#cd24992ea77010e1ef2dff18f7d5656fb0546f3b"
+source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.15#7e10c73d19d03627b96cc666eadcd35f784517e0"
 dependencies = [
  "async-trait",
  "indexmap 2.2.3",
@@ -1523,7 +1523,7 @@ dependencies = [
 [[package]]
 name = "ndc-sdk"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-hub.git?rev=02d26c1#02d26c191b921385258afbecd22617d8d9f2d5ca"
+source = "git+https://github.com/hasura/ndc-hub.git?rev=fc27ac5#fc27ac5e51d399cc86790b0fa0c912776e844923"
 dependencies = [
  "async-trait",
  "axum",
@@ -1560,7 +1560,7 @@ dependencies = [
 [[package]]
 name = "ndc-test"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.14#cd24992ea77010e1ef2dff18f7d5656fb0546f3b"
+source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.15#7e10c73d19d03627b96cc666eadcd35f784517e0"
 dependencies = [
  "async-trait",
  "clap",

--- a/crates/configuration/Cargo.toml
+++ b/crates/configuration/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 query-engine-metadata = { path = "../query-engine/metadata" }
 
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "fc27ac5" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "e0e9629" }
 
 schemars = { version = "0.8.16", features = ["smol_str", "preserve_order"] }
 serde = "1.0.196"

--- a/crates/configuration/Cargo.toml
+++ b/crates/configuration/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 query-engine-metadata = { path = "../query-engine/metadata" }
 
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "02d26c1" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "fc27ac5" }
 
 schemars = { version = "0.8.16", features = ["smol_str", "preserve_order"] }
 serde = "1.0.196"

--- a/crates/connectors/ndc-postgres/Cargo.toml
+++ b/crates/connectors/ndc-postgres/Cargo.toml
@@ -21,7 +21,7 @@ query-engine-metadata = { path = "../../query-engine/metadata" }
 query-engine-sql = { path = "../../query-engine/sql" }
 query-engine-translation = { path = "../../query-engine/translation" }
 
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "fc27ac5" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "e0e9629" }
 
 async-trait = "0.1.77"
 percent-encoding = "2.3.1"

--- a/crates/connectors/ndc-postgres/Cargo.toml
+++ b/crates/connectors/ndc-postgres/Cargo.toml
@@ -21,7 +21,7 @@ query-engine-metadata = { path = "../../query-engine/metadata" }
 query-engine-sql = { path = "../../query-engine/sql" }
 query-engine-translation = { path = "../../query-engine/translation" }
 
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "02d26c1" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "fc27ac5" }
 
 async-trait = "0.1.77"
 percent-encoding = "2.3.1"
@@ -34,8 +34,8 @@ tracing = "0.1.40"
 url = "2.5.0"
 
 [dev-dependencies]
-ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.14" }
-ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.14" }
+ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.15" }
+ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.15" }
 tests-common = { path = "../../tests/tests-common" }
 
 axum = "0.6.20"

--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -437,6 +437,11 @@ fn make_procedure_type(
     let mut fields = BTreeMap::new();
     let object_type_name = format!("{name}_response");
 
+    // If int4 doesn't exist anywhere else in the schema, we need to add it here. However, a user
+    // can't filter or aggregate based on the affected rows of a procedure, so we don't need to add
+    // any aggregate functions or comparison operators. However, if int4 exists elsewhere in the
+    // schema and has already been added, it will also already contain these functions and
+    // operators.
     scalar_types
         .entry("int4".to_string())
         .or_insert(models::ScalarType {

--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -21,7 +21,7 @@ pub async fn get_schema(
 ) -> Result<models::SchemaResponse, connector::SchemaError> {
     let configuration::RuntimeConfiguration { metadata, .. } = config;
 
-    let scalar_types: BTreeMap<String, models::ScalarType> =
+    let mut scalar_types: BTreeMap<String, models::ScalarType> =
         configuration::occurring_scalar_types(&metadata.tables, &metadata.native_queries)
             .iter()
             .map(|scalar_type| {
@@ -260,7 +260,9 @@ pub async fn get_schema(
             config.mutations_version,
         )
         .iter()
-        .map(|(name, mutation)| mutation_to_procedure(name, mutation, &mut more_object_types))
+        .map(|(name, mutation)| {
+            mutation_to_procedure(name, mutation, &mut more_object_types, &mut scalar_types)
+        })
         .collect();
 
     procedures.extend(generated_procedures);
@@ -301,17 +303,25 @@ fn mutation_to_procedure(
     name: &String,
     mutation: &generate::Mutation,
     object_types: &mut BTreeMap<String, models::ObjectType>,
+    scalar_types: &mut BTreeMap<String, models::ScalarType>,
 ) -> models::ProcedureInfo {
     match mutation {
-        generate::Mutation::DeleteMutation(delete) => delete_to_procedure(name, delete),
+        generate::Mutation::DeleteMutation(delete) => {
+            delete_to_procedure(name, delete, object_types, scalar_types)
+        }
         generate::Mutation::InsertMutation(insert) => {
-            insert_to_procedure(name, insert, object_types)
+            insert_to_procedure(name, insert, object_types, scalar_types)
         }
     }
 }
 
 /// given a `DeleteMutation`, turn it into a `ProcedureInfo` to be output in the schema
-fn delete_to_procedure(name: &String, delete: &delete::DeleteMutation) -> models::ProcedureInfo {
+fn delete_to_procedure(
+    name: &String,
+    delete: &delete::DeleteMutation,
+    object_types: &mut BTreeMap<String, models::ObjectType>,
+    scalar_types: &mut BTreeMap<String, models::ScalarType>,
+) -> models::ProcedureInfo {
     match delete {
         delete::DeleteMutation::DeleteByKey {
             by_column,
@@ -329,14 +339,16 @@ fn delete_to_procedure(name: &String, delete: &delete::DeleteMutation) -> models
                 },
             );
 
-            models::ProcedureInfo {
-                name: name.to_string(),
-                description: Some(description.to_string()),
+            make_procedure_type(
+                name.to_string(),
+                Some(description.to_string()),
                 arguments,
-                result_type: models::Type::Named {
+                models::Type::Named {
                     name: collection_name.to_string(),
                 },
-            }
+                object_types,
+                scalar_types,
+            )
         }
     }
 }
@@ -379,6 +391,7 @@ fn insert_to_procedure(
     name: &String,
     insert: &insert::InsertMutation,
     object_types: &mut BTreeMap<String, models::ObjectType>,
+    scalar_types: &mut BTreeMap<String, models::ScalarType>,
 ) -> models::ProcedureInfo {
     let mut arguments = BTreeMap::new();
     let object_type = make_object_type(&insert.columns);
@@ -393,12 +406,78 @@ fn insert_to_procedure(
         },
     );
 
+    make_procedure_type(
+        name.to_string(),
+        Some(insert.description.to_string()),
+        arguments,
+        models::Type::Named {
+            name: insert.collection_name.to_string(),
+        },
+        object_types,
+        scalar_types,
+    )
+}
+
+/// Build a `ProcedureInfo` type from the given parameters.
+///
+/// Because procedures return an `affected_rows` count alongside the result type that it's
+/// `returning`, we have to generate a separate object type for its result. As part of that, we may
+/// also have to include the `int4` scalar type (if it isn't included for another reason elsewhere
+/// in the schema). So, this function creates that object type, optionally adds that scalar type,
+/// and then returns a `ProcedureInfo` that points to the correct object type.
+fn make_procedure_type(
+    name: String,
+    description: Option<String>,
+    arguments: BTreeMap<String, models::ArgumentInfo>,
+    result_type: models::Type,
+
+    object_types: &mut BTreeMap<String, models::ObjectType>,
+    scalar_types: &mut BTreeMap<String, models::ScalarType>,
+) -> models::ProcedureInfo {
+    let mut fields = BTreeMap::new();
+    let object_type_name = format!("{name}_response");
+
+    scalar_types
+        .entry("int4".to_string())
+        .or_insert(models::ScalarType {
+            aggregate_functions: BTreeMap::new(),
+            comparison_operators: BTreeMap::new(),
+        });
+
+    fields.insert(
+        "affected_rows".to_string(),
+        models::ObjectField {
+            description: Some("The number of rows affected by the mutation".to_string()),
+            r#type: models::Type::Named {
+                name: "int4".to_string(),
+            },
+        },
+    );
+
+    fields.insert(
+        "returning".to_string(),
+        models::ObjectField {
+            description: Some("Data from rows affected by the mutation".to_string()),
+            r#type: models::Type::Array {
+                element_type: Box::from(result_type),
+            },
+        },
+    );
+
+    object_types.insert(
+        object_type_name.clone(),
+        models::ObjectType {
+            description: Some(format!("Responses from the '{name}' procedure")),
+            fields,
+        },
+    );
+
     models::ProcedureInfo {
-        name: name.to_string(),
-        description: Some(insert.description.to_string()),
+        name,
+        description,
         arguments,
         result_type: models::Type::Named {
-            name: insert.collection_name.to_string(),
+            name: object_type_name,
         },
     }
 }

--- a/crates/query-engine/sql/src/sql/helpers.rs
+++ b/crates/query-engine/sql/src/sql/helpers.rs
@@ -382,7 +382,8 @@ pub fn select_rowset_with_variables(
     final_select
 }
 
-/// Given a set of rows and aggregate queries, combine them into one Select.
+/// Build a `Select` query using a `SelectSet` of row fields and aggregates according to the
+/// following SQL template:
 ///
 /// ```sql
 /// SELECT row_to_json(<output_table_alias>) AS <output_column_alias>
@@ -397,6 +398,9 @@ pub fn select_rowset_with_variables(
 ///     ) AS <aggregate_table_alias>
 /// ) AS <output_table_alias>
 /// ```
+///
+/// The `SelectSet` determines whether we select from both the rows and the aggregates, or just the
+/// rows, or just the aggregates.
 pub fn select_mutation_rowset(
     (output_table_alias, output_column_alias): (TableAlias, ColumnAlias),
     (row_table_alias, row_column_alias): (TableAlias, ColumnAlias),

--- a/crates/query-engine/sql/src/sql/helpers.rs
+++ b/crates/query-engine/sql/src/sql/helpers.rs
@@ -401,15 +401,22 @@ pub fn select_mutation_rowset(
     (output_table_alias, output_column_alias): (TableAlias, ColumnAlias),
     (row_table_alias, row_column_alias): (TableAlias, ColumnAlias),
     aggregate_table_alias: TableAlias,
-    row_select: Select,
-    aggregate_select: Option<Select>,
+    select: SelectSet,
 ) -> Select {
     let row = vec![(
         output_column_alias,
         Expression::JsonBuildObject(BTreeMap::from([
-            ("type".to_string(), Box::new(Expression::Value(Value::String("procedure".to_string())))),
-            ("result".to_string(), Box::new(Expression::RowToJson(TableReference::AliasedTable(output_table_alias.clone()))))
-        ]))
+            (
+                "type".to_string(),
+                Box::new(Expression::Value(Value::String("procedure".to_string()))),
+            ),
+            (
+                "result".to_string(),
+                Box::new(Expression::RowToJson(TableReference::AliasedTable(
+                    output_table_alias.clone(),
+                ))),
+            ),
+        ])),
     )];
 
     let mut final_select = simple_select(row);
@@ -418,25 +425,43 @@ pub fn select_mutation_rowset(
         select_rows_as_json_for_mutation(row_sel, row_column_alias, row_table_alias.clone())
     };
 
-    let mut select_star = star_select(From::Select {
-        alias: row_table_alias.clone(),
-        select: Box::new(wrap_row(row_select)),
-    });
+    match select {
+        SelectSet::Rows(row_select) => {
+            let select_star = star_select(From::Select {
+                alias: row_table_alias.clone(),
+                select: Box::new(wrap_row(row_select)),
+            });
 
-    match aggregate_select {
-        None => {}
-        Some(aggregate_select) => {
+            final_select.from = Some(From::Select {
+                alias: output_table_alias,
+                select: Box::new(select_star),
+            });
+        }
+
+        SelectSet::Aggregates(aggregate_select) => {
+            final_select.from = Some(From::Select {
+                alias: output_table_alias,
+                select: Box::new(aggregate_select),
+            });
+        }
+
+        SelectSet::RowsAndAggregates(row_select, aggregate_select) => {
+            let mut select_star = star_select(From::Select {
+                alias: row_table_alias.clone(),
+                select: Box::new(wrap_row(row_select)),
+            });
+
             select_star.joins = vec![Join::CrossJoin(CrossJoin {
                 select: Box::new(aggregate_select),
                 alias: aggregate_table_alias.clone(),
             })];
-        }
-    }
 
-    final_select.from = Some(From::Select {
-        alias: output_table_alias,
-        select: Box::new(select_star),
-    });
+            final_select.from = Some(From::Select {
+                alias: output_table_alias,
+                select: Box::new(select_star),
+            });
+        }
+    };
 
     final_select
 }

--- a/crates/query-engine/sql/src/sql/helpers.rs
+++ b/crates/query-engine/sql/src/sql/helpers.rs
@@ -406,7 +406,10 @@ pub fn select_mutation_rowset(
 ) -> Select {
     let row = vec![(
         output_column_alias,
-        Expression::RowToJson(TableReference::AliasedTable(output_table_alias.clone())),
+        Expression::JsonBuildObject(BTreeMap::from([
+            ("type".to_string(), Box::new(Expression::Value(Value::String("procedure".to_string())))),
+            ("result".to_string(), Box::new(Expression::RowToJson(TableReference::AliasedTable(output_table_alias.clone()))))
+        ]))
     )];
 
     let mut final_select = simple_select(row);
@@ -505,14 +508,7 @@ pub fn select_rows_as_json_for_mutation(
             Expression::Value(Value::EmptyJsonArray),
         ],
     };
-    let wrapped_expression = Expression::FunctionCall {
-        function: Function::JsonBuildArray,
-        args: vec![Expression::JsonBuildObject(BTreeMap::from([(
-            "__value".to_string(),
-            Box::new(expression),
-        )]))],
-    };
-    let mut select = simple_select(vec![(column_alias, wrapped_expression)]);
+    let mut select = simple_select(vec![(column_alias, expression)]);
     select.from = Some(From::Select {
         select: Box::new(row_select),
         alias: table_alias,

--- a/crates/query-engine/translation/Cargo.toml
+++ b/crates/query-engine/translation/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "02d26c1" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "fc27ac5" }
 query-engine-metadata = { path = "../metadata" }
 query-engine-sql = { path = "../sql" }
 

--- a/crates/query-engine/translation/Cargo.toml
+++ b/crates/query-engine/translation/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "fc27ac5" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "e0e9629" }
 query-engine-metadata = { path = "../metadata" }
 query-engine-sql = { path = "../sql" }
 

--- a/crates/query-engine/translation/src/translation/error.rs
+++ b/crates/query-engine/translation/src/translation/error.rs
@@ -28,6 +28,8 @@ pub enum Error {
     ColumnIsIdentityAlways(String),
     MissingColumnInInsert(String, String),
     NotImplementedYet(String),
+    NoProcedureResultFieldsRequested,
+    UnexpectedStructure(String),
     InternalError(String),
 }
 
@@ -119,6 +121,11 @@ impl std::fmt::Display for Error {
             Error::NotImplementedYet(thing) => {
                 write!(f, "Queries containing {} are not supported.", thing)
             }
+            Error::NoProcedureResultFieldsRequested => write!(
+                f,
+                "Procedure requests must ask for 'affected_rows' or use the 'returning' clause."
+            ),
+            Error::UnexpectedStructure(structure) => write!(f, "Unexpected {}.", structure),
             Error::InternalError(thing) => {
                 write!(f, "Internal error: {}.", thing)
             }

--- a/crates/query-engine/translation/src/translation/mutation/translate.rs
+++ b/crates/query-engine/translation/src/translation/mutation/translate.rs
@@ -145,7 +145,7 @@ fn translate_mutation(
             sql::helpers::make_column_alias("returning".to_string()),
         ),
         state.make_table_alias("aggregates".to_string()),
-        rows_and_aggregates_to_select_set(returning_select, aggregate_select)?
+        rows_and_aggregates_to_select_set(returning_select, aggregate_select)?,
     );
 
     let common_table_expression = sql::ast::CommonTableExpression {
@@ -276,7 +276,7 @@ fn translate_native_query(
             sql::helpers::make_column_alias("returning".to_string()),
         ),
         state.make_table_alias("aggregates".to_string()),
-        rows_and_aggregates_to_select_set(returning_select, aggregate_select)?
+        rows_and_aggregates_to_select_set(returning_select, aggregate_select)?,
     );
 
     // add the procedure native query definition is a with clause.

--- a/crates/query-engine/translation/src/translation/mutation/translate.rs
+++ b/crates/query-engine/translation/src/translation/mutation/translate.rs
@@ -300,7 +300,7 @@ pub fn parse_procedure_fields(
 ) -> Result<
     (
         Option<IndexMap<String, models::Aggregate>>, // Contains "affected_rows"
-        Option<IndexMap<String, models::Field>>, // Contains "returning"
+        Option<IndexMap<String, models::Field>>,     // Contains "returning"
     ),
     Error,
 > {

--- a/crates/query-engine/translation/tests/goldenfiles/mutations/simple/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/mutations/simple/request.json
@@ -7,9 +7,26 @@
         "track_id": 90
       },
       "fields": {
-        "playlist_id": {
-          "type": "column",
-          "column": "PlaylistId"
+        "type": "object",
+        "fields": {
+          "affected_rows": {
+            "column": "affected_rows",
+            "type": "column"
+          },
+
+          "returning": {
+            "type": "column",
+            "column": "returning",
+            "fields": {
+              "type": "object",
+              "fields": {
+                "playlist_id": {
+                  "type": "column",
+                  "column": "PlaylistId"
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/crates/query-engine/translation/tests/goldenfiles/mutations/simple/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/mutations/simple/request.json
@@ -18,11 +18,14 @@
             "type": "column",
             "column": "returning",
             "fields": {
-              "type": "object",
+              "type": "array",
               "fields": {
-                "playlist_id": {
-                  "type": "column",
-                  "column": "PlaylistId"
+                "type": "object",
+                "fields": {
+                  "playlist_id": {
+                    "type": "column",
+                    "column": "PlaylistId"
+                  }
                 }
               }
             }

--- a/crates/query-engine/translation/tests/goldenfiles/mutations/v1_insert/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/mutations/v1_insert/request.json
@@ -10,13 +10,30 @@
         }
       },
       "fields": {
-        "artist_id": {
-          "type": "column",
-          "column": "id"
-        },
-        "name": {
-          "type": "column",
-          "column": "name"
+        "type": "object",
+        "fields": {
+          "affected_rows": {
+            "column": "affected_rows",
+            "type": "column"
+          },
+
+          "returning": {
+            "type": "column",
+            "column": "returning",
+            "fields": {
+              "type": "object",
+              "fields": {
+                "artist_id": {
+                  "type": "column",
+                  "column": "id"
+                },
+                "name": {
+                  "type": "column",
+                  "column": "name"
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/crates/query-engine/translation/tests/goldenfiles/mutations/v1_insert/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/mutations/v1_insert/request.json
@@ -21,15 +21,18 @@
             "type": "column",
             "column": "returning",
             "fields": {
-              "type": "object",
+              "type": "array",
               "fields": {
-                "artist_id": {
-                  "type": "column",
-                  "column": "id"
-                },
-                "name": {
-                  "type": "column",
-                  "column": "name"
+                "type": "object",
+                "fields": {
+                  "artist_id": {
+                    "type": "column",
+                    "column": "id"
+                  },
+                  "name": {
+                    "type": "column",
+                    "column": "name"
+                  }
                 }
               }
             }

--- a/crates/query-engine/translation/tests/snapshots/tests__mutations__simple.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__mutations__simple.snap
@@ -12,7 +12,10 @@ WITH "%0_NATIVE_QUERY_delete_playlist_track" AS (
     "TrackId" = 90 RETURNING *
 )
 SELECT
-  row_to_json("%2_universe") AS "universe"
+  json_build_object(
+    "result", row_to_json("%2_universe"),
+    "type", "Procedure"
+  ) as "universe"
 FROM
   (
     SELECT

--- a/crates/query-engine/translation/tests/snapshots/tests__mutations__simple.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__mutations__simple.snap
@@ -12,10 +12,7 @@ WITH "%0_NATIVE_QUERY_delete_playlist_track" AS (
     "TrackId" = 90 RETURNING *
 )
 SELECT
-  json_build_object(
-    "result", row_to_json("%2_universe"),
-    "type", "Procedure"
-  ) as "universe"
+  json_build_object('result', row_to_json("%2_universe"), 'type', $1) AS "universe"
 FROM
   (
     SELECT
@@ -23,12 +20,7 @@ FROM
     FROM
       (
         SELECT
-          json_build_array(
-            json_build_object(
-              '__value',
-              coalesce(json_agg(row_to_json("%3_returning")), '[]')
-            )
-          ) AS "returning"
+          coalesce(json_agg(row_to_json("%3_returning")), '[]') AS "returning"
         FROM
           (
             SELECT
@@ -47,4 +39,4 @@ FROM
 
 COMMIT;
 
-[[]]
+[[(1, String("procedure"))]]

--- a/crates/query-engine/translation/tests/snapshots/tests__mutations__v1_insert.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__mutations__v1_insert.snap
@@ -12,7 +12,7 @@ WITH "%0_generated_mutation" AS (
     (276, cast($1 as varchar)) RETURNING *
 )
 SELECT
-  row_to_json("%2_universe") AS "universe"
+  json_build_object('result', row_to_json("%2_universe"), 'type', $2) AS "universe"
 FROM
   (
     SELECT
@@ -20,12 +20,7 @@ FROM
     FROM
       (
         SELECT
-          json_build_array(
-            json_build_object(
-              '__value',
-              coalesce(json_agg(row_to_json("%3_returning")), '[]')
-            )
-          ) AS "returning"
+          coalesce(json_agg(row_to_json("%3_returning")), '[]') AS "returning"
         FROM
           (
             SELECT
@@ -45,4 +40,4 @@ FROM
 
 COMMIT;
 
-[[(1, String("Olympians"))]]
+[[(1, String("Olympians")), (2, String("procedure"))]]

--- a/crates/tests/databases-tests/Cargo.toml
+++ b/crates/tests/databases-tests/Cargo.toml
@@ -23,7 +23,7 @@ postgres = []
 openapi-generator = { path = "../../documentation/openapi" }
 ndc-postgres = { path = "../../connectors/ndc-postgres" }
 ndc-postgres-configuration = { path = "../../configuration" }
-ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.14" }
+ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.15" }
 tests-common = { path = "../tests-common" }
 
 axum = "0.6.20"

--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__schema_tests__schema_test__get_schema.snap
@@ -2362,6 +2362,226 @@ expression: result
         }
       }
     },
+    "v1_delete_Album_by_AlbumId_response": {
+      "description": "Responses from the 'v1_delete_Album_by_AlbumId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Album"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_Artist_by_ArtistId_response": {
+      "description": "Responses from the 'v1_delete_Artist_by_ArtistId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Artist"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_Customer_by_CustomerId_response": {
+      "description": "Responses from the 'v1_delete_Customer_by_CustomerId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Customer"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_Employee_by_EmployeeId_response": {
+      "description": "Responses from the 'v1_delete_Employee_by_EmployeeId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Employee"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_Genre_by_GenreId_response": {
+      "description": "Responses from the 'v1_delete_Genre_by_GenreId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Genre"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_InvoiceLine_by_InvoiceLineId_response": {
+      "description": "Responses from the 'v1_delete_InvoiceLine_by_InvoiceLineId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "InvoiceLine"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_Invoice_by_InvoiceId_response": {
+      "description": "Responses from the 'v1_delete_Invoice_by_InvoiceId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Invoice"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_MediaType_by_MediaTypeId_response": {
+      "description": "Responses from the 'v1_delete_MediaType_by_MediaTypeId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "MediaType"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_Playlist_by_PlaylistId_response": {
+      "description": "Responses from the 'v1_delete_Playlist_by_PlaylistId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Playlist"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_Track_by_TrackId_response": {
+      "description": "Responses from the 'v1_delete_Track_by_TrackId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Track"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_Album_object": {
       "fields": {
         "AlbumId": {
@@ -2384,6 +2604,28 @@ expression: result
         }
       }
     },
+    "v1_insert_Album_response": {
+      "description": "Responses from the 'v1_insert_Album' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Album"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_Artist_object": {
       "fields": {
         "ArtistId": {
@@ -2398,6 +2640,28 @@ expression: result
             "underlying_type": {
               "type": "named",
               "name": "varchar"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_Artist_response": {
+      "description": "Responses from the 'v1_insert_Artist' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Artist"
             }
           }
         }
@@ -2507,6 +2771,28 @@ expression: result
             "underlying_type": {
               "type": "named",
               "name": "int4"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_Customer_response": {
+      "description": "Responses from the 'v1_insert_Customer' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Customer"
             }
           }
         }
@@ -2642,6 +2928,28 @@ expression: result
         }
       }
     },
+    "v1_insert_Employee_response": {
+      "description": "Responses from the 'v1_insert_Employee' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Employee"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_Genre_object": {
       "fields": {
         "GenreId": {
@@ -2656,6 +2964,28 @@ expression: result
             "underlying_type": {
               "type": "named",
               "name": "varchar"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_Genre_response": {
+      "description": "Responses from the 'v1_insert_Genre' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Genre"
             }
           }
         }
@@ -2691,6 +3021,28 @@ expression: result
           "type": {
             "type": "named",
             "name": "numeric"
+          }
+        }
+      }
+    },
+    "v1_insert_InvoiceLine_response": {
+      "description": "Responses from the 'v1_insert_InvoiceLine' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "InvoiceLine"
+            }
           }
         }
       }
@@ -2768,6 +3120,28 @@ expression: result
         }
       }
     },
+    "v1_insert_Invoice_response": {
+      "description": "Responses from the 'v1_insert_Invoice' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Invoice"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_MediaType_object": {
       "fields": {
         "MediaTypeId": {
@@ -2782,6 +3156,28 @@ expression: result
             "underlying_type": {
               "type": "named",
               "name": "varchar"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_MediaType_response": {
+      "description": "Responses from the 'v1_insert_MediaType' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "MediaType"
             }
           }
         }
@@ -2803,6 +3199,28 @@ expression: result
         }
       }
     },
+    "v1_insert_PlaylistTrack_response": {
+      "description": "Responses from the 'v1_insert_PlaylistTrack' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "PlaylistTrack"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_Playlist_object": {
       "fields": {
         "Name": {
@@ -2818,6 +3236,28 @@ expression: result
           "type": {
             "type": "named",
             "name": "int4"
+          }
+        }
+      }
+    },
+    "v1_insert_Playlist_response": {
+      "description": "Responses from the 'v1_insert_Playlist' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Playlist"
+            }
           }
         }
       }
@@ -2888,6 +3328,28 @@ expression: result
           "type": {
             "type": "named",
             "name": "numeric"
+          }
+        }
+      }
+    },
+    "v1_insert_Track_response": {
+      "description": "Responses from the 'v1_insert_Track' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Track"
+            }
           }
         }
       }
@@ -3695,7 +4157,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Album"
+        "name": "v1_delete_Album_by_AlbumId_response"
       }
     },
     {
@@ -3712,7 +4174,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Artist"
+        "name": "v1_delete_Artist_by_ArtistId_response"
       }
     },
     {
@@ -3729,7 +4191,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Customer"
+        "name": "v1_delete_Customer_by_CustomerId_response"
       }
     },
     {
@@ -3745,7 +4207,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Employee"
+        "name": "v1_delete_Employee_by_EmployeeId_response"
       }
     },
     {
@@ -3761,7 +4223,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Genre"
+        "name": "v1_delete_Genre_by_GenreId_response"
       }
     },
     {
@@ -3777,7 +4239,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "InvoiceLine"
+        "name": "v1_delete_InvoiceLine_by_InvoiceLineId_response"
       }
     },
     {
@@ -3793,7 +4255,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Invoice"
+        "name": "v1_delete_Invoice_by_InvoiceId_response"
       }
     },
     {
@@ -3809,7 +4271,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "MediaType"
+        "name": "v1_delete_MediaType_by_MediaTypeId_response"
       }
     },
     {
@@ -3825,7 +4287,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Playlist"
+        "name": "v1_delete_Playlist_by_PlaylistId_response"
       }
     },
     {
@@ -3841,7 +4303,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Track"
+        "name": "v1_delete_Track_by_TrackId_response"
       }
     },
     {
@@ -3857,7 +4319,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Album"
+        "name": "v1_insert_Album_response"
       }
     },
     {
@@ -3873,7 +4335,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Artist"
+        "name": "v1_insert_Artist_response"
       }
     },
     {
@@ -3889,7 +4351,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Customer"
+        "name": "v1_insert_Customer_response"
       }
     },
     {
@@ -3905,7 +4367,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Employee"
+        "name": "v1_insert_Employee_response"
       }
     },
     {
@@ -3921,7 +4383,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Genre"
+        "name": "v1_insert_Genre_response"
       }
     },
     {
@@ -3937,7 +4399,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Invoice"
+        "name": "v1_insert_Invoice_response"
       }
     },
     {
@@ -3953,7 +4415,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "InvoiceLine"
+        "name": "v1_insert_InvoiceLine_response"
       }
     },
     {
@@ -3969,7 +4431,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "MediaType"
+        "name": "v1_insert_MediaType_response"
       }
     },
     {
@@ -3985,7 +4447,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Playlist"
+        "name": "v1_insert_Playlist_response"
       }
     },
     {
@@ -4001,7 +4463,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "PlaylistTrack"
+        "name": "v1_insert_PlaylistTrack_response"
       }
     },
     {
@@ -4017,7 +4479,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Track"
+        "name": "v1_insert_Track_response"
       }
     }
   ]

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__schema_tests__schema_test__get_schema.snap
@@ -2112,6 +2112,226 @@ expression: result
         }
       }
     },
+    "v1_delete_Album_by_AlbumId_response": {
+      "description": "Responses from the 'v1_delete_Album_by_AlbumId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Album"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_Artist_by_ArtistId_response": {
+      "description": "Responses from the 'v1_delete_Artist_by_ArtistId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Artist"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_Customer_by_CustomerId_response": {
+      "description": "Responses from the 'v1_delete_Customer_by_CustomerId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Customer"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_Employee_by_EmployeeId_response": {
+      "description": "Responses from the 'v1_delete_Employee_by_EmployeeId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Employee"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_Genre_by_GenreId_response": {
+      "description": "Responses from the 'v1_delete_Genre_by_GenreId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Genre"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_InvoiceLine_by_InvoiceLineId_response": {
+      "description": "Responses from the 'v1_delete_InvoiceLine_by_InvoiceLineId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "InvoiceLine"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_Invoice_by_InvoiceId_response": {
+      "description": "Responses from the 'v1_delete_Invoice_by_InvoiceId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Invoice"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_MediaType_by_MediaTypeId_response": {
+      "description": "Responses from the 'v1_delete_MediaType_by_MediaTypeId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "MediaType"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_Playlist_by_PlaylistId_response": {
+      "description": "Responses from the 'v1_delete_Playlist_by_PlaylistId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Playlist"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_Track_by_TrackId_response": {
+      "description": "Responses from the 'v1_delete_Track_by_TrackId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Track"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_Album_object": {
       "fields": {
         "AlbumId": {
@@ -2134,6 +2354,28 @@ expression: result
         }
       }
     },
+    "v1_insert_Album_response": {
+      "description": "Responses from the 'v1_insert_Album' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Album"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_Artist_object": {
       "fields": {
         "ArtistId": {
@@ -2148,6 +2390,28 @@ expression: result
             "underlying_type": {
               "type": "named",
               "name": "varchar"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_Artist_response": {
+      "description": "Responses from the 'v1_insert_Artist' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Artist"
             }
           }
         }
@@ -2257,6 +2521,28 @@ expression: result
             "underlying_type": {
               "type": "named",
               "name": "int8"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_Customer_response": {
+      "description": "Responses from the 'v1_insert_Customer' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Customer"
             }
           }
         }
@@ -2392,6 +2678,28 @@ expression: result
         }
       }
     },
+    "v1_insert_Employee_response": {
+      "description": "Responses from the 'v1_insert_Employee' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Employee"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_Genre_object": {
       "fields": {
         "GenreId": {
@@ -2406,6 +2714,28 @@ expression: result
             "underlying_type": {
               "type": "named",
               "name": "varchar"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_Genre_response": {
+      "description": "Responses from the 'v1_insert_Genre' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Genre"
             }
           }
         }
@@ -2441,6 +2771,28 @@ expression: result
           "type": {
             "type": "named",
             "name": "numeric"
+          }
+        }
+      }
+    },
+    "v1_insert_InvoiceLine_response": {
+      "description": "Responses from the 'v1_insert_InvoiceLine' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "InvoiceLine"
+            }
           }
         }
       }
@@ -2518,6 +2870,28 @@ expression: result
         }
       }
     },
+    "v1_insert_Invoice_response": {
+      "description": "Responses from the 'v1_insert_Invoice' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Invoice"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_MediaType_object": {
       "fields": {
         "MediaTypeId": {
@@ -2532,6 +2906,28 @@ expression: result
             "underlying_type": {
               "type": "named",
               "name": "varchar"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_MediaType_response": {
+      "description": "Responses from the 'v1_insert_MediaType' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "MediaType"
             }
           }
         }
@@ -2553,6 +2949,28 @@ expression: result
         }
       }
     },
+    "v1_insert_PlaylistTrack_response": {
+      "description": "Responses from the 'v1_insert_PlaylistTrack' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "PlaylistTrack"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_Playlist_object": {
       "fields": {
         "Name": {
@@ -2568,6 +2986,28 @@ expression: result
           "type": {
             "type": "named",
             "name": "int8"
+          }
+        }
+      }
+    },
+    "v1_insert_Playlist_response": {
+      "description": "Responses from the 'v1_insert_Playlist' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Playlist"
+            }
           }
         }
       }
@@ -2642,6 +3082,28 @@ expression: result
         }
       }
     },
+    "v1_insert_Track_response": {
+      "description": "Responses from the 'v1_insert_Track' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Track"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_pg_extension_spatial_ref_sys_object": {
       "fields": {
         "auth_name": {
@@ -2686,6 +3148,28 @@ expression: result
             "underlying_type": {
               "type": "named",
               "name": "varchar"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_pg_extension_spatial_ref_sys_response": {
+      "description": "Responses from the 'v1_insert_pg_extension_spatial_ref_sys' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "pg_extension_spatial_ref_sys"
             }
           }
         }
@@ -3454,7 +3938,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Album"
+        "name": "v1_delete_Album_by_AlbumId_response"
       }
     },
     {
@@ -3471,7 +3955,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Artist"
+        "name": "v1_delete_Artist_by_ArtistId_response"
       }
     },
     {
@@ -3488,7 +3972,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Customer"
+        "name": "v1_delete_Customer_by_CustomerId_response"
       }
     },
     {
@@ -3504,7 +3988,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Employee"
+        "name": "v1_delete_Employee_by_EmployeeId_response"
       }
     },
     {
@@ -3520,7 +4004,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Genre"
+        "name": "v1_delete_Genre_by_GenreId_response"
       }
     },
     {
@@ -3536,7 +4020,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "InvoiceLine"
+        "name": "v1_delete_InvoiceLine_by_InvoiceLineId_response"
       }
     },
     {
@@ -3552,7 +4036,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Invoice"
+        "name": "v1_delete_Invoice_by_InvoiceId_response"
       }
     },
     {
@@ -3568,7 +4052,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "MediaType"
+        "name": "v1_delete_MediaType_by_MediaTypeId_response"
       }
     },
     {
@@ -3584,7 +4068,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Playlist"
+        "name": "v1_delete_Playlist_by_PlaylistId_response"
       }
     },
     {
@@ -3600,7 +4084,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Track"
+        "name": "v1_delete_Track_by_TrackId_response"
       }
     },
     {
@@ -3616,7 +4100,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Album"
+        "name": "v1_insert_Album_response"
       }
     },
     {
@@ -3632,7 +4116,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Artist"
+        "name": "v1_insert_Artist_response"
       }
     },
     {
@@ -3648,7 +4132,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Customer"
+        "name": "v1_insert_Customer_response"
       }
     },
     {
@@ -3664,7 +4148,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Employee"
+        "name": "v1_insert_Employee_response"
       }
     },
     {
@@ -3680,7 +4164,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Genre"
+        "name": "v1_insert_Genre_response"
       }
     },
     {
@@ -3696,7 +4180,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Invoice"
+        "name": "v1_insert_Invoice_response"
       }
     },
     {
@@ -3712,7 +4196,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "InvoiceLine"
+        "name": "v1_insert_InvoiceLine_response"
       }
     },
     {
@@ -3728,7 +4212,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "MediaType"
+        "name": "v1_insert_MediaType_response"
       }
     },
     {
@@ -3744,7 +4228,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Playlist"
+        "name": "v1_insert_Playlist_response"
       }
     },
     {
@@ -3760,7 +4244,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "PlaylistTrack"
+        "name": "v1_insert_PlaylistTrack_response"
       }
     },
     {
@@ -3776,7 +4260,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Track"
+        "name": "v1_insert_Track_response"
       }
     },
     {
@@ -3792,7 +4276,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "pg_extension_spatial_ref_sys"
+        "name": "v1_insert_pg_extension_spatial_ref_sys_response"
       }
     }
   ]

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__delete_playlist_track.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__delete_playlist_track.snap
@@ -9,7 +9,7 @@ EXPLAIN WITH "%0_NATIVE_QUERY_delete_playlist_track" AS (
     "TrackId" = 90 RETURNING *
 )
 SELECT
-  row_to_json("%2_universe") AS "universe"
+  json_build_object('result', row_to_json("%2_universe"), 'type', $1) AS "universe"
 FROM
   (
     SELECT
@@ -17,12 +17,7 @@ FROM
     FROM
       (
         SELECT
-          json_build_array(
-            json_build_object(
-              '__value',
-              coalesce(json_agg(row_to_json("%3_returning")), '[]')
-            )
-          ) AS "returning"
+          coalesce(json_agg(row_to_json("%3_returning")), '[]') AS "returning"
         FROM
           (
             SELECT

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__insert_artist_album.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__insert_artist_album.snap
@@ -9,7 +9,7 @@ EXPLAIN WITH "%0_NATIVE_QUERY_insert_artist" AS (
     (276, cast($1 as varchar)) RETURNING *
 )
 SELECT
-  row_to_json("%2_universe") AS "universe"
+  json_build_object('result', row_to_json("%2_universe"), 'type', $2) AS "universe"
 FROM
   (
     SELECT
@@ -17,12 +17,7 @@ FROM
     FROM
       (
         SELECT
-          json_build_array(
-            json_build_object(
-              '__value',
-              coalesce(json_agg(row_to_json("%3_returning")), '[]')
-            )
-          ) AS "returning"
+          coalesce(json_agg(row_to_json("%3_returning")), '[]') AS "returning"
         FROM
           (
             SELECT
@@ -48,7 +43,7 @@ EXPLAIN WITH "%0_NATIVE_QUERY_insert_album" AS (
 (348, cast($1 as varchar), 276) RETURNING *
 )
 SELECT
-  row_to_json("%6_universe") AS "universe"
+  json_build_object('result', row_to_json("%6_universe"), 'type', $2) AS "universe"
 FROM
   (
     SELECT
@@ -56,12 +51,7 @@ FROM
     FROM
       (
         SELECT
-          json_build_array(
-            json_build_object(
-              '__value',
-              coalesce(json_agg(row_to_json("%7_returning")), '[]')
-            )
-          ) AS "returning"
+          coalesce(json_agg(row_to_json("%7_returning")), '[]') AS "returning"
         FROM
           (
             SELECT

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__delete_invoice_line.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__delete_invoice_line.snap
@@ -5,17 +5,16 @@ expression: result
 {
   "operation_results": [
     {
-      "affected_rows": 1,
-      "returning": [
-        {
-          "__value": [
-            {
-              "invoice_line_id": 90,
-              "quantity": 1
-            }
-          ]
-        }
-      ]
+      "type": "procedure",
+      "result": {
+        "returning": [
+          {
+            "invoice_line_id": 90,
+            "quantity": 1
+          }
+        ],
+        "affected_rows": 1
+      }
     }
   ]
 }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__delete_playlist_track.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__delete_playlist_track.snap
@@ -5,19 +5,18 @@ expression: result
 {
   "operation_results": [
     {
-      "affected_rows": 2,
-      "returning": [
-        {
-          "__value": [
-            {
-              "playlist_id": 1
-            },
-            {
-              "playlist_id": 8
-            }
-          ]
-        }
-      ]
+      "type": "procedure",
+      "result": {
+        "returning": [
+          {
+            "playlist_id": 1
+          },
+          {
+            "playlist_id": 8
+          }
+        ],
+        "affected_rows": 2
+      }
     }
   ]
 }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__insert_artist_album.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__insert_artist_album.snap
@@ -6,37 +6,35 @@ expression: result
   {
     "operation_results": [
       {
-        "affected_rows": 1,
-        "returning": [
-          {
-            "__value": [
-              {
-                "artist_id": 276,
-                "name": "Olympians"
-              }
-            ]
-          }
-        ]
+        "type": "procedure",
+        "result": {
+          "returning": [
+            {
+              "artist_id": 276,
+              "name": "Olympians"
+            }
+          ],
+          "affected_rows": 1
+        }
       },
       {
-        "affected_rows": 1,
-        "returning": [
-          {
-            "__value": [
-              {
-                "album_id": 348,
-                "title": "Lake Mannion",
-                "artist": {
-                  "rows": [
-                    {
-                      "name": "Olympians"
-                    }
-                  ]
-                }
+        "type": "procedure",
+        "result": {
+          "returning": [
+            {
+              "album_id": 348,
+              "title": "Lake Mannion",
+              "artist": {
+                "rows": [
+                  {
+                    "name": "Olympians"
+                  }
+                ]
               }
-            ]
-          }
-        ]
+            }
+          ],
+          "affected_rows": 1
+        }
       }
     ]
   },

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__v1_insert_custom_dog.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__v1_insert_custom_dog.snap
@@ -5,36 +5,39 @@ expression: result
 {
   "operation_results": [
     {
-      "affected_rows": 1,
-      "returning": [
-        {
-          "__value": [
-            {
-              "id": 1,
-              "name": "Cremebo",
-              "birthday": "2024-01-17",
-              "height_cm": 160,
-              "height_inch": 62.99212598425197,
-              "adopter_name": null
-            }
-          ]
-        }
-      ]
+      "type": "procedure",
+      "result": {
+        "returning": [
+          {
+            "id": 1,
+            "name": "Cremebo",
+            "birthday": "2024-01-17",
+            "height_cm": 160,
+            "height_inch": 62.99212598425197,
+            "adopter_name": null
+          }
+        ],
+        "affected_rows": 1
+      }
     },
     {
-      "affected_rows": 1,
-      "returning": [
-        {
-          "__value": [
-            {
-              "name": "Manbo",
-              "birthday": "2024-01-01",
-              "height_inch": 135.8267716535433,
-              "adopter_name": "Joseph"
-            }
-          ]
-        }
-      ]
+      "type": "procedure",
+      "result": {
+        "returning": [
+          {
+            "name": "Manbo",
+            "birthday": "2024-01-01",
+            "height_inch": 135.8267716535433,
+            "adopter_name": "Joseph"
+          }
+        ]
+      }
+    },
+    {
+      "type": "procedure",
+      "result": {
+        "affected_rows": 1
+      }
     }
   ]
 }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
@@ -2627,6 +2627,314 @@ expression: result
         }
       }
     },
+    "v1_delete_Album_by_AlbumId_response": {
+      "description": "Responses from the 'v1_delete_Album_by_AlbumId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Album"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_Artist_by_ArtistId_response": {
+      "description": "Responses from the 'v1_delete_Artist_by_ArtistId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Artist"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_Customer_by_CustomerId_response": {
+      "description": "Responses from the 'v1_delete_Customer_by_CustomerId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Customer"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_Employee_by_EmployeeId_response": {
+      "description": "Responses from the 'v1_delete_Employee_by_EmployeeId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Employee"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_Genre_by_GenreId_response": {
+      "description": "Responses from the 'v1_delete_Genre_by_GenreId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Genre"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_InvoiceLine_by_InvoiceLineId_response": {
+      "description": "Responses from the 'v1_delete_InvoiceLine_by_InvoiceLineId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "InvoiceLine"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_Invoice_by_InvoiceId_response": {
+      "description": "Responses from the 'v1_delete_Invoice_by_InvoiceId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Invoice"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_MediaType_by_MediaTypeId_response": {
+      "description": "Responses from the 'v1_delete_MediaType_by_MediaTypeId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "MediaType"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_Playlist_by_PlaylistId_response": {
+      "description": "Responses from the 'v1_delete_Playlist_by_PlaylistId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Playlist"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_Track_by_TrackId_response": {
+      "description": "Responses from the 'v1_delete_Track_by_TrackId' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Track"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_custom_dog_by_id_response": {
+      "description": "Responses from the 'v1_delete_custom_dog_by_id' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "custom_dog"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_spatial_ref_sys_by_srid_response": {
+      "description": "Responses from the 'v1_delete_spatial_ref_sys_by_srid' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "spatial_ref_sys"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_topology_topology_by_id_response": {
+      "description": "Responses from the 'v1_delete_topology_topology_by_id' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "topology_topology"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_topology_topology_by_name_response": {
+      "description": "Responses from the 'v1_delete_topology_topology_by_name' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "topology_topology"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_Album_object": {
       "fields": {
         "AlbumId": {
@@ -2649,6 +2957,28 @@ expression: result
         }
       }
     },
+    "v1_insert_Album_response": {
+      "description": "Responses from the 'v1_insert_Album' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Album"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_Artist_object": {
       "fields": {
         "ArtistId": {
@@ -2663,6 +2993,28 @@ expression: result
             "underlying_type": {
               "type": "named",
               "name": "varchar"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_Artist_response": {
+      "description": "Responses from the 'v1_insert_Artist' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Artist"
             }
           }
         }
@@ -2772,6 +3124,28 @@ expression: result
             "underlying_type": {
               "type": "named",
               "name": "int4"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_Customer_response": {
+      "description": "Responses from the 'v1_insert_Customer' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Customer"
             }
           }
         }
@@ -2907,6 +3281,28 @@ expression: result
         }
       }
     },
+    "v1_insert_Employee_response": {
+      "description": "Responses from the 'v1_insert_Employee' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Employee"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_Genre_object": {
       "fields": {
         "GenreId": {
@@ -2921,6 +3317,28 @@ expression: result
             "underlying_type": {
               "type": "named",
               "name": "varchar"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_Genre_response": {
+      "description": "Responses from the 'v1_insert_Genre' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Genre"
             }
           }
         }
@@ -2956,6 +3374,28 @@ expression: result
           "type": {
             "type": "named",
             "name": "numeric"
+          }
+        }
+      }
+    },
+    "v1_insert_InvoiceLine_response": {
+      "description": "Responses from the 'v1_insert_InvoiceLine' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "InvoiceLine"
+            }
           }
         }
       }
@@ -3033,6 +3473,28 @@ expression: result
         }
       }
     },
+    "v1_insert_Invoice_response": {
+      "description": "Responses from the 'v1_insert_Invoice' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Invoice"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_MediaType_object": {
       "fields": {
         "MediaTypeId": {
@@ -3047,6 +3509,28 @@ expression: result
             "underlying_type": {
               "type": "named",
               "name": "varchar"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_MediaType_response": {
+      "description": "Responses from the 'v1_insert_MediaType' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "MediaType"
             }
           }
         }
@@ -3068,6 +3552,28 @@ expression: result
         }
       }
     },
+    "v1_insert_PlaylistTrack_response": {
+      "description": "Responses from the 'v1_insert_PlaylistTrack' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "PlaylistTrack"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_Playlist_object": {
       "fields": {
         "Name": {
@@ -3083,6 +3589,28 @@ expression: result
           "type": {
             "type": "named",
             "name": "int4"
+          }
+        }
+      }
+    },
+    "v1_insert_Playlist_response": {
+      "description": "Responses from the 'v1_insert_Playlist' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Playlist"
+            }
           }
         }
       }
@@ -3157,6 +3685,28 @@ expression: result
         }
       }
     },
+    "v1_insert_Track_response": {
+      "description": "Responses from the 'v1_insert_Track' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "Track"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_custom_dog_object": {
       "fields": {
         "adopter_name": {
@@ -3184,6 +3734,28 @@ expression: result
           "type": {
             "type": "named",
             "name": "text"
+          }
+        }
+      }
+    },
+    "v1_insert_custom_dog_response": {
+      "description": "Responses from the 'v1_insert_custom_dog' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "custom_dog"
+            }
           }
         }
       }
@@ -3229,6 +3801,28 @@ expression: result
             "underlying_type": {
               "type": "named",
               "name": "varchar"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_spatial_ref_sys_response": {
+      "description": "Responses from the 'v1_insert_spatial_ref_sys' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "spatial_ref_sys"
             }
           }
         }
@@ -3289,6 +3883,28 @@ expression: result
         }
       }
     },
+    "v1_insert_topology_layer_response": {
+      "description": "Responses from the 'v1_insert_topology_layer' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "topology_layer"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_topology_topology_object": {
       "fields": {
         "hasz": {
@@ -3319,6 +3935,28 @@ expression: result
           "type": {
             "type": "named",
             "name": "int4"
+          }
+        }
+      }
+    },
+    "v1_insert_topology_topology_response": {
+      "description": "Responses from the 'v1_insert_topology_topology' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "topology_topology"
+            }
           }
         }
       }
@@ -4198,7 +4836,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Album"
+        "name": "v1_delete_Album_by_AlbumId_response"
       }
     },
     {
@@ -4215,7 +4853,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Artist"
+        "name": "v1_delete_Artist_by_ArtistId_response"
       }
     },
     {
@@ -4232,7 +4870,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Customer"
+        "name": "v1_delete_Customer_by_CustomerId_response"
       }
     },
     {
@@ -4248,7 +4886,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Employee"
+        "name": "v1_delete_Employee_by_EmployeeId_response"
       }
     },
     {
@@ -4264,7 +4902,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Genre"
+        "name": "v1_delete_Genre_by_GenreId_response"
       }
     },
     {
@@ -4280,7 +4918,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "InvoiceLine"
+        "name": "v1_delete_InvoiceLine_by_InvoiceLineId_response"
       }
     },
     {
@@ -4296,7 +4934,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Invoice"
+        "name": "v1_delete_Invoice_by_InvoiceId_response"
       }
     },
     {
@@ -4312,7 +4950,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "MediaType"
+        "name": "v1_delete_MediaType_by_MediaTypeId_response"
       }
     },
     {
@@ -4328,7 +4966,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Playlist"
+        "name": "v1_delete_Playlist_by_PlaylistId_response"
       }
     },
     {
@@ -4344,7 +4982,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Track"
+        "name": "v1_delete_Track_by_TrackId_response"
       }
     },
     {
@@ -4360,7 +4998,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "custom_dog"
+        "name": "v1_delete_custom_dog_by_id_response"
       }
     },
     {
@@ -4376,7 +5014,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "spatial_ref_sys"
+        "name": "v1_delete_spatial_ref_sys_by_srid_response"
       }
     },
     {
@@ -4392,7 +5030,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "topology_topology"
+        "name": "v1_delete_topology_topology_by_id_response"
       }
     },
     {
@@ -4408,7 +5046,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "topology_topology"
+        "name": "v1_delete_topology_topology_by_name_response"
       }
     },
     {
@@ -4424,7 +5062,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Album"
+        "name": "v1_insert_Album_response"
       }
     },
     {
@@ -4440,7 +5078,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Artist"
+        "name": "v1_insert_Artist_response"
       }
     },
     {
@@ -4456,7 +5094,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Customer"
+        "name": "v1_insert_Customer_response"
       }
     },
     {
@@ -4472,7 +5110,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Employee"
+        "name": "v1_insert_Employee_response"
       }
     },
     {
@@ -4488,7 +5126,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Genre"
+        "name": "v1_insert_Genre_response"
       }
     },
     {
@@ -4504,7 +5142,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Invoice"
+        "name": "v1_insert_Invoice_response"
       }
     },
     {
@@ -4520,7 +5158,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "InvoiceLine"
+        "name": "v1_insert_InvoiceLine_response"
       }
     },
     {
@@ -4536,7 +5174,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "MediaType"
+        "name": "v1_insert_MediaType_response"
       }
     },
     {
@@ -4552,7 +5190,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Playlist"
+        "name": "v1_insert_Playlist_response"
       }
     },
     {
@@ -4568,7 +5206,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "PlaylistTrack"
+        "name": "v1_insert_PlaylistTrack_response"
       }
     },
     {
@@ -4584,7 +5222,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "Track"
+        "name": "v1_insert_Track_response"
       }
     },
     {
@@ -4600,7 +5238,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "custom_dog"
+        "name": "v1_insert_custom_dog_response"
       }
     },
     {
@@ -4616,7 +5254,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "spatial_ref_sys"
+        "name": "v1_insert_spatial_ref_sys_response"
       }
     },
     {
@@ -4632,7 +5270,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "topology_layer"
+        "name": "v1_insert_topology_layer_response"
       }
     },
     {
@@ -4648,7 +5286,7 @@ expression: result
       },
       "result_type": {
         "type": "named",
-        "name": "topology_topology"
+        "name": "v1_insert_topology_topology_response"
       }
     }
   ]

--- a/crates/tests/tests-common/Cargo.toml
+++ b/crates/tests/tests-common/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/lib.rs"
 
 [dependencies]
 ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.15" }
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "fc27ac5" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "e0e9629" }
 ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.15" }
 
 ndc-postgres = { path = "../../connectors/ndc-postgres" }

--- a/crates/tests/tests-common/Cargo.toml
+++ b/crates/tests/tests-common/Cargo.toml
@@ -9,9 +9,9 @@ name = "tests_common"
 path = "src/lib.rs"
 
 [dependencies]
-ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.14" }
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "02d26c1" }
-ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.14" }
+ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.15" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "fc27ac5" }
+ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.15" }
 
 ndc-postgres = { path = "../../connectors/ndc-postgres" }
 ndc-postgres-configuration = { path = "../../configuration" }

--- a/crates/tests/tests-common/goldenfiles/mutations/delete_invoice_line.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/delete_invoice_line.json
@@ -7,13 +7,30 @@
         "InvoiceLineId": 90
       },
       "fields": {
-        "invoice_line_id": {
-          "type": "column",
-          "column": "InvoiceLineId"
-        },
-        "quantity": {
-          "type": "column",
-          "column": "Quantity"
+        "type": "object",
+        "fields": {
+          "affected_rows": {
+            "column": "affected_rows",
+            "type": "column"
+          },
+
+          "returning": {
+            "type": "column",
+            "column": "returning",
+            "fields": {
+              "type": "object",
+              "fields": {
+                "invoice_line_id": {
+                  "type": "column",
+                  "column": "InvoiceLineId"
+                },
+                "quantity": {
+                  "type": "column",
+                  "column": "Quantity"
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/crates/tests/tests-common/goldenfiles/mutations/delete_invoice_line.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/delete_invoice_line.json
@@ -18,15 +18,18 @@
             "type": "column",
             "column": "returning",
             "fields": {
-              "type": "object",
+              "type": "array",
               "fields": {
-                "invoice_line_id": {
-                  "type": "column",
-                  "column": "InvoiceLineId"
-                },
-                "quantity": {
-                  "type": "column",
-                  "column": "Quantity"
+                "type": "object",
+                "fields": {
+                  "invoice_line_id": {
+                    "type": "column",
+                    "column": "InvoiceLineId"
+                  },
+                  "quantity": {
+                    "type": "column",
+                    "column": "Quantity"
+                  }
                 }
               }
             }

--- a/crates/tests/tests-common/goldenfiles/mutations/delete_playlist_track.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/delete_playlist_track.json
@@ -7,9 +7,26 @@
         "track_id": 90
       },
       "fields": {
-        "playlist_id": {
-          "type": "column",
-          "column": "PlaylistId"
+        "type": "object",
+        "fields": {
+          "affected_rows": {
+            "column": "affected_rows",
+            "type": "column"
+          },
+
+          "returning": {
+            "type": "column",
+            "column": "returning",
+            "fields": {
+              "type": "object",
+              "fields": {
+                "playlist_id": {
+                  "type": "column",
+                  "column": "PlaylistId"
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/crates/tests/tests-common/goldenfiles/mutations/delete_playlist_track.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/delete_playlist_track.json
@@ -18,11 +18,14 @@
             "type": "column",
             "column": "returning",
             "fields": {
-              "type": "object",
+              "type": "array",
               "fields": {
-                "playlist_id": {
-                  "type": "column",
-                  "column": "PlaylistId"
+                "type": "object",
+                "fields": {
+                  "playlist_id": {
+                    "type": "column",
+                    "column": "PlaylistId"
+                  }
                 }
               }
             }

--- a/crates/tests/tests-common/goldenfiles/mutations/insert_artist_album.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/insert_artist_album.json
@@ -19,15 +19,18 @@
             "type": "column",
             "column": "returning",
             "fields": {
-              "type": "object",
+              "type": "array",
               "fields": {
-                "artist_id": {
-                  "type": "column",
-                  "column": "ArtistId"
-                },
-                "name": {
-                  "type": "column",
-                  "column": "Name"
+                "type": "object",
+                "fields": {
+                  "artist_id": {
+                    "type": "column",
+                    "column": "ArtistId"
+                  },
+                  "name": {
+                    "type": "column",
+                    "column": "Name"
+                  }
                 }
               }
             }
@@ -55,30 +58,33 @@
             "type": "column",
             "column": "returning",
             "fields": {
-              "type": "object",
+              "type": "array",
               "fields": {
-                "album_id": {
-                  "type": "column",
-                  "column": "AlbumId"
-                },
-                "title": {
-                  "type": "column",
-                  "column": "Title"
-                },
-                "artist": {
-                  "type": "relationship",
-                  "column": "Title",
-                  "relationship": "AlbumToArtist",
-                  "query": {
-                    "fields": {
-                      "name": {
-                        "type": "column",
-                        "column": "Name",
-                        "arguments": {}
-                      }
-                    }
+                "type": "object",
+                "fields": {
+                  "album_id": {
+                    "type": "column",
+                    "column": "AlbumId"
                   },
-                  "arguments": {}
+                  "title": {
+                    "type": "column",
+                    "column": "Title"
+                  },
+                  "artist": {
+                    "type": "relationship",
+                    "column": "Title",
+                    "relationship": "AlbumToArtist",
+                    "query": {
+                      "fields": {
+                        "name": {
+                          "type": "column",
+                          "column": "Name",
+                          "arguments": {}
+                        }
+                      }
+                    },
+                    "arguments": {}
+                  }
                 }
               }
             }

--- a/crates/tests/tests-common/goldenfiles/mutations/insert_artist_album.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/insert_artist_album.json
@@ -10,13 +10,27 @@
       "fields": {
         "type": "object",
         "fields": {
-          "artist_id": {
-            "type": "column",
-            "column": "ArtistId"
+          "affected_rows": {
+            "column": "affected_rows",
+            "type": "column"
           },
-          "name": {
+
+          "returning": {
             "type": "column",
-            "column": "Name"
+            "column": "returning",
+            "fields": {
+              "type": "object",
+              "fields": {
+                "artist_id": {
+                  "type": "column",
+                  "column": "ArtistId"
+                },
+                "name": {
+                  "type": "column",
+                  "column": "Name"
+                }
+              }
+            }
           }
         }
       }
@@ -32,28 +46,42 @@
       "fields": {
         "type": "object",
         "fields": {
-          "album_id": {
-            "type": "column",
-            "column": "AlbumId"
+          "affected_rows": {
+            "column": "affected_rows",
+            "type": "column"
           },
-          "title": {
+
+          "returning": {
             "type": "column",
-            "column": "Title"
-          },
-          "artist": {
-            "type": "relationship",
-            "column": "Title",
-            "relationship": "AlbumToArtist",
-            "query": {
+            "column": "returning",
+            "fields": {
+              "type": "object",
               "fields": {
-                "name": {
+                "album_id": {
                   "type": "column",
-                  "column": "Name",
+                  "column": "AlbumId"
+                },
+                "title": {
+                  "type": "column",
+                  "column": "Title"
+                },
+                "artist": {
+                  "type": "relationship",
+                  "column": "Title",
+                  "relationship": "AlbumToArtist",
+                  "query": {
+                    "fields": {
+                      "name": {
+                        "type": "column",
+                        "column": "Name",
+                        "arguments": {}
+                      }
+                    }
+                  },
                   "arguments": {}
                 }
               }
-            },
-            "arguments": {}
+            }
           }
         }
       }

--- a/crates/tests/tests-common/goldenfiles/mutations/insert_artist_album.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/insert_artist_album.json
@@ -8,13 +8,16 @@
         "name": "Olympians"
       },
       "fields": {
-        "artist_id": {
-          "type": "column",
-          "column": "ArtistId"
-        },
-        "name": {
-          "type": "column",
-          "column": "Name"
+        "type": "object",
+        "fields": {
+          "artist_id": {
+            "type": "column",
+            "column": "ArtistId"
+          },
+          "name": {
+            "type": "column",
+            "column": "Name"
+          }
         }
       }
     },
@@ -27,28 +30,31 @@
         "artist_id": 276
       },
       "fields": {
-        "album_id": {
-          "type": "column",
-          "column": "AlbumId"
-        },
-        "title": {
-          "type": "column",
-          "column": "Title"
-        },
-        "artist": {
-          "type": "relationship",
-          "column": "Title",
-          "relationship": "AlbumToArtist",
-          "query": {
-            "fields": {
-              "name": {
-                "type": "column",
-                "column": "Name",
-                "arguments": {}
-              }
-            }
+        "type": "object",
+        "fields": {
+          "album_id": {
+            "type": "column",
+            "column": "AlbumId"
           },
-          "arguments": {}
+          "title": {
+            "type": "column",
+            "column": "Title"
+          },
+          "artist": {
+            "type": "relationship",
+            "column": "Title",
+            "relationship": "AlbumToArtist",
+            "query": {
+              "fields": {
+                "name": {
+                  "type": "column",
+                  "column": "Name",
+                  "arguments": {}
+                }
+              }
+            },
+            "arguments": {}
+          }
         }
       }
     }

--- a/crates/tests/tests-common/goldenfiles/mutations/insert_artist_album_bad.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/insert_artist_album_bad.json
@@ -8,13 +8,30 @@
         "name": "Olympians"
       },
       "fields": {
-        "artist_id": {
-          "type": "column",
-          "column": "ArtistId"
-        },
-        "name": {
-          "type": "column",
-          "column": "Name"
+        "type": "object",
+        "fields": {
+          "affected_rows": {
+            "column": "affected_rows",
+            "type": "column"
+          },
+
+          "returning": {
+            "type": "column",
+            "column": "returning",
+            "fields": {
+              "type": "object",
+              "fields": {
+                "artist_id": {
+                  "type": "column",
+                  "column": "ArtistId"
+                },
+                "name": {
+                  "type": "column",
+                  "column": "Name"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -27,28 +44,45 @@
         "artist_id": 276
       },
       "fields": {
-        "album_id": {
-          "type": "column",
-          "column": "AlbumId"
-        },
-        "title": {
-          "type": "column",
-          "column": "Title"
-        },
-        "artist": {
-          "type": "relationship",
-          "column": "Title",
-          "relationship": "AlbumToArtist",
-          "query": {
+        "type": "object",
+        "fields": {
+          "affected_rows": {
+            "column": "affected_rows",
+            "type": "column"
+          },
+
+          "returning": {
+            "type": "column",
+            "column": "returning",
             "fields": {
-              "name": {
-                "type": "column",
-                "column": "Name",
-                "arguments": {}
+              "type": "object",
+              "fields": {
+                "album_id": {
+                  "type": "column",
+                  "column": "AlbumId"
+                },
+                "title": {
+                  "type": "column",
+                  "column": "Title"
+                },
+                "artist": {
+                  "type": "relationship",
+                  "column": "Title",
+                  "relationship": "AlbumToArtist",
+                  "query": {
+                    "fields": {
+                      "name": {
+                        "type": "column",
+                        "column": "Name",
+                        "arguments": {}
+                      }
+                    }
+                  },
+                  "arguments": {}
+                }
               }
             }
-          },
-          "arguments": {}
+          }
         }
       }
     }

--- a/crates/tests/tests-common/goldenfiles/mutations/insert_artist_album_bad.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/insert_artist_album_bad.json
@@ -19,15 +19,18 @@
             "type": "column",
             "column": "returning",
             "fields": {
-              "type": "object",
+              "type": "array",
               "fields": {
-                "artist_id": {
-                  "type": "column",
-                  "column": "ArtistId"
-                },
-                "name": {
-                  "type": "column",
-                  "column": "Name"
+                "type": "object",
+                "fields": {
+                  "artist_id": {
+                    "type": "column",
+                    "column": "ArtistId"
+                  },
+                  "name": {
+                    "type": "column",
+                    "column": "Name"
+                  }
                 }
               }
             }
@@ -55,30 +58,33 @@
             "type": "column",
             "column": "returning",
             "fields": {
-              "type": "object",
+              "type": "array",
               "fields": {
-                "album_id": {
-                  "type": "column",
-                  "column": "AlbumId"
-                },
-                "title": {
-                  "type": "column",
-                  "column": "Title"
-                },
-                "artist": {
-                  "type": "relationship",
-                  "column": "Title",
-                  "relationship": "AlbumToArtist",
-                  "query": {
-                    "fields": {
-                      "name": {
-                        "type": "column",
-                        "column": "Name",
-                        "arguments": {}
-                      }
-                    }
+                "type": "object",
+                "fields": {
+                  "album_id": {
+                    "type": "column",
+                    "column": "AlbumId"
                   },
-                  "arguments": {}
+                  "title": {
+                    "type": "column",
+                    "column": "Title"
+                  },
+                  "artist": {
+                    "type": "relationship",
+                    "column": "Title",
+                    "relationship": "AlbumToArtist",
+                    "query": {
+                      "fields": {
+                        "name": {
+                          "type": "column",
+                          "column": "Name",
+                          "arguments": {}
+                        }
+                      }
+                    },
+                    "arguments": {}
+                  }
                 }
               }
             }

--- a/crates/tests/tests-common/goldenfiles/mutations/v1_insert_custom_dog.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/v1_insert_custom_dog.json
@@ -21,31 +21,34 @@
             "type": "column",
             "column": "returning",
             "fields": {
-              "type": "object",
+              "type": "array",
               "fields": {
-                "id": {
-                  "type": "column",
-                  "column": "id"
-                },
-                "name": {
-                  "type": "column",
-                  "column": "name"
-                },
-                "birthday": {
-                  "type": "column",
-                  "column": "birthday"
-                },
-                "height_cm": {
-                  "type": "column",
-                  "column": "height_cm"
-                },
-                "height_inch": {
-                  "type": "column",
-                  "column": "height_in"
-                },
-                "adopter_name": {
-                  "type": "column",
-                  "column": "adopter_name"
+                "type": "object",
+                "fields": {
+                  "id": {
+                    "type": "column",
+                    "column": "id"
+                  },
+                  "name": {
+                    "type": "column",
+                    "column": "name"
+                  },
+                  "birthday": {
+                    "type": "column",
+                    "column": "birthday"
+                  },
+                  "height_cm": {
+                    "type": "column",
+                    "column": "height_cm"
+                  },
+                  "height_inch": {
+                    "type": "column",
+                    "column": "height_in"
+                  },
+                  "adopter_name": {
+                    "type": "column",
+                    "column": "adopter_name"
+                  }
                 }
               }
             }
@@ -71,23 +74,26 @@
             "type": "column",
             "column": "returning",
             "fields": {
-              "type": "object",
+              "type": "array",
               "fields": {
-                "name": {
-                  "type": "column",
-                  "column": "name"
-                },
-                "birthday": {
-                  "type": "column",
-                  "column": "birthday"
-                },
-                "height_inch": {
-                  "type": "column",
-                  "column": "height_in"
-                },
-                "adopter_name": {
-                  "type": "column",
-                  "column": "adopter_name"
+                "type": "object",
+                "fields": {
+                  "name": {
+                    "type": "column",
+                    "column": "name"
+                  },
+                  "birthday": {
+                    "type": "column",
+                    "column": "birthday"
+                  },
+                  "height_inch": {
+                    "type": "column",
+                    "column": "height_in"
+                  },
+                  "adopter_name": {
+                    "type": "column",
+                    "column": "adopter_name"
+                  }
                 }
               }
             }

--- a/crates/tests/tests-common/goldenfiles/mutations/v1_insert_custom_dog.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/v1_insert_custom_dog.json
@@ -10,29 +10,46 @@
         }
       },
       "fields": {
-        "id": {
-          "type": "column",
-          "column": "id"
-        },
-        "name": {
-          "type": "column",
-          "column": "name"
-        },
-        "birthday": {
-          "type": "column",
-          "column": "birthday"
-        },
-        "height_cm": {
-          "type": "column",
-          "column": "height_cm"
-        },
-        "height_inch": {
-          "type": "column",
-          "column": "height_in"
-        },
-        "adopter_name": {
-          "type": "column",
-          "column": "adopter_name"
+        "type": "object",
+        "fields": {
+          "affected_rows": {
+            "column": "affected_rows",
+            "type": "column"
+          },
+
+          "returning": {
+            "type": "column",
+            "column": "returning",
+            "fields": {
+              "type": "object",
+              "fields": {
+                "id": {
+                  "type": "column",
+                  "column": "id"
+                },
+                "name": {
+                  "type": "column",
+                  "column": "name"
+                },
+                "birthday": {
+                  "type": "column",
+                  "column": "birthday"
+                },
+                "height_cm": {
+                  "type": "column",
+                  "column": "height_cm"
+                },
+                "height_inch": {
+                  "type": "column",
+                  "column": "height_in"
+                },
+                "adopter_name": {
+                  "type": "column",
+                  "column": "adopter_name"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -48,21 +65,54 @@
         }
       },
       "fields": {
-        "name": {
-          "type": "column",
-          "column": "name"
-        },
-        "birthday": {
-          "type": "column",
-          "column": "birthday"
-        },
-        "height_inch": {
-          "type": "column",
-          "column": "height_in"
-        },
-        "adopter_name": {
-          "type": "column",
-          "column": "adopter_name"
+        "type": "object",
+        "fields": {
+          "returning": {
+            "type": "column",
+            "column": "returning",
+            "fields": {
+              "type": "object",
+              "fields": {
+                "name": {
+                  "type": "column",
+                  "column": "name"
+                },
+                "birthday": {
+                  "type": "column",
+                  "column": "birthday"
+                },
+                "height_inch": {
+                  "type": "column",
+                  "column": "height_in"
+                },
+                "adopter_name": {
+                  "type": "column",
+                  "column": "adopter_name"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "procedure",
+      "name": "v1_insert_custom_dog",
+      "arguments": {
+        "_object": {
+          "name": "Kremboli",
+          "height_cm": 345,
+          "adopter_name": "Yaakov",
+          "birthday": "2024-02-14"
+        }
+      },
+      "fields": {
+        "type": "object",
+        "fields": {
+          "affected_rows": {
+            "column": "affected_rows",
+            "type": "column"
+          }
         }
       }
     }

--- a/crates/tests/tests-common/goldenfiles/mutations/v1_insert_custom_dog_missing_column.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/v1_insert_custom_dog_missing_column.json
@@ -20,31 +20,34 @@
             "type": "column",
             "column": "returning",
             "fields": {
-              "type": "object",
+              "type": "array",
               "fields": {
-                "id": {
-                  "type": "column",
-                  "column": "id"
-                },
-                "name": {
-                  "type": "column",
-                  "column": "name"
-                },
-                "birthday": {
-                  "type": "column",
-                  "column": "birthday"
-                },
-                "height_cm": {
-                  "type": "column",
-                  "column": "height_cm"
-                },
-                "height_inch": {
-                  "type": "column",
-                  "column": "height_in"
-                },
-                "adopter_name": {
-                  "type": "column",
-                  "column": "adopter_name"
+                "type": "object",
+                "fields": {
+                  "id": {
+                    "type": "column",
+                    "column": "id"
+                  },
+                  "name": {
+                    "type": "column",
+                    "column": "name"
+                  },
+                  "birthday": {
+                    "type": "column",
+                    "column": "birthday"
+                  },
+                  "height_cm": {
+                    "type": "column",
+                    "column": "height_cm"
+                  },
+                  "height_inch": {
+                    "type": "column",
+                    "column": "height_in"
+                  },
+                  "adopter_name": {
+                    "type": "column",
+                    "column": "adopter_name"
+                  }
                 }
               }
             }

--- a/crates/tests/tests-common/goldenfiles/mutations/v1_insert_custom_dog_missing_column.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/v1_insert_custom_dog_missing_column.json
@@ -9,29 +9,46 @@
         }
       },
       "fields": {
-        "id": {
-          "type": "column",
-          "column": "id"
-        },
-        "name": {
-          "type": "column",
-          "column": "name"
-        },
-        "birthday": {
-          "type": "column",
-          "column": "birthday"
-        },
-        "height_cm": {
-          "type": "column",
-          "column": "height_cm"
-        },
-        "height_inch": {
-          "type": "column",
-          "column": "height_in"
-        },
-        "adopter_name": {
-          "type": "column",
-          "column": "adopter_name"
+        "type": "object",
+        "fields": {
+          "affected_rows": {
+            "column": "affected_rows",
+            "type": "column"
+          },
+
+          "returning": {
+            "type": "column",
+            "column": "returning",
+            "fields": {
+              "type": "object",
+              "fields": {
+                "id": {
+                  "type": "column",
+                  "column": "id"
+                },
+                "name": {
+                  "type": "column",
+                  "column": "name"
+                },
+                "birthday": {
+                  "type": "column",
+                  "column": "birthday"
+                },
+                "height_cm": {
+                  "type": "column",
+                  "column": "height_cm"
+                },
+                "height_inch": {
+                  "type": "column",
+                  "column": "height_in"
+                },
+                "adopter_name": {
+                  "type": "column",
+                  "column": "adopter_name"
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/scripts/new-configuration.sh
+++ b/scripts/new-configuration.sh
@@ -19,7 +19,7 @@ DEFAULT_EXTRA_CONFIG="{}" # this is needed for mac to work, because EXTRA_CONFIG
 EXTRA_CONFIG="${3:-$DEFAULT_EXTRA_CONFIG}" # this defaults to '{}'
 
 # wait until the server is up and running
-"${CURRENT_DIR}/wait-until" --timeout=30 --report -- sh -c 'curl -fsS "http://${CONFIGURATION_SERVER}/healthz" > /dev/null'
+"${CURRENT_DIR}/wait-until" --timeout=30 --report -- sh -c 'curl -fsS "http://${CONFIGURATION_SERVER}/health" > /dev/null'
 
 function get {
   # write HTTP responses to this file

--- a/scripts/new-configuration.sh
+++ b/scripts/new-configuration.sh
@@ -19,7 +19,7 @@ DEFAULT_EXTRA_CONFIG="{}" # this is needed for mac to work, because EXTRA_CONFIG
 EXTRA_CONFIG="${3:-$DEFAULT_EXTRA_CONFIG}" # this defaults to '{}'
 
 # wait until the server is up and running
-"${CURRENT_DIR}/wait-until" --timeout=30 --report -- sh -c 'curl -fsS "http://${CONFIGURATION_SERVER}/health" > /dev/null'
+"${CURRENT_DIR}/wait-until" --timeout=30 --report -- sh -c 'curl -fsS "http://${CONFIGURATION_SERVER}/healthz" > /dev/null'
 
 function get {
   # write HTTP responses to this file


### PR DESCRIPTION
## What

This PR updates `ndc-postgres` to adhere to the RC15 version of `ndc-spec`.

## How

This required a bit more work than we'd originally expected: because the format of procedure results changed, we now need to generate a new object type for each procedure (namely, the result type: a product of `affected_rows` (int4) and `returning` (whatever the underlying collection's row type is).