### PR TITLE
Print useful output when ndc-test fails.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,6 @@ dependencies = [
  "insta",
  "ndc-postgres",
  "ndc-postgres-configuration",
- "ndc-test",
  "openapi-generator",
  "schemars",
  "serde_json",

--- a/crates/tests/databases-tests/Cargo.toml
+++ b/crates/tests/databases-tests/Cargo.toml
@@ -26,7 +26,6 @@ postgres = []
 openapi-generator = { path = "../../documentation/openapi" }
 ndc-postgres = { path = "../../connectors/ndc-postgres" }
 ndc-postgres-configuration = { path = "../../configuration" }
-ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.18" }
 tests-common = { path = "../tests-common" }
 
 axum = "0.6.20"

--- a/crates/tests/databases-tests/src/citus/ndc_tests.rs
+++ b/crates/tests/databases-tests/src/citus/ndc_tests.rs
@@ -3,10 +3,10 @@
 #![cfg(test)]
 
 use super::common;
-use tests_common::common_tests;
+use tests_common::common_tests::ndc_tests;
 
 #[tokio::test]
-async fn test_connector() -> Result<(), Vec<ndc_test::FailedTest>> {
+async fn test_connector() -> ndc_tests::Result {
     let router = common::create_router().await;
-    common_tests::ndc_tests::test_connector(router).await
+    ndc_tests::test_connector(router).await
 }

--- a/crates/tests/databases-tests/src/cockroach/ndc_tests.rs
+++ b/crates/tests/databases-tests/src/cockroach/ndc_tests.rs
@@ -3,10 +3,10 @@
 #![cfg(test)]
 
 use super::common;
-use tests_common::common_tests;
+use tests_common::common_tests::ndc_tests;
 
 #[tokio::test]
-async fn test_connector() -> Result<(), Vec<ndc_test::FailedTest>> {
+async fn test_connector() -> ndc_tests::Result {
     let router = common::create_router().await;
-    common_tests::ndc_tests::test_connector(router).await
+    ndc_tests::test_connector(router).await
 }

--- a/crates/tests/databases-tests/src/postgres/ndc_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/ndc_tests.rs
@@ -3,10 +3,10 @@
 #![cfg(test)]
 
 use super::common;
-use tests_common::common_tests;
+use tests_common::common_tests::ndc_tests;
 
 #[tokio::test]
-async fn test_connector() -> Result<(), Vec<ndc_test::FailedTest>> {
+async fn test_connector() -> ndc_tests::Result {
     let router = common::create_router().await;
-    common_tests::ndc_tests::test_connector(router).await
+    ndc_tests::test_connector(router).await
 }

--- a/crates/tests/tests-common/src/common_tests/ndc_tests.rs
+++ b/crates/tests/tests-common/src/common_tests/ndc_tests.rs
@@ -1,6 +1,32 @@
 use std::net;
 
-pub async fn test_connector(router: axum::Router) -> Result<(), Vec<ndc_test::FailedTest>> {
+pub type Result = std::result::Result<(), Failures>;
+
+pub struct Failures(Vec<ndc_test::FailedTest>);
+
+// The `Debug` implementation for `Failures` is a pretty-printed debug output of each failure,
+// separated by a newline.
+//
+// It's not perfect, but it's much easier to read than the standard debug output.
+impl std::fmt::Debug for Failures {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for failure in &self.0 {
+            writeln!(f, "{failure:#?}")?;
+        }
+        Ok(())
+    }
+}
+
+// The `Display` implementation just delegates to the `Debug` implementation.
+impl std::fmt::Display for Failures {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl std::error::Error for Failures {}
+
+pub async fn test_connector(router: axum::Router) -> Result {
     let server = hyper::Server::bind(&net::SocketAddr::new(
         net::IpAddr::V4(net::Ipv4Addr::LOCALHOST),
         0,
@@ -34,6 +60,6 @@ pub async fn test_connector(router: axum::Router) -> Result<(), Vec<ndc_test::Fa
     if test_results.failures.is_empty() {
         Ok(())
     } else {
-        Err(test_results.failures)
+        Err(Failures(test_results.failures))
     }
 }


### PR DESCRIPTION
### What

The `Debug` output of `Vec<FailedTest>` can be very long and hard to read.

### How

By simply pretty-printing each failure separated by newlines, we can make it readable.