### PR TITLE
fix just dev workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,4 @@ generated/
 /result-*
 
 # deployments created for testing
-static/temp-deploys/*.json
-
-# IntelliJ IDEs
-.idea
+static/temp-deploys/*

--- a/crates/tests/tests-common/src/ndc_metadata/mod.rs
+++ b/crates/tests/tests-common/src/ndc_metadata/mod.rs
@@ -10,6 +10,7 @@ pub mod helpers;
 use std::io;
 use std::path::{Path, PathBuf};
 
+#[derive(Debug)]
 pub struct FreshDeployment {
     pub db_name: String,
     pub ndc_metadata_path: PathBuf,


### PR DESCRIPTION
### What

Fix the `just dev` workflow stuck in an infinite loop.

### How

Mutation tests create a new ndc metadata directory for each test. Because the directory were not ignored by git, only the config files, they were picked up as changed to be watched for. We fix the gitignore and that fix the test.
