### PR TITLE
Add an `update` command to the CLI that introspects the database.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,6 +1516,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0.79"
 clap = { version = "4.4.8", features = ["derive"] }
 serde_json = { version = "1.0.113", features = ["raw_value"] }
 thiserror = "1.0.57"
+tokio = { version = "1.36.0", features = ["full"] }
 
 [dev-dependencies]
 tempfile = "3.10.0"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -11,10 +11,11 @@ use ndc_postgres_cli::*;
 
 /// The application entrypoint. It pulls information from the environment and then calls the [run]
 /// function, so all process-level non-determinism is held here.
-pub fn main() -> anyhow::Result<()> {
+#[tokio::main]
+pub async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     // The library is not aware of the current directory so that we can more easily test it.
     let current_directory = env::current_dir()?;
-    run(args.subcommand, &current_directory)?;
+    run(args.subcommand, &current_directory).await?;
     Ok(())
 }

--- a/crates/cli/tests/initialize_tests.rs
+++ b/crates/cli/tests/initialize_tests.rs
@@ -3,11 +3,11 @@ use std::fs;
 use ndc_postgres_cli::*;
 use ndc_postgres_configuration::RawConfiguration;
 
-#[test]
-fn test_initialize_directory() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_initialize_directory() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
 
-    run(Command::Initialize, dir.path())?;
+    run(Command::Initialize, dir.path()).await?;
 
     let configuration_file_path = dir.path().join("configuration.json");
     assert!(configuration_file_path.exists());
@@ -17,15 +17,15 @@ fn test_initialize_directory() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_do_not_initialize_when_files_already_exist() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_do_not_initialize_when_files_already_exist() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     fs::write(
         dir.path().join("random.file"),
         "this directory is no longer empty",
     )?;
 
-    match run(Command::Initialize, dir.path()) {
+    match run(Command::Initialize, dir.path()).await {
         Ok(()) => panic!("Expected the command to fail."),
         Err(error) => match error.downcast::<Error>() {
             Err(input) => panic!("Expected a CLI error, but got {input}"),

--- a/crates/cli/tests/update_tests.rs
+++ b/crates/cli/tests/update_tests.rs
@@ -1,0 +1,42 @@
+use std::fs;
+
+use ndc_postgres_cli::*;
+use ndc_postgres_configuration as configuration;
+use ndc_postgres_configuration::RawConfiguration;
+
+const CONNECTION_STRING: &str = "postgresql://postgres:password@localhost:64002";
+
+#[tokio::test]
+async fn test_update_configuration() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    {
+        let configuration_file_path = dir.path().join("configuration.json");
+        let input = RawConfiguration::Version3(configuration::version3::RawConfiguration {
+            connection_uri: CONNECTION_STRING.into(),
+            ..configuration::version3::RawConfiguration::empty()
+        });
+        let writer = fs::File::create(configuration_file_path)?;
+        serde_json::to_writer(writer, &input)?;
+    }
+
+    run(Command::Update, dir.path()).await?;
+
+    let configuration_file_path = dir.path().join("configuration.json");
+    assert!(configuration_file_path.exists());
+    let contents = fs::read_to_string(configuration_file_path)?;
+    let output: RawConfiguration = serde_json::from_str(&contents)?;
+    match output {
+        RawConfiguration::Version3(configuration::version3::RawConfiguration {
+            connection_uri:
+                configuration::ConnectionUri::Uri(configuration::ResolvedSecret(connection_uri)),
+            metadata,
+            ..
+        }) => {
+            assert_eq!(connection_uri, CONNECTION_STRING.to_string());
+            let some_table_metadata = metadata.tables.0.get("Artist");
+            assert!(some_table_metadata.is_some());
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
### What

This works similarly to the update behavior of the old configuration server.

### How

There wasn't a lot to do.

This does not update the scripts; I will follow up with that later.