### PR TITLE
Always clean up temp databases and deployments.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3157,6 +3157,7 @@ dependencies = [
 name = "tests-common"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "axum",
  "axum-test-helper",
  "env_logger",

--- a/crates/tests/databases-tests/src/postgres/mutation_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/mutation_tests.rs
@@ -2,13 +2,13 @@
 /// create a fresh db then run a query against it
 mod basic {
     use super::super::common;
-    use tests_common::ndc_metadata::{clean_up_ndc_metadata, create_fresh_ndc_metadata};
+    use tests_common::ndc_metadata::FreshDeployment;
     use tests_common::request::{run_mutation, run_query};
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn delete_playlist_track() {
         let ndc_metadata =
-            create_fresh_ndc_metadata(common::CONNECTION_STRING, common::CHINOOK_NDC_METADATA_PATH)
+            FreshDeployment::create(common::CONNECTION_STRING, common::CHINOOK_NDC_METADATA_PATH)
                 .await
                 .unwrap();
 
@@ -19,14 +19,13 @@ mod basic {
         )
         .await;
 
-        clean_up_ndc_metadata(ndc_metadata).await.unwrap();
         insta::assert_json_snapshot!(result)
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn insert_artist_album() {
         let ndc_metadata =
-            create_fresh_ndc_metadata(common::CONNECTION_STRING, common::CHINOOK_NDC_METADATA_PATH)
+            FreshDeployment::create(common::CONNECTION_STRING, common::CHINOOK_NDC_METADATA_PATH)
                 .await
                 .unwrap();
 
@@ -41,14 +40,13 @@ mod basic {
 
         let result = (mutation_result, selection_result);
 
-        clean_up_ndc_metadata(ndc_metadata).await.unwrap();
         insta::assert_json_snapshot!(result)
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn delete_invoice_line() {
         let ndc_metadata =
-            create_fresh_ndc_metadata(common::CONNECTION_STRING, common::CHINOOK_NDC_METADATA_PATH)
+            FreshDeployment::create(common::CONNECTION_STRING, common::CHINOOK_NDC_METADATA_PATH)
                 .await
                 .unwrap();
 
@@ -59,14 +57,13 @@ mod basic {
         )
         .await;
 
-        clean_up_ndc_metadata(ndc_metadata).await.unwrap();
         insta::assert_json_snapshot!(result)
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn v1_insert_custom_dog() {
         let ndc_metadata =
-            create_fresh_ndc_metadata(common::CONNECTION_STRING, common::CHINOOK_NDC_METADATA_PATH)
+            FreshDeployment::create(common::CONNECTION_STRING, common::CHINOOK_NDC_METADATA_PATH)
                 .await
                 .unwrap();
 
@@ -78,7 +75,6 @@ mod basic {
 
         let result = mutation_result;
 
-        clean_up_ndc_metadata(ndc_metadata).await.unwrap();
         insta::assert_json_snapshot!(result)
     }
 }
@@ -86,15 +82,15 @@ mod basic {
 #[cfg(test)]
 mod negative {
     use super::super::common;
-    use tests_common::ndc_metadata::{clean_up_ndc_metadata, create_fresh_ndc_metadata};
+    use tests_common::ndc_metadata::FreshDeployment;
     use tests_common::request::{run_mutation_fail, run_query, StatusCode};
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     /// Check that the second statement fails on duplicate key constraint,
     /// and that it rolls back the first statement.
     async fn insert_artist_album_bad() {
         let ndc_metadata =
-            create_fresh_ndc_metadata(common::CONNECTION_STRING, common::CHINOOK_NDC_METADATA_PATH)
+            FreshDeployment::create(common::CONNECTION_STRING, common::CHINOOK_NDC_METADATA_PATH)
                 .await
                 .unwrap();
 
@@ -114,15 +110,14 @@ mod negative {
 
         let result = (mutation_result, selection_result);
 
-        clean_up_ndc_metadata(ndc_metadata).await.unwrap();
         insta::assert_json_snapshot!(result);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     /// Check that insert fails due to missing column.
     async fn v1_insert_custom_dog_missing_column() {
         let ndc_metadata =
-            create_fresh_ndc_metadata(common::CONNECTION_STRING, common::CHINOOK_NDC_METADATA_PATH)
+            FreshDeployment::create(common::CONNECTION_STRING, common::CHINOOK_NDC_METADATA_PATH)
                 .await
                 .unwrap();
 
@@ -139,7 +134,6 @@ mod negative {
 
         let result = mutation_result;
 
-        clean_up_ndc_metadata(ndc_metadata).await.unwrap();
         insta::assert_json_snapshot!(result);
     }
 }

--- a/crates/tests/tests-common/Cargo.toml
+++ b/crates/tests/tests-common/Cargo.toml
@@ -19,6 +19,7 @@ ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.
 ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "09edbd5" }
 ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.18" }
 
+anyhow = "1.0.79"
 axum = "0.6.20"
 axum-test-helper = "0.3.0"
 env_logger = "0.10.2"

--- a/crates/tests/tests-common/src/ndc_metadata/database.rs
+++ b/crates/tests/tests-common/src/ndc_metadata/database.rs
@@ -26,14 +26,14 @@ async fn create_database_copy(connection_uri: &str, new_db_name: &str) -> String
 }
 
 /// given a connection string, drop a database `db_name`
-pub async fn drop_database(connection_uri: &str, db_name: &str) {
-    let mut connection = PgConnection::connect(connection_uri).await.unwrap();
+pub async fn drop_database(connection_uri: &str, db_name: &str) -> sqlx::Result<()> {
+    let mut connection = PgConnection::connect(connection_uri).await?;
 
     let drop_db_sql = format!("DROP DATABASE IF EXISTS \"{db_name}\" WITH (FORCE)");
 
     // we don't mind if this fails
-    let _ = connection.execute(drop_db_sql.as_str()).await;
-    println!("dropped {db_name}")
+    connection.execute(drop_db_sql.as_str()).await?;
+    Ok(())
 }
 
 // given a connection string, we need to make a new database and return a new connection string

--- a/crates/tests/tests-common/src/ndc_metadata/mod.rs
+++ b/crates/tests/tests-common/src/ndc_metadata/mod.rs
@@ -1,7 +1,4 @@
-//! Helpers for creating fresh NDC metadata files for testing . Use `create_fresh_ndc_metadata` to
-//! set up a new database and NDC metadata file, and `clean_up_ndc_metadata` to remove it again
-//! afterwards. It would be great to find a way of implementing these in a more Bracket-esq pattern
-//! that automatically takes care of clean up in future.
+//! Helpers for creating fresh NDC metadata files for testing.
 
 mod configuration;
 mod database;
@@ -14,32 +11,62 @@ use std::path::{Path, PathBuf};
 pub struct FreshDeployment {
     pub db_name: String,
     pub ndc_metadata_path: PathBuf,
-    pub admin_connection_string: String, // for dropping after
+    admin_connection_uri: String, // for dropping after
 }
 
-/// Create a new NDC metadata, pointing to a fresh copy of the database
-pub async fn create_fresh_ndc_metadata(
-    connection_uri: &str,
-    ndc_metadata_path: impl AsRef<Path>,
-) -> io::Result<FreshDeployment> {
-    let (db_name, new_connection_uri) = database::create_fresh_database(connection_uri).await;
+impl FreshDeployment {
+    /// Create a fresh copy of the database and its associated NDC metadata.
+    pub async fn create(
+        connection_uri: &str,
+        ndc_metadata_path: impl AsRef<Path>,
+    ) -> io::Result<FreshDeployment> {
+        let (db_name, new_connection_uri) = database::create_fresh_database(connection_uri).await;
 
-    let new_ndc_metadata_path = PathBuf::from("static/temp-deploys").join(&db_name);
+        let new_ndc_metadata_path = PathBuf::from("static/temp-deploys").join(&db_name);
 
-    configuration::copy_ndc_metadata_with_new_postgres_url(
-        ndc_metadata_path,
-        &new_connection_uri,
-        &new_ndc_metadata_path,
-    )?;
-    Ok(FreshDeployment {
-        db_name,
-        ndc_metadata_path: new_ndc_metadata_path,
-        admin_connection_string: connection_uri.to_string(),
-    })
+        configuration::copy_ndc_metadata_with_new_postgres_url(
+            ndc_metadata_path,
+            &new_connection_uri,
+            &new_ndc_metadata_path,
+        )?;
+        Ok(FreshDeployment {
+            db_name,
+            ndc_metadata_path: new_ndc_metadata_path,
+            admin_connection_uri: connection_uri.to_string(),
+        })
+    }
 }
 
-/// Remove database created for fresh NDC metadata
-pub async fn clean_up_ndc_metadata(ndc_metadata: FreshDeployment) -> io::Result<()> {
-    database::drop_database(&ndc_metadata.admin_connection_string, &ndc_metadata.db_name).await;
-    configuration::delete_ndc_metadata(&ndc_metadata.ndc_metadata_path)
+impl Drop for FreshDeployment {
+    fn drop(&mut self) {
+        // To take ownership of the data so that we can move it into a future, we must replace it
+        // with something else.
+        //
+        // We use empty strings, which isn't ideal, but if the compiler has done its job, there
+        // should be no dangling references to these anyway.
+        //
+        // We then swap them in so that we take ownership of the properties we need.
+        let mut db_name = "".to_string();
+        let mut ndc_metadata_path = PathBuf::from("");
+        let mut admin_connection_uri = "".to_string();
+        std::mem::swap(&mut self.db_name, &mut db_name);
+        std::mem::swap(&mut self.ndc_metadata_path, &mut ndc_metadata_path);
+        std::mem::swap(&mut self.admin_connection_uri, &mut admin_connection_uri);
+
+        // In order to call async behavior from a synchronous `Drop`, we must block on it.
+        // This magic incantation seems to do the trick. Others did not.
+        let result: anyhow::Result<()> = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async move {
+                database::drop_database(&admin_connection_uri, &db_name).await?;
+                configuration::delete_ndc_metadata(&ndc_metadata_path)?;
+                Ok(())
+            })
+        });
+        match result {
+            Ok(()) => (),
+            // We must not panic during a `drop`, so we just print the error in a feeble attempt to
+            // do the right thing.
+            Err(error) => eprintln!("Error while dropping FreshDeployment: {error}"),
+        }
+    }
 }


### PR DESCRIPTION
### What

Yes, even if the tests fail.

Previously, these would accumulate.

### How

We implement `Drop` on `FreshDeployment` to ensure that the database and file system are always cleaned up (barring something catastrophic, such as power failure).