### PR TITLE
fix engine metadata

### DIFF
--- a/static/postgres/chinook-metadata.json
+++ b/static/postgres/chinook-metadata.json
@@ -3,472 +3,521 @@
     "definition": {
       "name": "db",
       "url": {
-        "singleUrl": "http://localhost:8100"
+        "singleUrl": {
+          "value": "http://localhost:8100"
+        }
       },
       "schema": {
-        "scalar_types": {
-          "varchar": {
-            "aggregate_functions": {},
-            "comparison_operators": {
-              "_neq": {
-                "argument_type": {
-                  "type": "named",
-                  "name": "varchar"
+        "version": "v0.1",
+        "schema": {
+          "scalar_types": {
+            "varchar": {
+              "aggregate_functions": {},
+              "comparison_operators": {
+                "_neq": {
+                  "argument_type": {
+                    "type": "named",
+                    "name": "varchar"
+                  },
+                  "type": "custom"
+                },
+                "_gt": {
+                  "argument_type": {
+                    "type": "named",
+                    "name": "varchar"
+                  },
+                  "type": "custom"
+                },
+                "_gte": {
+                  "argument_type": {
+                    "type": "named",
+                    "name": "varchar"
+                  },
+                  "type": "custom"
+                },
+                "_lt": {
+                  "argument_type": {
+                    "type": "named",
+                    "name": "varchar"
+                  },
+                  "type": "custom"
+                },
+                "_lte": {
+                  "argument_type": {
+                    "type": "named",
+                    "name": "varchar"
+                  },
+                  "type": "custom"
+                },
+                "_like": {
+                  "argument_type": {
+                    "type": "named",
+                    "name": "varchar"
+                  },
+                  "type": "custom"
+                },
+                "_ilike": {
+                  "argument_type": {
+                    "type": "named",
+                    "name": "varchar"
+                  },
+                  "type": "custom"
+                },
+                "_nlike": {
+                  "argument_type": {
+                    "type": "named",
+                    "name": "varchar"
+                  },
+                  "type": "custom"
+                },
+                "_nilike": {
+                  "argument_type": {
+                    "type": "named",
+                    "name": "varchar"
+                  },
+                  "type": "custom"
+                },
+                "_regex": {
+                  "argument_type": {
+                    "type": "named",
+                    "name": "varchar"
+                  },
+                  "type": "custom"
+                },
+                "_iregex": {
+                  "argument_type": {
+                    "type": "named",
+                    "name": "varchar"
+                  },
+                  "type": "custom"
+                },
+                "_nregex": {
+                  "argument_type": {
+                    "type": "named",
+                    "name": "varchar"
+                  },
+                  "type": "custom"
+                },
+                "_niregex": {
+                  "argument_type": {
+                    "type": "named",
+                    "name": "varchar"
+                  },
+                  "type": "custom"
+                },
+                "_similar": {
+                  "argument_type": {
+                    "type": "named",
+                    "name": "varchar"
+                  },
+                  "type": "custom"
+                },
+                "_nsimilar": {
+                  "argument_type": {
+                    "type": "named",
+                    "name": "varchar"
+                  },
+                  "type": "custom"
+                },
+                "_eq": {
+                  "type": "equal"
                 }
               },
-              "_gt": {
-                "argument_type": {
-                  "type": "named",
-                  "name": "varchar"
+              "update_operators": {}
+            },
+            "int4": {
+              "aggregate_functions": {
+                "min": {
+                  "result_type": {
+                    "type": "nullable",
+                    "underlying_type": {
+                      "type": "named",
+                      "name": "int4"
+                    }
+                  }
+                },
+                "max": {
+                  "result_type": {
+                    "type": "nullable",
+                    "underlying_type": {
+                      "type": "named",
+                      "name": "int4"
+                    }
+                  }
                 }
               },
-              "_gte": {
-                "argument_type": {
-                  "type": "named",
-                  "name": "varchar"
+              "comparison_operators": {
+                "_gt": {
+                  "argument_type": {
+                    "type": "named",
+                    "name": "int4"
+                  },
+                  "type": "custom"
+                },
+                "_gte": {
+                  "argument_type": {
+                    "type": "named",
+                    "name": "int4"
+                  },
+                  "type": "custom"
+                },
+                "_lt": {
+                  "argument_type": {
+                    "type": "named",
+                    "name": "int4"
+                  },
+                  "type": "custom"
+                },
+                "_lte": {
+                  "argument_type": {
+                    "type": "named",
+                    "name": "int4"
+                  },
+                  "type": "custom"
+                },
+                "_neq": {
+                  "argument_type": {
+                    "type": "named",
+                    "name": "int4"
+                  },
+                  "type": "custom"
+                },
+                "_eq": {
+                  "type": "equal"
                 }
               },
-              "_lt": {
-                "argument_type": {
-                  "type": "named",
-                  "name": "varchar"
-                }
-              },
-              "_lte": {
-                "argument_type": {
-                  "type": "named",
-                  "name": "varchar"
-                }
-              },
-              "_like": {
-                "argument_type": {
-                  "type": "named",
-                  "name": "varchar"
-                }
-              },
-              "_ilike": {
-                "argument_type": {
-                  "type": "named",
-                  "name": "varchar"
-                }
-              },
-              "_nlike": {
-                "argument_type": {
-                  "type": "named",
-                  "name": "varchar"
-                }
-              },
-              "_nilike": {
-                "argument_type": {
-                  "type": "named",
-                  "name": "varchar"
-                }
-              },
-              "_regex": {
-                "argument_type": {
-                  "type": "named",
-                  "name": "varchar"
-                }
-              },
-              "_iregex": {
-                "argument_type": {
-                  "type": "named",
-                  "name": "varchar"
-                }
-              },
-              "_nregex": {
-                "argument_type": {
-                  "type": "named",
-                  "name": "varchar"
-                }
-              },
-              "_niregex": {
-                "argument_type": {
-                  "type": "named",
-                  "name": "varchar"
-                }
-              },
-              "_similar": {
-                "argument_type": {
-                  "type": "named",
-                  "name": "varchar"
-                }
-              },
-              "_nsimilar": {
-                "argument_type": {
-                  "type": "named",
-                  "name": "varchar"
+              "update_operators": {}
+            }
+          },
+          "object_types": {
+            "Artist": {
+              "description": "An artist",
+              "fields": {
+                "ArtistId": {
+                  "description": "The artist's primary key",
+                  "arguments": {},
+                  "type": {
+                    "type": "named",
+                    "name": "int4"
+                  }
+                },
+                "Name": {
+                  "description": "The artist's name",
+                  "arguments": {},
+                  "type": {
+                    "type": "named",
+                    "name": "varchar"
+                  }
                 }
               }
             },
-            "update_operators": {}
+            "Album": {
+              "description": "An album",
+              "fields": {
+                "AlbumId": {
+                  "description": "The album's primary key",
+                  "arguments": {},
+                  "type": {
+                    "type": "named",
+                    "name": "int4"
+                  }
+                },
+                "Title": {
+                  "description": "The album's title",
+                  "arguments": {},
+                  "type": {
+                    "type": "named",
+                    "name": "varchar"
+                  }
+                },
+                "ArtistId": {
+                  "description": "The album's artist ID",
+                  "arguments": {},
+                  "type": {
+                    "type": "named",
+                    "name": "int4"
+                  }
+                }
+              }
+            },
+            "Track": {
+              "description": "A track",
+              "fields": {
+                "TrackId": {
+                  "description": "The track's primary key",
+                  "arguments": {},
+                  "type": {
+                    "type": "named",
+                    "name": "int4"
+                  }
+                },
+                "Name": {
+                  "description": "The track's name",
+                  "arguments": {},
+                  "type": {
+                    "type": "named",
+                    "name": "varchar"
+                  }
+                },
+                "AlbumId": {
+                  "description": "The track's album ID",
+                  "arguments": {},
+                  "type": {
+                    "type": "named",
+                    "name": "int4"
+                  }
+                }
+              }
+            },
+            "artist_below_id": {
+              "description": "An artist",
+              "fields": {
+                "ArtistId": {
+                  "description": "The artist's primary key",
+                  "arguments": {},
+                  "type": {
+                    "type": "named",
+                    "name": "int4"
+                  }
+                },
+                "Name": {
+                  "description": "The artist's name",
+                  "arguments": {},
+                  "type": {
+                    "type": "named",
+                    "name": "varchar"
+                  }
+                }
+              }
+            },
+            "v1_insert_custom_dog_object": {
+              "description": "A dog",
+              "fields": {
+                "name": {
+                  "description": "The dog's name",
+                  "arguments": {},
+                  "type": {
+                    "type": "named",
+                    "name": "text"
+                  }
+                },
+                "birthday": {
+                  "description": "The dog's birthday",
+                  "arguments": {},
+                  "type": {
+                    "type": "named",
+                    "name": "date"
+                  }
+                },
+                "height_cm": {
+                  "description": "The dog's height in centimeters",
+                  "arguments": {},
+                  "type": {
+                    "type": "named",
+                    "name": "numeric"
+                  }
+                },
+                "adopter_name": {
+                  "description": "The dog's adopter's name",
+                  "arguments": {},
+                  "type": {
+                    "type": "named",
+                    "name": "text"
+                  }
+                }
+              }
+            },
+            "custom_dog": {
+              "description": "A dog",
+              "fields": {
+                "id": {
+                  "description": "The dog's id",
+                  "arguments": {},
+                  "type": {
+                    "type": "named",
+                    "name": "int8"
+                  }
+                },
+                "name": {
+                  "description": "The dog's name",
+                  "arguments": {},
+                  "type": {
+                    "type": "named",
+                    "name": "text"
+                  }
+                },
+                "birthday": {
+                  "description": "The dog's birthday",
+                  "arguments": {},
+                  "type": {
+                    "type": "named",
+                    "name": "date"
+                  }
+                },
+                "height_cm": {
+                  "description": "The dog's height in centimeters",
+                  "arguments": {},
+                  "type": {
+                    "type": "named",
+                    "name": "numeric"
+                  }
+                },
+                "height_in": {
+                  "description": "The dog's height in inches",
+                  "arguments": {},
+                  "type": {
+                    "type": "named",
+                    "name": "numeric"
+                  }
+                },
+                "adopter_name": {
+                  "description": "The dog's adopter's name",
+                  "arguments": {},
+                  "type": {
+                    "type": "named",
+                    "name": "text"
+                  }
+                }
+              }
+            }
           },
-          "int4": {
-            "aggregate_functions": {
-              "min": {
-                "result_type": {
-                  "type": "nullable",
-                  "underlying_type": {
+          "collections": [
+            {
+              "name": "Artist",
+              "description": "A collection of artists",
+              "arguments": {},
+              "type": "Artist",
+              "deletable": false,
+              "uniqueness_constraints": {
+                "ArtistById": {
+                  "unique_columns": ["ArtistId"]
+                }
+              },
+              "foreign_keys": {}
+            },
+            {
+              "name": "Album",
+              "description": "A collection of albums",
+              "arguments": {},
+              "type": "Album",
+              "deletable": false,
+              "uniqueness_constraints": {
+                "AlbumById": {
+                  "unique_columns": ["AlbumId"]
+                }
+              },
+              "foreign_keys": {}
+            },
+            {
+              "name": "Track",
+              "description": "A collection of tracks",
+              "arguments": {},
+              "type": "Track",
+              "deletable": false,
+              "uniqueness_constraints": {
+                "TrackById": {
+                  "unique_columns": ["TrackId"]
+                }
+              },
+              "foreign_keys": {}
+            },
+            {
+              "name": "artist_below_id",
+              "description": "A collection of artists below a certain id",
+              "arguments": {
+                "id": {
+                  "description": "The ceiling id",
+                  "type": {
                     "type": "named",
                     "name": "int4"
                   }
                 }
               },
-              "max": {
-                "result_type": {
-                  "type": "nullable",
-                  "underlying_type": {
+              "type": "Artist",
+              "deletable": false,
+              "uniqueness_constraints": {},
+              "foreign_keys": {}
+            }
+          ],
+          "functions": [],
+          "procedures": [
+            {
+              "name": "insert_artist",
+              "description": "Insert an artist",
+              "arguments": {
+                "id": {
+                  "description": "The id of the artist to insert",
+                  "type": {
                     "type": "named",
-                    "name": "int4"
+                    "name": "Int!"
+                  }
+                },
+                "name": {
+                  "description": "The name of the artist to insert",
+                  "type": {
+                    "type": "named",
+                    "name": "String!"
+                  }
+                }
+              },
+              "result_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "array",
+                  "element_type": {
+                    "type": "named",
+                    "name": "Artist"
                   }
                 }
               }
             },
-            "comparison_operators": {
-              "_gt": {
-                "argument_type": {
-                  "type": "named",
-                  "name": "int4"
+            {
+              "name": "v1_insert_custom_dog",
+              "description": "Insert a dog",
+              "arguments": {
+                "_object": {
+                  "description": "The dog to insert",
+                  "type": {
+                    "type": "named",
+                    "name": "v1_insert_custom_dog_object"
+                  }
                 }
               },
-              "_gte": {
-                "argument_type": {
-                  "type": "named",
-                  "name": "int4"
-                }
-              },
-              "_lt": {
-                "argument_type": {
-                  "type": "named",
-                  "name": "int4"
-                }
-              },
-              "_lte": {
-                "argument_type": {
-                  "type": "named",
-                  "name": "int4"
-                }
-              },
-              "_neq": {
-                "argument_type": {
-                  "type": "named",
-                  "name": "int4"
+              "result_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "array",
+                  "element_type": {
+                    "type": "named",
+                    "name": "custom_dog"
+                  }
                 }
               }
-            },
-            "update_operators": {}
-          }
+            }
+          ]
         },
-        "object_types": {
-          "Artist": {
-            "description": "An artist",
-            "fields": {
-              "ArtistId": {
-                "description": "The artist's primary key",
-                "arguments": {},
-                "type": {
-                  "type": "named",
-                  "name": "int4"
-                }
-              },
-              "Name": {
-                "description": "The artist's name",
-                "arguments": {},
-                "type": {
-                  "type": "named",
-                  "name": "varchar"
-                }
-              }
-            }
-          },
-          "Album": {
-            "description": "An album",
-            "fields": {
-              "AlbumId": {
-                "description": "The album's primary key",
-                "arguments": {},
-                "type": {
-                  "type": "named",
-                  "name": "int4"
-                }
-              },
-              "Title": {
-                "description": "The album's title",
-                "arguments": {},
-                "type": {
-                  "type": "named",
-                  "name": "varchar"
-                }
-              },
-              "ArtistId": {
-                "description": "The album's artist ID",
-                "arguments": {},
-                "type": {
-                  "type": "named",
-                  "name": "int4"
-                }
-              }
-            }
-          },
-          "Track": {
-            "description": "A track",
-            "fields": {
-              "TrackId": {
-                "description": "The track's primary key",
-                "arguments": {},
-                "type": {
-                  "type": "named",
-                  "name": "int4"
-                }
-              },
-              "Name": {
-                "description": "The track's name",
-                "arguments": {},
-                "type": {
-                  "type": "named",
-                  "name": "varchar"
-                }
-              },
-              "AlbumId": {
-                "description": "The track's album ID",
-                "arguments": {},
-                "type": {
-                  "type": "named",
-                  "name": "int4"
-                }
-              }
-            }
-          },
-          "artist_below_id": {
-            "description": "An artist",
-            "fields": {
-              "ArtistId": {
-                "description": "The artist's primary key",
-                "arguments": {},
-                "type": {
-                  "type": "named",
-                  "name": "int4"
-                }
-              },
-              "Name": {
-                "description": "The artist's name",
-                "arguments": {},
-                "type": {
-                  "type": "named",
-                  "name": "varchar"
-                }
-              }
-            }
-          },
-          "v1_insert_custom_dog_object": {
-            "description": "A dog",
-            "fields": {
-              "name": {
-                "description": "The dog's name",
-                "arguments": {},
-                "type": {
-                  "type": "named",
-                  "name": "text"
-                }
-              },
-              "birthday": {
-                "description": "The dog's birthday",
-                "arguments": {},
-                "type": {
-                  "type": "named",
-                  "name": "date"
-                }
-              },
-              "height_cm": {
-                "description": "The dog's height in centimeters",
-                "arguments": {},
-                "type": {
-                  "type": "named",
-                  "name": "numeric"
-                }
-              },
-              "adopter_name": {
-                "description": "The dog's adopter's name",
-                "arguments": {},
-                "type": {
-                  "type": "named",
-                  "name": "text"
-                }
-              }
-            }
-          },
-          "custom_dog": {
-            "description": "A dog",
-            "fields": {
-              "id": {
-                "description": "The dog's id",
-                "arguments": {},
-                "type": {
-                  "type": "named",
-                  "name": "int8"
-                }
-              },
-              "name": {
-                "description": "The dog's name",
-                "arguments": {},
-                "type": {
-                  "type": "named",
-                  "name": "text"
-                }
-              },
-              "birthday": {
-                "description": "The dog's birthday",
-                "arguments": {},
-                "type": {
-                  "type": "named",
-                  "name": "date"
-                }
-              },
-              "height_cm": {
-                "description": "The dog's height in centimeters",
-                "arguments": {},
-                "type": {
-                  "type": "named",
-                  "name": "numeric"
-                }
-              },
-              "height_in": {
-                "description": "The dog's height in inches",
-                "arguments": {},
-                "type": {
-                  "type": "named",
-                  "name": "numeric"
-                }
-              },
-              "adopter_name": {
-                "description": "The dog's adopter's name",
-                "arguments": {},
-                "type": {
-                  "type": "named",
-                  "name": "text"
-                }
-              }
+        "capabilities": {
+          "version": "0.1.0",
+          "capabilities": {
+            "query": {
+              "aggregates": {},
+              "variables": {},
+              "explain": {}
+            },
+            "mutation": {
+              "transactional": {},
+              "explain": {}
+            },
+            "relationships": {
+              "relation_comparisons": {},
+              "order_by_aggregate": {}
             }
           }
-        },
-        "collections": [
-          {
-            "name": "Artist",
-            "description": "A collection of artists",
-            "arguments": {},
-            "type": "Artist",
-            "deletable": false,
-            "uniqueness_constraints": {
-              "ArtistById": {
-                "unique_columns": ["ArtistId"]
-              }
-            },
-            "foreign_keys": {}
-          },
-          {
-            "name": "Album",
-            "description": "A collection of albums",
-            "arguments": {},
-            "type": "Album",
-            "deletable": false,
-            "uniqueness_constraints": {
-              "AlbumById": {
-                "unique_columns": ["AlbumId"]
-              }
-            },
-            "foreign_keys": {}
-          },
-          {
-            "name": "Track",
-            "description": "A collection of tracks",
-            "arguments": {},
-            "type": "Track",
-            "deletable": false,
-            "uniqueness_constraints": {
-              "TrackById": {
-                "unique_columns": ["TrackId"]
-              }
-            },
-            "foreign_keys": {}
-          },
-          {
-            "name": "artist_below_id",
-            "description": "A collection of artists below a certain id",
-            "arguments": {
-              "id": {
-                "description": "The ceiling id",
-                "type": {
-                  "type": "named",
-                  "name": "int4"
-                }
-              }
-            },
-            "type": "Artist",
-            "deletable": false,
-            "uniqueness_constraints": {},
-            "foreign_keys": {}
-          }
-        ],
-        "functions": [],
-        "procedures": [
-          {
-            "name": "insert_artist",
-            "description": "Insert an artist",
-            "arguments": {
-              "id": {
-                "description": "The id of the artist to insert",
-                "type": {
-                  "type": "named",
-                  "name": "Int!"
-                }
-              },
-              "name": {
-                "description": "The name of the artist to insert",
-                "type": {
-                  "type": "named",
-                  "name": "String!"
-                }
-              }
-            },
-            "result_type": {
-              "type": "nullable",
-              "underlying_type": {
-                "type": "array",
-                "element_type": {
-                  "type": "named",
-                  "name": "Artist"
-                }
-              }
-            }
-          },
-          {
-            "name": "v1_insert_custom_dog",
-            "description": "Insert a dog",
-            "arguments": {
-              "_object": {
-                "description": "The dog to insert",
-                "type": {
-                  "type": "named",
-                  "name": "v1_insert_custom_dog_object"
-                }
-              }
-            },
-            "result_type": {
-              "type": "nullable",
-              "underlying_type": {
-                "type": "array",
-                "element_type": {
-                  "type": "named",
-                  "name": "custom_dog"
-                }
-              }
-            }
-          }
-        ]
+        }
       }
     },
     "version": "v1",
-    "kind": "DataConnector"
+    "kind": "DataConnectorLink"
   },
   {
     "definition": {


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

This PR fixes the engine metadata

### How

Changes `DataConnector` to `DataConnectorLink`.

To the reviewer: Please use [hide whitespaces](https://github.com/hasura/ndc-postgres/pull/303/files?diff=unified&w=1) if you want to look at the changes.
