### PR TITLE
benchmarks: Generate configuration without the configuration server.

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Build the Docker image 🔨
         run: |
-          docker load < $(nix build --no-link --print-out-paths '.#docker')
+          docker load --input="$(nix build --no-link --print-out-paths '.#docker')"
 
       - name: Start dependencies ▶️
         run: |
@@ -39,19 +39,20 @@ jobs:
           set -e -u -o pipefail
           cd benchmarks/component
           mkdir -p generated
-          docker compose up --detach --wait agent-configuration
-          CONFIGURATION_SERVER_PORT="$(docker compose port agent-configuration 9100 | sed 's/.\+://')"
-          CONFIGURATION_SERVER="localhost:${CONFIGURATION_SERVER_PORT}"
-          ../../scripts/new-configuration.sh "$CONFIGURATION_SERVER" 'postgresql://postgres:password@postgres' \
-            | tee ./generated/ndc-metadata.json
-          docker compose down agent-configuration
+          jq --arg uri 'postgresql://postgres:password@postgres' \
+            '.connectionUri.uri.value = $uri' \
+            ../../static/postgres/v3-chinook-ndc-metadata.json \
+            > ./generated/ndc-metadata.json
 
       - name: Run benchmarks 🏃
         run: |
           cd benchmarks/component
           for benchmark in $(ls benchmarks); do
             echo "Starting agent..."
-            docker compose up --wait agent
+            docker compose up --wait agent || {
+              docker compose logs agent
+              exit 1
+            }
             echo "Running ${benchmark}..."
             docker compose run --rm benchmark run "/benchmarks/$benchmark"
             echo "Saving metrics for ${benchmark}..."

--- a/benchmarks/component/docker-compose.yaml
+++ b/benchmarks/component/docker-compose.yaml
@@ -74,27 +74,6 @@ services:
       postgres:
         condition: service_started
 
-  agent-configuration:
-    image: ghcr.io/hasura/ndc-postgres:dev
-    command:
-      - configuration
-      - serve
-    init: true
-    ports:
-      - 9100
-    healthcheck:
-      test:
-        - CMD
-        - ndc-postgres
-        - check-health
-        - --port=9100
-      interval: 1s
-      timeout: 1s
-      retries: 30
-    depends_on:
-      postgres:
-        condition: service_started
-
   postgres:
     image: postgis/postgis:${POSTGRESQL_VERSION:-16}-3.4
     platform: linux/amd64


### PR DESCRIPTION
### What

The configuration server is going away. Eventually we'll have a CLI that does the same thing, but that doesn't currently exist.

Fortunately, specifically for the benchmarks, we can replicate the configuration server behavior simply by using `jq` to replace the connection URI in the already-generated configuration file.

### How

I've made the changes in both the local benchmark script and in the CI YAML file.