### PR TITLE
Bring ndc-postgres in line with ndc-spec RC16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,7 +1462,7 @@ dependencies = [
 [[package]]
 name = "ndc-client"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.15#7e10c73d19d03627b96cc666eadcd35f784517e0"
+source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.16#608ecc4b6719753c186a37494bbe95ae26e64f45"
 dependencies = [
  "async-trait",
  "indexmap 2.2.3",
@@ -1523,7 +1523,7 @@ dependencies = [
 [[package]]
 name = "ndc-sdk"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-hub.git?rev=e0e9629#e0e9629dc176bb41ee1b4ca8498dc3d6372f6a28"
+source = "git+https://github.com/hasura/ndc-hub.git?rev=ee52bae#ee52baea902ab6137338774f059bf97419bd12d0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1560,7 +1560,7 @@ dependencies = [
 [[package]]
 name = "ndc-test"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.15#7e10c73d19d03627b96cc666eadcd35f784517e0"
+source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.16#608ecc4b6719753c186a37494bbe95ae26e64f45"
 dependencies = [
  "async-trait",
  "clap",

--- a/crates/configuration/Cargo.toml
+++ b/crates/configuration/Cargo.toml
@@ -9,7 +9,7 @@ workspace = true
 [dependencies]
 query-engine-metadata = { path = "../query-engine/metadata" }
 
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "e0e9629" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "ee52bae" }
 
 schemars = { version = "0.8.16", features = ["smol_str", "preserve_order"] }
 serde = "1.0.196"

--- a/crates/connectors/ndc-postgres/Cargo.toml
+++ b/crates/connectors/ndc-postgres/Cargo.toml
@@ -24,7 +24,7 @@ query-engine-metadata = { path = "../../query-engine/metadata" }
 query-engine-sql = { path = "../../query-engine/sql" }
 query-engine-translation = { path = "../../query-engine/translation" }
 
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "e0e9629" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "ee52bae" }
 
 async-trait = "0.1.77"
 percent-encoding = "2.3.1"
@@ -37,8 +37,8 @@ tracing = "0.1.40"
 url = "2.5.0"
 
 [dev-dependencies]
-ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.15" }
-ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.15" }
+ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.16" }
+ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.16" }
 tests-common = { path = "../../tests/tests-common" }
 
 axum = "0.6.20"

--- a/crates/query-engine/translation/Cargo.toml
+++ b/crates/query-engine/translation/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 workspace = true
 
 [dependencies]
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "e0e9629" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "ee52bae" }
 query-engine-metadata = { path = "../metadata" }
 query-engine-sql = { path = "../sql" }
 

--- a/crates/tests/databases-tests/Cargo.toml
+++ b/crates/tests/databases-tests/Cargo.toml
@@ -26,7 +26,7 @@ postgres = []
 openapi-generator = { path = "../../documentation/openapi" }
 ndc-postgres = { path = "../../connectors/ndc-postgres" }
 ndc-postgres-configuration = { path = "../../configuration" }
-ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.15" }
+ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.16" }
 tests-common = { path = "../tests-common" }
 
 axum = "0.6.20"

--- a/crates/tests/tests-common/Cargo.toml
+++ b/crates/tests/tests-common/Cargo.toml
@@ -12,9 +12,9 @@ name = "tests_common"
 path = "src/lib.rs"
 
 [dependencies]
-ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.15" }
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "e0e9629" }
-ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.15" }
+ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.16" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "ee52bae" }
+ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.16" }
 
 ndc-postgres = { path = "../../connectors/ndc-postgres" }
 ndc-postgres-configuration = { path = "../../configuration" }


### PR DESCRIPTION
Upgrading to RC16 is a no-op for us, so this just bumps the versions.