### PR TITLE
update rust toolchain

### DIFF
--- a/crates/query-engine/translation/src/translation/query/sorting.rs
+++ b/crates/query-engine/translation/src/translation/query/sorting.rs
@@ -179,7 +179,7 @@ fn group_elements(elements: &[models::OrderByElement]) -> Vec<OrderByElementGrou
     for (_, vec) in column_element_groups {
         element_vecs.push(OrderByElementGroup::Columns {
             // if it's here, there's at least one.
-            path: vec.get(0).unwrap().1,
+            path: vec.first().unwrap().1,
             columns: vec
                 .into_iter()
                 .map(|(index, _, direction, element)| GroupedOrderByElement {
@@ -194,7 +194,7 @@ fn group_elements(elements: &[models::OrderByElement]) -> Vec<OrderByElementGrou
     for (_, vec) in aggregate_element_groups {
         element_vecs.push(OrderByElementGroup::Aggregates {
             // if it's here, there's at least one.
-            path: vec.get(0).unwrap().1,
+            path: vec.first().unwrap().1,
             aggregates: vec
                 .into_iter()
                 .map(|(index, _, direction, element)| GroupedOrderByElement {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701220101,
-        "narHash": "sha256-EBuCZ/Vjp3ovx8ZvfALfuUk4/76Ey/6cJmzmeXBRmDk=",
+        "lastModified": 1707685877,
+        "narHash": "sha256-XoXRS+5whotelr1rHiZle5t5hDg9kpguS5yk8c8qzOc=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "514cd663e5af505a244e55ad013733638574aff9",
+        "rev": "2c653e4478476a52c6aa3ac0495e4dea7449ea0e",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701068326,
-        "narHash": "sha256-vmMceA+q6hG1yrjb+MP8T0YFDQIrW3bl45e7z24IEts=",
+        "lastModified": 1707863367,
+        "narHash": "sha256-LdBbCSSP7VHaHA4KXcPGKqkvsowT2+7W4jlEHJj6rPg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8cfef6986adfb599ba379ae53c9f5631ecd2fd9c",
+        "rev": "35ff7e87ee05199a8003f438ec11a174bcbd98ea",
         "type": "github"
       },
       "original": {
@@ -72,11 +72,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701224160,
-        "narHash": "sha256-qnMmxNMKmd6Soel0cfauyMJ+LzuZbvmiDQPSIuTbQ+M=",
+        "lastModified": 1707963067,
+        "narHash": "sha256-1vmNGzAIenei+keS8vIUNYVkEGwEwF+3FR7/bXU/r18=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4a080e26d55eaedb95ab1bf8eeaeb84149c10f12",
+        "rev": "23f224428779539eb4dc13f6a77c97ffe4680d74",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.74.0"
+channel = "1.76.0"
 profile = "default"  # see https://rust-lang.github.io/rustup/concepts/profiles.html
 components = ["rust-analyzer", "rust-src"]  # see https://rust-lang.github.io/rustup/concepts/components.html


### PR DESCRIPTION
### What

We updated the rust toolchain for ndc-hub to 1.76.0, might as well do the same for ndc-postgres.
