### PR TITLE
Enable all Clippy warnings in Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ members = [
   "crates/query-engine/*",
   "crates/tests/*",
 ]
+
+[workspace.lints.clippy]
+all = "warn"

--- a/crates/configuration/Cargo.toml
+++ b/crates/configuration/Cargo.toml
@@ -3,6 +3,9 @@ name = "ndc-postgres-configuration"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 query-engine-metadata = { path = "../query-engine/metadata" }
 

--- a/crates/connectors/ndc-postgres/Cargo.toml
+++ b/crates/connectors/ndc-postgres/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 
 default-run = "ndc-postgres"
 
+[lints]
+workspace = true
+
 [lib]
 name = "ndc_postgres"
 path = "src/lib.rs"

--- a/crates/documentation/openapi/Cargo.toml
+++ b/crates/documentation/openapi/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 
-default-run = "openapi-generator"
+[lints]
+workspace = true
 
 [lib]
 name = "openapi_generator"

--- a/crates/query-engine/execution/Cargo.toml
+++ b/crates/query-engine/execution/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 query-engine-sql = { path = "../sql" }
 

--- a/crates/query-engine/metadata/Cargo.toml
+++ b/crates/query-engine/metadata/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 schemars = { version = "0.8.16", features = ["smol_str"] }
 serde = { version = "1.0.196", features = ["derive"] }

--- a/crates/query-engine/sql/Cargo.toml
+++ b/crates/query-engine/sql/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 schemars = { version = "0.8.16", features = ["smol_str", "preserve_order"] }
 serde = "1.0.196"

--- a/crates/query-engine/translation/Cargo.toml
+++ b/crates/query-engine/translation/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "02d26c1" }
 query-engine-metadata = { path = "../metadata" }

--- a/crates/tests/databases-tests/Cargo.toml
+++ b/crates/tests/databases-tests/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 [features]
 # We only run the AWS Aurora tests if this feature is enabled.
 # This is handled by the `just test` command, which enables the feature if the

--- a/crates/tests/tests-common/Cargo.toml
+++ b/crates/tests/tests-common/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 [lib]
 name = "tests_common"
 path = "src/lib.rs"

--- a/justfile
+++ b/justfile
@@ -324,10 +324,10 @@ repl-yugabyte:
 
 # run `clippy` linter
 lint *FLAGS:
-  cargo clippy {{FLAGS}}
+  cargo clippy -- --deny=clippy::all {{FLAGS}}
 
 lint-apply *FLAGS:
-  cargo clippy --fix {{FLAGS}}
+  cargo clippy --fix -- --deny=clippy::all {{FLAGS}}
 
 # reformat everything
 format:


### PR DESCRIPTION
### What

Enabling the warnings in _Cargo.toml_ means tooling (e.g. `cargo clippy` and `rust-analyzer`) will share the same list of warnings.

### How

Rust v1.74 added support for [a `[lints]` section in Cargo.toml files](https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-lints-section).

I have also added `--deny=clippy::all` to the Justfile so it fails if there are any warnings, just like CI does. This won't scale if we add more warnings though; not sure how to fix that yet.