### PR TITLE
fix IN empty list

### DIFF
--- a/crates/tests/databases-tests/src/aurora/query_tests.rs
+++ b/crates/tests/databases-tests/src/aurora/query_tests.rs
@@ -156,6 +156,12 @@ mod predicates {
     }
 
     #[tokio::test]
+    async fn select_where_name_in_empty() {
+        let result = run_query(create_router().await, "select_where_name_in_empty").await;
+        insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test]
     async fn select_where_name_not_in() {
         let result = run_query(create_router().await, "select_where_name_not_in").await;
         insta::assert_json_snapshot!(result);

--- a/crates/tests/databases-tests/src/aurora/snapshots/databases_tests__aurora__query_tests__predicates__select_where_name_in_empty.snap
+++ b/crates/tests/databases-tests/src/aurora/snapshots/databases_tests__aurora__query_tests__predicates__select_where_name_in_empty.snap
@@ -1,0 +1,9 @@
+---
+source: crates/tests/databases-tests/src/aurora/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": []
+  }
+]

--- a/crates/tests/databases-tests/src/citus/query_tests.rs
+++ b/crates/tests/databases-tests/src/citus/query_tests.rs
@@ -156,6 +156,12 @@ mod predicates {
     }
 
     #[tokio::test]
+    async fn select_where_name_in_empty() {
+        let result = run_query(create_router().await, "select_where_name_in_empty").await;
+        insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test]
     async fn select_where_name_not_in() {
         let result = run_query(create_router().await, "select_where_name_not_in").await;
         insta::assert_json_snapshot!(result);

--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__query_tests__predicates__select_where_name_in_empty.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__query_tests__predicates__select_where_name_in_empty.snap
@@ -1,0 +1,9 @@
+---
+source: crates/tests/databases-tests/src/citus/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": []
+  }
+]

--- a/crates/tests/databases-tests/src/cockroach/query_tests.rs
+++ b/crates/tests/databases-tests/src/cockroach/query_tests.rs
@@ -166,6 +166,12 @@ mod predicates {
     }
 
     #[tokio::test]
+    async fn select_where_name_in_empty() {
+        let result = run_query(create_router().await, "select_where_name_in_empty").await;
+        insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test]
     async fn select_where_name_not_in() {
         let result = run_query(create_router().await, "select_where_name_not_in").await;
         insta::assert_json_snapshot!(result);

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__query_tests__predicates__select_where_name_in_empty.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__query_tests__predicates__select_where_name_in_empty.snap
@@ -1,0 +1,9 @@
+---
+source: crates/tests/databases-tests/src/cockroach/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": []
+  }
+]

--- a/crates/tests/databases-tests/src/postgres/query_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/query_tests.rs
@@ -174,6 +174,12 @@ mod predicates {
     }
 
     #[tokio::test]
+    async fn select_where_name_in_empty() {
+        let result = run_query(create_router().await, "select_where_name_in_empty").await;
+        insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test]
     async fn select_where_name_not_in() {
         let result = run_query(create_router().await, "select_where_name_not_in").await;
         insta::assert_json_snapshot!(result);

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__predicates__select_where_name_in_empty.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__predicates__select_where_name_in_empty.snap
@@ -1,0 +1,9 @@
+---
+source: crates/tests/databases-tests/src/postgres/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": []
+  }
+]

--- a/crates/tests/databases-tests/src/yugabyte/query_tests.rs
+++ b/crates/tests/databases-tests/src/yugabyte/query_tests.rs
@@ -150,6 +150,12 @@ mod predicates {
     }
 
     #[tokio::test]
+    async fn select_where_name_in_empty() {
+        let result = run_query(create_router().await, "select_where_name_in_empty").await;
+        insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test]
     async fn select_where_name_not_in() {
         let result = run_query(create_router().await, "select_where_name_not_in").await;
         insta::assert_json_snapshot!(result);

--- a/crates/tests/databases-tests/src/yugabyte/snapshots/databases_tests__yugabyte__query_tests__predicates__select_where_name_in_empty.snap
+++ b/crates/tests/databases-tests/src/yugabyte/snapshots/databases_tests__yugabyte__query_tests__predicates__select_where_name_in_empty.snap
@@ -1,0 +1,9 @@
+---
+source: crates/tests/databases-tests/src/yugabyte/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": []
+  }
+]

--- a/crates/tests/tests-common/goldenfiles/select_where_name_in_empty.json
+++ b/crates/tests/tests-common/goldenfiles/select_where_name_in_empty.json
@@ -1,0 +1,32 @@
+{
+  "collection": "Album",
+  "query": {
+    "fields": {
+      "AlbumId": {
+        "type": "column",
+        "column": "AlbumId",
+        "arguments": {}
+      },
+      "Title": {
+        "type": "column",
+        "column": "Title",
+        "arguments": {}
+      }
+    },
+    "predicate": {
+      "type": "binary_comparison_operator",
+      "column": {
+        "type": "column",
+        "name": "Title",
+        "path": []
+      },
+      "operator": "_in",
+      "value": {
+        "type": "scalar",
+        "value": []
+      }
+    }
+  },
+  "arguments": {},
+  "collection_relationships": {}
+}


### PR DESCRIPTION
### What

Fix a bug wrt `IN` empty list.

### How

postgres does not support the `<expr> in ()` syntax, so we replace it with `false`.
