### PR TITLE
Use the `RuntimeConfiguration` as the real configuration.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,7 @@ dependencies = [
  "insta",
  "ndc-postgres",
  "ndc-postgres-configuration",
- "ndc-test 0.1.0 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.16)",
+ "ndc-test",
  "openapi-generator",
  "schemars",
  "serde_json",
@@ -1462,24 +1462,7 @@ dependencies = [
 [[package]]
 name = "ndc-client"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.16#608ecc4b6719753c186a37494bbe95ae26e64f45"
-dependencies = [
- "async-trait",
- "indexmap 2.2.3",
- "opentelemetry",
- "reqwest",
- "schemars",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with 2.3.3",
- "url",
-]
-
-[[package]]
-name = "ndc-client"
-version = "0.1.0"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.18#46ef35891198840a21653738cb386f97b069f56f"
+source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.18#46ef35891198840a21653738cb386f97b069f56f"
 dependencies = [
  "async-trait",
  "indexmap 2.2.3",
@@ -1503,10 +1486,10 @@ dependencies = [
  "env_logger",
  "hyper",
  "insta",
- "ndc-client 0.1.0 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.16)",
+ "ndc-client",
  "ndc-postgres-configuration",
  "ndc-sdk",
- "ndc-test 0.1.0 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.16)",
+ "ndc-test",
  "percent-encoding",
  "prometheus",
  "query-engine-execution",
@@ -1553,8 +1536,8 @@ dependencies = [
  "http",
  "indexmap 2.2.3",
  "mime",
- "ndc-client 0.1.0 (git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.18)",
- "ndc-test 0.1.0 (git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.18)",
+ "ndc-client",
+ "ndc-test",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-otlp",
@@ -1578,32 +1561,13 @@ dependencies = [
 [[package]]
 name = "ndc-test"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.16#608ecc4b6719753c186a37494bbe95ae26e64f45"
+source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.18#46ef35891198840a21653738cb386f97b069f56f"
 dependencies = [
  "async-trait",
  "clap",
  "colored",
  "indexmap 2.2.3",
- "ndc-client 0.1.0 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.16)",
- "proptest",
- "reqwest",
- "semver",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "ndc-test"
-version = "0.1.0"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.18#46ef35891198840a21653738cb386f97b069f56f"
-dependencies = [
- "async-trait",
- "clap",
- "colored",
- "indexmap 2.2.3",
- "ndc-client 0.1.0 (git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.18)",
+ "ndc-client",
  "proptest",
  "reqwest",
  "semver",
@@ -3198,11 +3162,11 @@ dependencies = [
  "env_logger",
  "hyper",
  "jsonschema",
- "ndc-client 0.1.0 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.16)",
+ "ndc-client",
  "ndc-postgres",
  "ndc-postgres-configuration",
  "ndc-sdk",
- "ndc-test 0.1.0 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.16)",
+ "ndc-test",
  "reqwest",
  "schemars",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1541,7 +1541,7 @@ dependencies = [
 [[package]]
 name = "ndc-sdk"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-hub.git?rev=42b3cfa#42b3cfa31fad9fb8bcf6c86adcfb0d39f3f0f245"
+source = "git+https://github.com/hasura/ndc-hub.git?rev=09edbd5#09edbd53d3d96a6b557c3f6918e272ce7739a6ae"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/configuration/Cargo.toml
+++ b/crates/configuration/Cargo.toml
@@ -9,7 +9,7 @@ workspace = true
 [dependencies]
 query-engine-metadata = { path = "../query-engine/metadata" }
 
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "42b3cfa" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "09edbd5" }
 
 schemars = { version = "0.8.16", features = ["smol_str", "preserve_order"] }
 serde = "1.0.196"

--- a/crates/configuration/src/configuration.rs
+++ b/crates/configuration/src/configuration.rs
@@ -1,6 +1,5 @@
 //! Configuration for the connector.
 
-use std::borrow::Cow;
 use std::fs::File;
 use std::path::Path;
 
@@ -28,7 +27,19 @@ impl RawConfiguration {
     }
 }
 
-pub type Configuration = RawConfiguration;
+/// A configuration type, tailored to the needs of the query/mutation/explain methods (i.e., those
+/// not to do with configuration management).
+///
+/// This separation also decouples the implementation from things like API versioning concerns
+/// somewhat.
+#[derive(Debug)]
+pub struct Configuration {
+    pub metadata: metadata::Metadata,
+    pub pool_settings: PoolSettings,
+    pub connection_uri: String,
+    pub isolation_level: IsolationLevel,
+    pub mutations_version: Option<metadata::mutations::MutationsVersion>,
+}
 
 pub async fn introspect(input: RawConfiguration) -> anyhow::Result<RawConfiguration> {
     match input {
@@ -52,38 +63,13 @@ pub async fn parse_configuration(
             message: error.to_string(),
         })
     })?;
-    Ok(RawConfiguration::Version3(configuration))
-}
-
-/// A configuration type, tailored to the needs of the query/mutation/explain methods (i.e., those
-/// not to do with configuration management).
-///
-/// This separation also decouples the implementation from things like API versioning concerns
-/// somewhat.
-///
-/// Since the RuntimeConfiguration is reconstructed from a Configuration at every method call, and
-/// since it consists of a sub-selection of components from the full Configuration, the fields are
-/// borrowed rather than owned.
-#[derive(Debug)]
-pub struct RuntimeConfiguration<'request> {
-    pub metadata: Cow<'request, metadata::Metadata>,
-    pub pool_settings: &'request PoolSettings,
-    pub connection_uri: &'request str,
-    pub isolation_level: IsolationLevel,
-    pub mutations_version: Option<metadata::mutations::MutationsVersion>,
-}
-
-/// Apply the common interpretations on the Configuration API type into an RuntimeConfiguration.
-pub fn as_runtime_configuration(input: &Configuration) -> RuntimeConfiguration<'_> {
-    match &input {
-        RawConfiguration::Version3(config) => RuntimeConfiguration {
-            metadata: Cow::Borrowed(&config.metadata),
-            pool_settings: &config.pool_settings,
-            connection_uri: match &config.connection_uri {
-                ConnectionUri::Uri(ResolvedSecret(uri)) => uri,
-            },
-            isolation_level: config.isolation_level,
-            mutations_version: config.configure_options.mutations_version,
+    Ok(Configuration {
+        metadata: configuration.metadata,
+        pool_settings: configuration.pool_settings,
+        connection_uri: match configuration.connection_uri {
+            ConnectionUri::Uri(ResolvedSecret(uri)) => uri,
         },
-    }
+        isolation_level: configuration.isolation_level,
+        mutations_version: configuration.configure_options.mutations_version,
+    })
 }

--- a/crates/configuration/src/lib.rs
+++ b/crates/configuration/src/lib.rs
@@ -3,9 +3,6 @@ mod values;
 
 pub mod version3;
 
-pub use configuration::{
-    as_runtime_configuration, introspect, parse_configuration, Configuration, RawConfiguration,
-    RuntimeConfiguration,
-};
+pub use configuration::{introspect, parse_configuration, Configuration, RawConfiguration};
 pub use values::{ConnectionUri, IsolationLevel, PoolSettings, ResolvedSecret};
 pub use version3::occurring_scalar_types;

--- a/crates/connectors/ndc-postgres/Cargo.toml
+++ b/crates/connectors/ndc-postgres/Cargo.toml
@@ -37,8 +37,8 @@ tracing = "0.1.40"
 url = "2.5.0"
 
 [dev-dependencies]
-ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.16" }
-ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.16" }
+ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.18" }
+ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.18" }
 tests-common = { path = "../../tests/tests-common" }
 
 axum = "0.6.20"

--- a/crates/connectors/ndc-postgres/Cargo.toml
+++ b/crates/connectors/ndc-postgres/Cargo.toml
@@ -24,7 +24,7 @@ query-engine-metadata = { path = "../../query-engine/metadata" }
 query-engine-sql = { path = "../../query-engine/sql" }
 query-engine-translation = { path = "../../query-engine/translation" }
 
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "42b3cfa" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "09edbd5" }
 
 async-trait = "0.1.77"
 percent-encoding = "2.3.1"

--- a/crates/connectors/ndc-postgres/src/connector.rs
+++ b/crates/connectors/ndc-postgres/src/connector.rs
@@ -60,11 +60,9 @@ impl connector::Connector for Postgres {
         configuration: &Self::Configuration,
         metrics: &mut prometheus::Registry,
     ) -> Result<Self::State, connector::InitializationError> {
-        let runtime_configuration = configuration::as_runtime_configuration(configuration);
-
         state::create_state(
-            runtime_configuration.connection_uri,
-            runtime_configuration.pool_settings,
+            &configuration.connection_uri,
+            &configuration.pool_settings,
             metrics,
         )
         .instrument(info_span!("Initialise state"))
@@ -135,8 +133,7 @@ impl connector::Connector for Postgres {
     async fn get_schema(
         configuration: &Self::Configuration,
     ) -> Result<JsonResponse<models::SchemaResponse>, connector::SchemaError> {
-        let runtime_configuration = configuration::as_runtime_configuration(configuration);
-        schema::get_schema(runtime_configuration)
+        schema::get_schema(configuration)
             .await
             .map_err(|err| {
                 tracing::error!(
@@ -161,8 +158,7 @@ impl connector::Connector for Postgres {
         state: &Self::State,
         request: models::QueryRequest,
     ) -> Result<JsonResponse<models::ExplainResponse>, connector::ExplainError> {
-        let runtime_configuration = configuration::as_runtime_configuration(configuration);
-        query::explain(runtime_configuration, state, request)
+        query::explain(configuration, state, request)
             .await
             .map_err(|err| {
                 tracing::error!(
@@ -187,8 +183,7 @@ impl connector::Connector for Postgres {
         state: &Self::State,
         request: models::MutationRequest,
     ) -> Result<JsonResponse<models::ExplainResponse>, connector::ExplainError> {
-        let runtime_configuration = configuration::as_runtime_configuration(configuration);
-        mutation::explain(runtime_configuration, state, request)
+        mutation::explain(configuration, state, request)
             .await
             .map_err(|err| {
                 tracing::error!(
@@ -213,8 +208,7 @@ impl connector::Connector for Postgres {
         state: &Self::State,
         request: models::MutationRequest,
     ) -> Result<JsonResponse<models::MutationResponse>, connector::MutationError> {
-        let runtime_configuration = configuration::as_runtime_configuration(configuration);
-        mutation::mutation(runtime_configuration, state, request)
+        mutation::mutation(configuration, state, request)
             .await
             .map_err(|err| {
                 tracing::error!(
@@ -238,8 +232,7 @@ impl connector::Connector for Postgres {
         state: &Self::State,
         query_request: models::QueryRequest,
     ) -> Result<JsonResponse<models::QueryResponse>, connector::QueryError> {
-        let runtime_configuration = configuration::as_runtime_configuration(configuration);
-        query::query(runtime_configuration, state, query_request)
+        query::query(configuration, state, query_request)
             .await
             .map_err(|err| {
                 tracing::error!(

--- a/crates/connectors/ndc-postgres/src/mutation.rs
+++ b/crates/connectors/ndc-postgres/src/mutation.rs
@@ -25,7 +25,7 @@ use super::state;
 /// This function implements the [mutation endpoint](https://hasura.github.io/ndc-spec/specification/mutations/index.html)
 /// from the NDC specification.
 pub async fn mutation(
-    configuration: configuration::RuntimeConfiguration<'_>,
+    configuration: &configuration::Configuration,
     state: &state::State,
     request: models::MutationRequest,
 ) -> Result<JsonResponse<models::MutationResponse>, connector::MutationError> {
@@ -57,7 +57,7 @@ pub async fn mutation(
 
 /// Create a mutation execution plan from a request.
 pub fn plan_mutation(
-    configuration: configuration::RuntimeConfiguration<'_>,
+    configuration: &configuration::Configuration,
     state: &state::State,
     request: models::MutationRequest,
 ) -> Result<

--- a/crates/connectors/ndc-postgres/src/mutation/explain.rs
+++ b/crates/connectors/ndc-postgres/src/mutation/explain.rs
@@ -19,8 +19,8 @@ use crate::state;
 ///
 /// This function implements the [mutation/explain endpoint](https://hasura.github.io/ndc-spec/specification/explain.html)
 /// from the NDC specification.
-pub async fn explain<'a>(
-    configuration: configuration::RuntimeConfiguration<'_>,
+pub async fn explain(
+    configuration: &configuration::Configuration,
     state: &state::State,
     mutation_request: models::MutationRequest,
 ) -> Result<models::ExplainResponse, connector::ExplainError> {

--- a/crates/connectors/ndc-postgres/src/query.rs
+++ b/crates/connectors/ndc-postgres/src/query.rs
@@ -24,7 +24,7 @@ use super::state;
 /// This function implements the [query endpoint](https://hasura.github.io/ndc-spec/specification/queries/index.html)
 /// from the NDC specification.
 pub async fn query(
-    configuration: configuration::RuntimeConfiguration<'_>,
+    configuration: &configuration::Configuration,
     state: &state::State,
     query_request: models::QueryRequest,
 ) -> Result<JsonResponse<models::QueryResponse>, connector::QueryError> {
@@ -55,7 +55,7 @@ pub async fn query(
 }
 
 fn plan_query(
-    configuration: configuration::RuntimeConfiguration<'_>,
+    configuration: &configuration::Configuration,
     state: &state::State,
     query_request: models::QueryRequest,
 ) -> Result<sql::execution_plan::ExecutionPlan<sql::execution_plan::Query>, connector::QueryError> {

--- a/crates/connectors/ndc-postgres/src/query/explain.rs
+++ b/crates/connectors/ndc-postgres/src/query/explain.rs
@@ -22,7 +22,7 @@ use super::state;
 /// This function implements the [query/explain endpoint](https://hasura.github.io/ndc-spec/specification/explain.html)
 /// from the NDC specification.
 pub async fn explain(
-    configuration: configuration::RuntimeConfiguration<'_>,
+    configuration: &configuration::Configuration,
     state: &state::State,
     query_request: models::QueryRequest,
 ) -> Result<models::ExplainResponse, connector::ExplainError> {
@@ -86,7 +86,7 @@ pub async fn explain(
 }
 
 fn plan_query(
-    configuration: configuration::RuntimeConfiguration<'_>,
+    configuration: &configuration::Configuration,
     state: &state::State,
     query_request: models::QueryRequest,
 ) -> Result<sql::execution_plan::ExecutionPlan<sql::execution_plan::Query>, connector::ExplainError>

--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -17,10 +17,9 @@ use query_engine_translation::translation::mutation::{delete, generate, insert};
 /// This function implements the [schema endpoint](https://hasura.github.io/ndc-spec/specification/schema/index.html)
 /// from the NDC specification.
 pub async fn get_schema(
-    config: configuration::RuntimeConfiguration<'_>,
+    config: &configuration::Configuration,
 ) -> Result<models::SchemaResponse, connector::SchemaError> {
-    let configuration::RuntimeConfiguration { metadata, .. } = config;
-
+    let metadata = &config.metadata;
     let mut scalar_types: BTreeMap<String, models::ScalarType> =
         configuration::occurring_scalar_types(&metadata.tables, &metadata.native_queries)
             .iter()

--- a/crates/query-engine/translation/Cargo.toml
+++ b/crates/query-engine/translation/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 query-engine-metadata = { path = "../metadata" }
 query-engine-sql = { path = "../sql" }
 
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "42b3cfa" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "09edbd5" }
 
 indexmap = "2"
 multimap = "0.9.1"

--- a/crates/tests/databases-tests/Cargo.toml
+++ b/crates/tests/databases-tests/Cargo.toml
@@ -26,7 +26,7 @@ postgres = []
 openapi-generator = { path = "../../documentation/openapi" }
 ndc-postgres = { path = "../../connectors/ndc-postgres" }
 ndc-postgres-configuration = { path = "../../configuration" }
-ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.16" }
+ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.18" }
 tests-common = { path = "../tests-common" }
 
 axum = "0.6.20"

--- a/crates/tests/databases-tests/src/postgres/configuration_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/configuration_tests.rs
@@ -15,7 +15,7 @@ use tests_common::common_tests;
 
 #[tokio::test]
 async fn get_configuration_schema() {
-    let schema = schemars::schema_for!(ndc_postgres_configuration::Configuration);
+    let schema = schemars::schema_for!(ndc_postgres_configuration::RawConfiguration);
     insta::assert_json_snapshot!(schema);
 }
 

--- a/crates/tests/tests-common/Cargo.toml
+++ b/crates/tests/tests-common/Cargo.toml
@@ -16,7 +16,7 @@ ndc-postgres = { path = "../../connectors/ndc-postgres" }
 ndc-postgres-configuration = { path = "../../configuration" }
 
 ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.16" }
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "42b3cfa" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "09edbd5" }
 ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.16" }
 
 axum = "0.6.20"

--- a/crates/tests/tests-common/Cargo.toml
+++ b/crates/tests/tests-common/Cargo.toml
@@ -15,9 +15,9 @@ path = "src/lib.rs"
 ndc-postgres = { path = "../../connectors/ndc-postgres" }
 ndc-postgres-configuration = { path = "../../configuration" }
 
-ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.16" }
+ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.18" }
 ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "09edbd5" }
-ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.16" }
+ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.18" }
 
 axum = "0.6.20"
 axum-test-helper = "0.3.0"


### PR DESCRIPTION
### What

As we no longer need to persist this, we don't need to worry about the schema changing at all.

### How

I renamed `RuntimeConfiguration` to `Configuration`, removed the borrowing (making it a totally owned type), and fixed all compilation failures.

I have upgraded `ndc-sdk` to remove the expectation that `Configuration` must be serializable.