### PR TITLE
Remove duplication in error types and error-handling.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2176,6 +2176,7 @@ dependencies = [
  "serde_json",
  "sqlformat",
  "sqlx",
+ "thiserror",
  "tracing",
 ]
 

--- a/crates/connectors/ndc-postgres/src/convert.rs
+++ b/crates/connectors/ndc-postgres/src/convert.rs
@@ -1,0 +1,75 @@
+//! Functions to convert between internal error types and the error types exposed by ndc-sdk.
+
+use ndc_sdk::connector;
+
+pub(crate) fn execution_error_to_query_error(
+    error: query_engine_execution::error::Error,
+) -> connector::QueryError {
+    match error {
+        query_engine_execution::error::Error::Query(query_error) => match &query_error {
+            query_engine_execution::error::QueryError::VariableNotFound(_) => {
+                connector::QueryError::InvalidRequest(query_error.to_string())
+            }
+            query_engine_execution::error::QueryError::NotSupported(_) => {
+                connector::QueryError::UnsupportedOperation(query_error.to_string())
+            }
+            query_engine_execution::error::QueryError::DBError(_) => {
+                connector::QueryError::UnprocessableContent(query_error.to_string())
+            }
+            query_engine_execution::error::QueryError::DBConstraintError(_) => {
+                connector::QueryError::UnprocessableContent(query_error.to_string())
+            }
+        },
+        query_engine_execution::error::Error::DB(_) => {
+            connector::QueryError::Other(Box::new(error))
+        }
+    }
+}
+
+pub(crate) fn execution_error_to_mutation_error(
+    error: query_engine_execution::error::Error,
+) -> connector::MutationError {
+    match error {
+        query_engine_execution::error::Error::Query(query_error) => match &query_error {
+            query_engine_execution::error::QueryError::VariableNotFound(_) => {
+                connector::MutationError::InvalidRequest(query_error.to_string())
+            }
+            query_engine_execution::error::QueryError::NotSupported(_) => {
+                connector::MutationError::UnsupportedOperation(query_error.to_string())
+            }
+            query_engine_execution::error::QueryError::DBError(_) => {
+                connector::MutationError::UnprocessableContent(query_error.to_string())
+            }
+            query_engine_execution::error::QueryError::DBConstraintError(_) => {
+                connector::MutationError::ConstraintNotMet(query_error.to_string())
+            }
+        },
+        query_engine_execution::error::Error::DB(_) => {
+            connector::MutationError::Other(Box::new(error))
+        }
+    }
+}
+
+pub(crate) fn execution_error_to_explain_error(
+    error: query_engine_execution::error::Error,
+) -> connector::ExplainError {
+    match error {
+        query_engine_execution::error::Error::Query(query_error) => match &query_error {
+            query_engine_execution::error::QueryError::VariableNotFound(_) => {
+                connector::ExplainError::InvalidRequest(query_error.to_string())
+            }
+            query_engine_execution::error::QueryError::NotSupported(_) => {
+                connector::ExplainError::UnsupportedOperation(query_error.to_string())
+            }
+            query_engine_execution::error::QueryError::DBError(_) => {
+                connector::ExplainError::UnprocessableContent(query_error.to_string())
+            }
+            query_engine_execution::error::QueryError::DBConstraintError(_) => {
+                connector::ExplainError::UnprocessableContent(query_error.to_string())
+            }
+        },
+        query_engine_execution::error::Error::DB(_) => {
+            connector::ExplainError::Other(Box::new(error))
+        }
+    }
+}

--- a/crates/connectors/ndc-postgres/src/convert.rs
+++ b/crates/connectors/ndc-postgres/src/convert.rs
@@ -5,71 +5,113 @@ use ndc_sdk::connector;
 pub(crate) fn execution_error_to_query_error(
     error: query_engine_execution::error::Error,
 ) -> connector::QueryError {
+    use query_engine_execution::error::*;
     match error {
-        query_engine_execution::error::Error::Query(query_error) => match &query_error {
-            query_engine_execution::error::QueryError::VariableNotFound(_) => {
+        Error::Query(query_error) => match &query_error {
+            QueryError::VariableNotFound(_) => {
                 connector::QueryError::InvalidRequest(query_error.to_string())
             }
-            query_engine_execution::error::QueryError::NotSupported(_) => {
+            QueryError::NotSupported(_) => {
                 connector::QueryError::UnsupportedOperation(query_error.to_string())
             }
-            query_engine_execution::error::QueryError::DBError(_) => {
+            QueryError::DBError(_) => {
                 connector::QueryError::UnprocessableContent(query_error.to_string())
             }
-            query_engine_execution::error::QueryError::DBConstraintError(_) => {
+            QueryError::DBConstraintError(_) => {
                 connector::QueryError::UnprocessableContent(query_error.to_string())
             }
         },
-        query_engine_execution::error::Error::DB(_) => {
-            connector::QueryError::Other(Box::new(error))
-        }
+        Error::DB(_) => connector::QueryError::Other(Box::new(error)),
     }
 }
 
 pub(crate) fn execution_error_to_mutation_error(
     error: query_engine_execution::error::Error,
 ) -> connector::MutationError {
+    use query_engine_execution::error::*;
     match error {
-        query_engine_execution::error::Error::Query(query_error) => match &query_error {
-            query_engine_execution::error::QueryError::VariableNotFound(_) => {
+        Error::Query(query_error) => match &query_error {
+            QueryError::VariableNotFound(_) => {
                 connector::MutationError::InvalidRequest(query_error.to_string())
             }
-            query_engine_execution::error::QueryError::NotSupported(_) => {
+            QueryError::NotSupported(_) => {
                 connector::MutationError::UnsupportedOperation(query_error.to_string())
             }
-            query_engine_execution::error::QueryError::DBError(_) => {
+            QueryError::DBError(_) => {
                 connector::MutationError::UnprocessableContent(query_error.to_string())
             }
-            query_engine_execution::error::QueryError::DBConstraintError(_) => {
+            QueryError::DBConstraintError(_) => {
                 connector::MutationError::ConstraintNotMet(query_error.to_string())
             }
         },
-        query_engine_execution::error::Error::DB(_) => {
-            connector::MutationError::Other(Box::new(error))
-        }
+        Error::DB(_) => connector::MutationError::Other(Box::new(error)),
     }
 }
 
 pub(crate) fn execution_error_to_explain_error(
     error: query_engine_execution::error::Error,
 ) -> connector::ExplainError {
+    use query_engine_execution::error::*;
     match error {
-        query_engine_execution::error::Error::Query(query_error) => match &query_error {
-            query_engine_execution::error::QueryError::VariableNotFound(_) => {
+        Error::Query(query_error) => match &query_error {
+            QueryError::VariableNotFound(_) => {
                 connector::ExplainError::InvalidRequest(query_error.to_string())
             }
-            query_engine_execution::error::QueryError::NotSupported(_) => {
+            QueryError::NotSupported(_) => {
                 connector::ExplainError::UnsupportedOperation(query_error.to_string())
             }
-            query_engine_execution::error::QueryError::DBError(_) => {
+            QueryError::DBError(_) => {
                 connector::ExplainError::UnprocessableContent(query_error.to_string())
             }
-            query_engine_execution::error::QueryError::DBConstraintError(_) => {
+            QueryError::DBConstraintError(_) => {
                 connector::ExplainError::UnprocessableContent(query_error.to_string())
             }
         },
-        query_engine_execution::error::Error::DB(_) => {
-            connector::ExplainError::Other(Box::new(error))
+        Error::DB(_) => connector::ExplainError::Other(Box::new(error)),
+    }
+}
+
+pub(crate) fn translation_error_to_query_error(
+    error: query_engine_translation::translation::error::Error,
+) -> connector::QueryError {
+    use query_engine_translation::translation::error::*;
+    match error {
+        Error::CapabilityNotSupported(_) => {
+            connector::QueryError::UnsupportedOperation(error.to_string())
         }
+        Error::NotImplementedYet(_) => {
+            connector::QueryError::UnsupportedOperation(error.to_string())
+        }
+        _ => connector::QueryError::InvalidRequest(error.to_string()),
+    }
+}
+
+pub(crate) fn translation_error_to_mutation_error(
+    error: query_engine_translation::translation::error::Error,
+) -> connector::MutationError {
+    use query_engine_translation::translation::error::*;
+    match error {
+        Error::CapabilityNotSupported(_) => {
+            connector::MutationError::UnsupportedOperation(error.to_string())
+        }
+        Error::NotImplementedYet(_) => {
+            connector::MutationError::UnsupportedOperation(error.to_string())
+        }
+        _ => connector::MutationError::InvalidRequest(error.to_string()),
+    }
+}
+
+pub(crate) fn translation_error_to_explain_error(
+    error: query_engine_translation::translation::error::Error,
+) -> connector::ExplainError {
+    use query_engine_translation::translation::error::*;
+    match error {
+        Error::CapabilityNotSupported(_) => {
+            connector::ExplainError::UnsupportedOperation(error.to_string())
+        }
+        Error::NotImplementedYet(_) => {
+            connector::ExplainError::UnsupportedOperation(error.to_string())
+        }
+        _ => connector::ExplainError::InvalidRequest(error.to_string()),
     }
 }

--- a/crates/connectors/ndc-postgres/src/lib.rs
+++ b/crates/connectors/ndc-postgres/src/lib.rs
@@ -8,3 +8,6 @@ pub mod mutation;
 pub mod query;
 pub mod schema;
 pub mod state;
+
+mod convert;
+mod record;

--- a/crates/connectors/ndc-postgres/src/mutation.rs
+++ b/crates/connectors/ndc-postgres/src/mutation.rs
@@ -143,10 +143,5 @@ fn log_err_metrics_and_convert_error(
             state.metrics.error_metrics.record_database_error();
             connector::MutationError::Other(err.to_string().into())
         }
-        query_engine_execution::error::Error::Multiple(err1, err2) => {
-            log_err_metrics_and_convert_error(state, err1);
-            log_err_metrics_and_convert_error(state, err2);
-            connector::MutationError::Other(err.to_string().into())
-        }
     }
 }

--- a/crates/connectors/ndc-postgres/src/mutation.rs
+++ b/crates/connectors/ndc-postgres/src/mutation.rs
@@ -121,28 +121,29 @@ async fn execute_mutation(
 
 fn log_err_metrics_and_convert_error(
     state: &state::State,
-    err: &query_engine_execution::mutation::Error,
+    err: &query_engine_execution::error::Error,
 ) -> connector::MutationError {
     match err {
-        query_engine_execution::mutation::Error::Query(err) => match &err {
-            query_engine_execution::mutation::QueryError::NotSupported(_) => {
+        query_engine_execution::error::Error::Query(err) => match &err {
+            query_engine_execution::error::QueryError::VariableNotFound(_) => todo!(),
+            query_engine_execution::error::QueryError::NotSupported(_) => {
                 state.metrics.error_metrics.record_unsupported_feature();
                 connector::MutationError::UnsupportedOperation(err.to_string())
             }
-            query_engine_execution::mutation::QueryError::DBError(_) => {
+            query_engine_execution::error::QueryError::DBError(_) => {
                 state.metrics.error_metrics.record_invalid_request();
                 connector::MutationError::UnprocessableContent(err.to_string())
             }
-            query_engine_execution::mutation::QueryError::DBConstraintError(_) => {
+            query_engine_execution::error::QueryError::DBConstraintError(_) => {
                 state.metrics.error_metrics.record_invalid_request();
                 connector::MutationError::ConstraintNotMet(err.to_string())
             }
         },
-        query_engine_execution::mutation::Error::DB(_) => {
+        query_engine_execution::error::Error::DB(_) => {
             state.metrics.error_metrics.record_database_error();
             connector::MutationError::Other(err.to_string().into())
         }
-        query_engine_execution::mutation::Error::Multiple(err1, err2) => {
+        query_engine_execution::error::Error::Multiple(err1, err2) => {
             log_err_metrics_and_convert_error(state, err1);
             log_err_metrics_and_convert_error(state, err2);
             connector::MutationError::Other(err.to_string().into())

--- a/crates/connectors/ndc-postgres/src/mutation.rs
+++ b/crates/connectors/ndc-postgres/src/mutation.rs
@@ -77,22 +77,8 @@ pub fn plan_mutation(
                 configuration.mutations_version,
             )
             .map_err(|err| {
-                tracing::error!("{}", err);
-                // log metrics
-                match err {
-                    translation::error::Error::CapabilityNotSupported(_) => {
-                        state.metrics.error_metrics.record_unsupported_capability();
-                        connector::MutationError::UnsupportedOperation(err.to_string())
-                    }
-                    translation::error::Error::NotImplementedYet(_) => {
-                        state.metrics.error_metrics.record_unsupported_feature();
-                        connector::MutationError::UnsupportedOperation(err.to_string())
-                    }
-                    _ => {
-                        state.metrics.error_metrics.record_invalid_request();
-                        connector::MutationError::InvalidRequest(err.to_string())
-                    }
-                }
+                record::translation_error(&err, &state.metrics);
+                convert::translation_error_to_mutation_error(err)
             })
         })
         .collect::<Result<Vec<_>, connector::MutationError>>()?;

--- a/crates/connectors/ndc-postgres/src/mutation/explain.rs
+++ b/crates/connectors/ndc-postgres/src/mutation/explain.rs
@@ -99,11 +99,6 @@ fn log_err_metrics_and_convert_error(
             state.metrics.error_metrics.record_database_error();
             connector::ExplainError::Other(err.to_string().into())
         }
-        query_engine_execution::error::Error::Multiple(err1, err2) => {
-            log_err_metrics_and_convert_error(state, err1);
-            log_err_metrics_and_convert_error(state, err2);
-            connector::ExplainError::Other(err.to_string().into())
-        }
     }
 }
 

--- a/crates/connectors/ndc-postgres/src/mutation/explain.rs
+++ b/crates/connectors/ndc-postgres/src/mutation/explain.rs
@@ -72,33 +72,34 @@ pub async fn explain(
 
 fn log_err_metrics_and_convert_error(
     state: &state::State,
-    err: &query_engine_execution::mutation::Error,
+    err: &query_engine_execution::error::Error,
 ) -> connector::ExplainError {
     match err {
-        query_engine_execution::mutation::Error::Query(err) => {
+        query_engine_execution::error::Error::Query(err) => {
             tracing::error!("{}", err);
             // log error metric
             match &err {
-                query_engine_execution::mutation::QueryError::NotSupported(_) => {
+                query_engine_execution::error::QueryError::VariableNotFound(_) => todo!(),
+                query_engine_execution::error::QueryError::NotSupported(_) => {
                     state.metrics.error_metrics.record_unsupported_feature();
                     connector::ExplainError::UnsupportedOperation(err.to_string())
                 }
-                query_engine_execution::mutation::QueryError::DBError(_) => {
+                query_engine_execution::error::QueryError::DBError(_) => {
                     state.metrics.error_metrics.record_invalid_request();
                     connector::ExplainError::UnprocessableContent(err.to_string())
                 }
-                query_engine_execution::mutation::QueryError::DBConstraintError(_) => {
+                query_engine_execution::error::QueryError::DBConstraintError(_) => {
                     state.metrics.error_metrics.record_invalid_request();
                     connector::ExplainError::UnprocessableContent(err.to_string())
                 }
             }
         }
-        query_engine_execution::mutation::Error::DB(err) => {
+        query_engine_execution::error::Error::DB(err) => {
             tracing::error!("{}", err);
             state.metrics.error_metrics.record_database_error();
             connector::ExplainError::Other(err.to_string().into())
         }
-        query_engine_execution::mutation::Error::Multiple(err1, err2) => {
+        query_engine_execution::error::Error::Multiple(err1, err2) => {
             log_err_metrics_and_convert_error(state, err1);
             log_err_metrics_and_convert_error(state, err2);
             connector::ExplainError::Other(err.to_string().into())

--- a/crates/connectors/ndc-postgres/src/query.rs
+++ b/crates/connectors/ndc-postgres/src/query.rs
@@ -68,22 +68,8 @@ fn plan_query(
         query_request,
     )
     .map_err(|err| {
-        tracing::error!("{}", err);
-        // log metrics
-        match err {
-            translation::error::Error::CapabilityNotSupported(_) => {
-                state.metrics.error_metrics.record_unsupported_capability();
-                connector::QueryError::UnsupportedOperation(err.to_string())
-            }
-            translation::error::Error::NotImplementedYet(_) => {
-                state.metrics.error_metrics.record_unsupported_feature();
-                connector::QueryError::UnsupportedOperation(err.to_string())
-            }
-            _ => {
-                state.metrics.error_metrics.record_invalid_request();
-                connector::QueryError::InvalidRequest(err.to_string())
-            }
-        }
+        record::translation_error(&err, &state.metrics);
+        convert::translation_error_to_query_error(err)
     });
     timer.complete_with(result)
 }

--- a/crates/connectors/ndc-postgres/src/query.rs
+++ b/crates/connectors/ndc-postgres/src/query.rs
@@ -94,28 +94,30 @@ async fn execute_query(
         .await
         .map(JsonResponse::Serialized)
         .map_err(|err| match err {
-            query_engine_execution::query::Error::Query(err) => {
+            query_engine_execution::error::Error::Query(err) => {
                 tracing::error!("{}", err);
                 // log error metric
                 match &err {
-                    query_engine_execution::query::QueryError::VariableNotFound(_) => {
+                    query_engine_execution::error::QueryError::VariableNotFound(_) => {
                         state.metrics.error_metrics.record_invalid_request();
                         connector::QueryError::InvalidRequest(err.to_string())
                     }
-                    query_engine_execution::query::QueryError::NotSupported(_) => {
+                    query_engine_execution::error::QueryError::NotSupported(_) => {
                         state.metrics.error_metrics.record_unsupported_feature();
                         connector::QueryError::UnsupportedOperation(err.to_string())
                     }
-                    query_engine_execution::query::QueryError::DBError(_) => {
+                    query_engine_execution::error::QueryError::DBError(_) => {
                         state.metrics.error_metrics.record_invalid_request();
                         connector::QueryError::UnprocessableContent(err.to_string())
                     }
+                    query_engine_execution::error::QueryError::DBConstraintError(_) => todo!(),
                 }
             }
-            query_engine_execution::query::Error::DB(err) => {
+            query_engine_execution::error::Error::DB(err) => {
                 tracing::error!("{}", err);
                 state.metrics.error_metrics.record_database_error();
                 connector::QueryError::Other(err.to_string().into())
             }
+            query_engine_execution::error::Error::Multiple(_, _) => todo!(),
         })
 }

--- a/crates/connectors/ndc-postgres/src/query.rs
+++ b/crates/connectors/ndc-postgres/src/query.rs
@@ -118,6 +118,5 @@ async fn execute_query(
                 state.metrics.error_metrics.record_database_error();
                 connector::QueryError::Other(err.to_string().into())
             }
-            query_engine_execution::error::Error::Multiple(_, _) => todo!(),
         })
 }

--- a/crates/connectors/ndc-postgres/src/query/explain.rs
+++ b/crates/connectors/ndc-postgres/src/query/explain.rs
@@ -10,10 +10,7 @@ use tracing::{info_span, Instrument};
 use ndc_postgres_configuration as configuration;
 use ndc_sdk::connector;
 use ndc_sdk::models;
-use query_engine_sql::sql;
-use query_engine_translation::translation;
 
-use crate::configuration_mapping;
 use crate::convert;
 use crate::record;
 use crate::state;
@@ -34,52 +31,39 @@ pub async fn explain(
         );
 
         // Compile the query.
-        let plan = async { plan_query(configuration, state, query_request) }
-            .instrument(info_span!("Plan query"))
-            .await?;
+        let plan = async {
+            super::plan_query(configuration, state, query_request).map_err(|err| {
+                record::translation_error(&err, &state.metrics);
+                convert::translation_error_to_explain_error(err)
+            })
+        }
+        .instrument(info_span!("Plan query"))
+        .await?;
 
         // Execute an explain query.
-        let (query, plan) = query_engine_execution::query::explain(
-            &state.pool,
-            &state.database_info,
-            &state.metrics,
-            plan,
-        )
+        let (query, plan) = async {
+            query_engine_execution::query::explain(
+                &state.pool,
+                &state.database_info,
+                &state.metrics,
+                plan,
+            )
+            .await
+            .map_err(|err| {
+                record::execution_error(&err, &state.metrics);
+                convert::execution_error_to_explain_error(err)
+            })
+        }
         .instrument(info_span!("Explain query"))
-        .await
-        .map_err(|err| {
-            record::execution_error(&err, &state.metrics);
-            convert::execution_error_to_explain_error(err)
-        })?;
+        .await?;
 
         state.metrics.record_successful_explain();
 
         let details =
             BTreeMap::from_iter([("SQL Query".into(), query), ("Execution Plan".into(), plan)]);
 
-        let response = models::ExplainResponse { details };
-
-        Ok(response)
+        Ok(models::ExplainResponse { details })
     }
     .instrument(info_span!("/explain"))
     .await
-}
-
-fn plan_query(
-    configuration: &configuration::Configuration,
-    state: &state::State,
-    query_request: models::QueryRequest,
-) -> Result<sql::execution_plan::ExecutionPlan<sql::execution_plan::Query>, connector::ExplainError>
-{
-    let timer = state.metrics.time_query_plan();
-    let result = translation::query::translate(
-        &configuration.metadata,
-        configuration_mapping::convert_isolation_level(configuration.isolation_level),
-        query_request,
-    )
-    .map_err(|err| {
-        record::translation_error(&err, &state.metrics);
-        convert::translation_error_to_explain_error(err)
-    });
-    timer.complete_with(result)
 }

--- a/crates/connectors/ndc-postgres/src/query/explain.rs
+++ b/crates/connectors/ndc-postgres/src/query/explain.rs
@@ -71,7 +71,6 @@ pub async fn explain(
                 state.metrics.error_metrics.record_database_error();
                 connector::ExplainError::Other(err.to_string().into())
             }
-            query_engine_execution::error::Error::Multiple(_, _) => todo!(),
         })?;
 
         state.metrics.record_successful_explain();

--- a/crates/connectors/ndc-postgres/src/query/explain.rs
+++ b/crates/connectors/ndc-postgres/src/query/explain.rs
@@ -78,21 +78,8 @@ fn plan_query(
         query_request,
     )
     .map_err(|err| {
-        tracing::error!("{}", err);
-        match err {
-            translation::error::Error::CapabilityNotSupported(_) => {
-                state.metrics.error_metrics.record_unsupported_capability();
-                connector::ExplainError::UnsupportedOperation(err.to_string())
-            }
-            translation::error::Error::NotImplementedYet(_) => {
-                state.metrics.error_metrics.record_unsupported_feature();
-                connector::ExplainError::UnsupportedOperation(err.to_string())
-            }
-            _ => {
-                state.metrics.error_metrics.record_invalid_request();
-                connector::ExplainError::InvalidRequest(err.to_string())
-            }
-        }
+        record::translation_error(&err, &state.metrics);
+        convert::translation_error_to_explain_error(err)
     });
     timer.complete_with(result)
 }

--- a/crates/connectors/ndc-postgres/src/record.rs
+++ b/crates/connectors/ndc-postgres/src/record.rs
@@ -7,20 +7,41 @@ pub(crate) fn execution_error(
     error: &query_engine_execution::error::Error,
     metrics: &metrics::Metrics,
 ) {
+    use query_engine_execution::error::*;
     tracing::error!("{}", error);
     match error {
-        query_engine_execution::error::Error::Query(err) => match &err {
-            query_engine_execution::error::QueryError::VariableNotFound(_)
-            | query_engine_execution::error::QueryError::DBError(_)
-            | query_engine_execution::error::QueryError::DBConstraintError(_) => {
+        Error::Query(err) => match &err {
+            QueryError::VariableNotFound(_)
+            | QueryError::DBError(_)
+            | QueryError::DBConstraintError(_) => {
                 metrics.error_metrics.record_invalid_request();
             }
-            query_engine_execution::error::QueryError::NotSupported(_) => {
+            QueryError::NotSupported(_) => {
                 metrics.error_metrics.record_unsupported_feature();
             }
         },
-        query_engine_execution::error::Error::DB(_) => {
+        Error::DB(_) => {
             metrics.error_metrics.record_database_error();
+        }
+    }
+}
+
+/// Record a translation error in the current trace, and increment a counter.
+pub(crate) fn translation_error(
+    error: &query_engine_translation::translation::error::Error,
+    metrics: &metrics::Metrics,
+) {
+    use query_engine_translation::translation::error::*;
+    tracing::error!("{}", error);
+    match error {
+        Error::CapabilityNotSupported(_) => {
+            metrics.error_metrics.record_unsupported_capability();
+        }
+        Error::NotImplementedYet(_) => {
+            metrics.error_metrics.record_unsupported_feature();
+        }
+        _ => {
+            metrics.error_metrics.record_invalid_request();
         }
     }
 }

--- a/crates/connectors/ndc-postgres/src/record.rs
+++ b/crates/connectors/ndc-postgres/src/record.rs
@@ -1,0 +1,26 @@
+//! Record information about errors in traces and metrics.
+
+use query_engine_execution::metrics;
+
+/// Record an execution error in the current trace, and increment a counter.
+pub(crate) fn execution_error(
+    error: &query_engine_execution::error::Error,
+    metrics: &metrics::Metrics,
+) {
+    tracing::error!("{}", error);
+    match error {
+        query_engine_execution::error::Error::Query(err) => match &err {
+            query_engine_execution::error::QueryError::VariableNotFound(_)
+            | query_engine_execution::error::QueryError::DBError(_)
+            | query_engine_execution::error::QueryError::DBConstraintError(_) => {
+                metrics.error_metrics.record_invalid_request();
+            }
+            query_engine_execution::error::QueryError::NotSupported(_) => {
+                metrics.error_metrics.record_unsupported_feature();
+            }
+        },
+        query_engine_execution::error::Error::DB(_) => {
+            metrics.error_metrics.record_database_error();
+        }
+    }
+}

--- a/crates/query-engine/execution/Cargo.toml
+++ b/crates/query-engine/execution/Cargo.toml
@@ -14,5 +14,6 @@ prometheus = "0.13.3"
 serde_json = "1.0.113"
 sqlformat = "0.2.3"
 sqlx = { version = "0.7.3", features = [ "json", "postgres", "runtime-tokio-rustls", "uuid" ] }
+thiserror = "1.0.57"
 tracing = "0.1.40"
 bytes = "1.5.0"

--- a/crates/query-engine/execution/src/error.rs
+++ b/crates/query-engine/execution/src/error.rs
@@ -1,47 +1,23 @@
 /// Errors
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("{0}")]
     Query(QueryError),
+    #[error("{0}")]
     DB(sqlx::Error),
 }
 
 /// Query planning error.
+#[derive(Debug, thiserror::Error)]
 pub enum QueryError {
+    #[error("Variable {0:?} not found.")]
     VariableNotFound(String),
+    #[error("{0} are not supported.")]
     NotSupported(String),
+    #[error("{0}")]
     DBError(sqlx::Error),
+    #[error("{0}")]
     DBConstraintError(sqlx::Error),
-}
-
-impl std::fmt::Display for QueryError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            QueryError::VariableNotFound(thing) => {
-                write!(f, "Variable '{}' not found.", thing)
-            }
-            QueryError::NotSupported(thing) => {
-                write!(f, "{} are not supported.", thing)
-            }
-            QueryError::DBError(thing) => {
-                write!(f, "{}", thing)
-            }
-            QueryError::DBConstraintError(thing) => {
-                write!(f, "{}", thing)
-            }
-        }
-    }
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Error::Query(err) => {
-                write!(f, "{}", err)
-            }
-            Error::DB(err) => {
-                write!(f, "{}", err)
-            }
-        }
-    }
 }
 
 impl From<sqlx::Error> for Error {

--- a/crates/query-engine/execution/src/error.rs
+++ b/crates/query-engine/execution/src/error.rs
@@ -2,7 +2,6 @@
 pub enum Error {
     Query(QueryError),
     DB(sqlx::Error),
-    Multiple(Box<Error>, Box<Error>),
 }
 
 /// Query planning error.
@@ -40,9 +39,6 @@ impl std::fmt::Display for Error {
             }
             Error::DB(err) => {
                 write!(f, "{}", err)
-            }
-            Error::Multiple(err1, err2) => {
-                write!(f, "1. {}\n2. {}", err1, err2)
             }
         }
     }

--- a/crates/query-engine/execution/src/error.rs
+++ b/crates/query-engine/execution/src/error.rs
@@ -1,0 +1,72 @@
+/// Errors
+pub enum Error {
+    Query(QueryError),
+    DB(sqlx::Error),
+    Multiple(Box<Error>, Box<Error>),
+}
+
+/// Query planning error.
+pub enum QueryError {
+    VariableNotFound(String),
+    NotSupported(String),
+    DBError(sqlx::Error),
+    DBConstraintError(sqlx::Error),
+}
+
+impl std::fmt::Display for QueryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            QueryError::VariableNotFound(thing) => {
+                write!(f, "Variable '{}' not found.", thing)
+            }
+            QueryError::NotSupported(thing) => {
+                write!(f, "{} are not supported.", thing)
+            }
+            QueryError::DBError(thing) => {
+                write!(f, "{}", thing)
+            }
+            QueryError::DBConstraintError(thing) => {
+                write!(f, "{}", thing)
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::Query(err) => {
+                write!(f, "{}", err)
+            }
+            Error::DB(err) => {
+                write!(f, "{}", err)
+            }
+            Error::Multiple(err1, err2) => {
+                write!(f, "1. {}\n2. {}", err1, err2)
+            }
+        }
+    }
+}
+
+impl From<sqlx::Error> for Error {
+    fn from(err: sqlx::Error) -> Error {
+        match err
+            .as_database_error()
+            .and_then(|e| e.try_downcast_ref())
+            .map(|e: &sqlx::postgres::PgDatabaseError| e.code())
+        {
+            None => Error::DB(err),
+            Some(code) => {
+                // We want to map data and constraint exceptions to query errors
+                // https://www.postgresql.org/docs/current/errcodes-appendix.html
+                if code.starts_with("22") {
+                    Error::Query(QueryError::DBError(err))
+                } else if code.starts_with("23") {
+                    Error::Query(QueryError::DBConstraintError(err))
+                } else {
+                    Error::DB(err)
+                }
+            }
+        }
+    }
+}

--- a/crates/query-engine/execution/src/lib.rs
+++ b/crates/query-engine/execution/src/lib.rs
@@ -2,6 +2,7 @@
 //! See `/architecture.md#execution` in the repository for more details.
 
 pub mod database_info;
+pub mod error;
 pub mod metrics;
 pub mod mutation;
 pub mod query;

--- a/crates/query-engine/execution/src/mutation.rs
+++ b/crates/query-engine/execution/src/mutation.rs
@@ -116,13 +116,11 @@ async fn rollback_on_exception<T>(
     result: Result<T, Error>,
     connection: &mut PoolConnection<Postgres>,
 ) -> Result<T, Error> {
-    match result {
-        Err(err1) => match execute_statement(connection, &transaction_rollback()).await {
-            Err(err2) => Err(Error::Multiple(Box::new(err1), Box::new(err2))),
-            Ok(()) => Err(err1),
-        },
-        Ok(ok) => Ok(ok),
+    if result.is_err() {
+        // If rolling back fails, ignore it.
+        let _ = execute_statement(connection, &transaction_rollback()).await;
     }
+    result
 }
 
 /// Execute the query, and append the result to the given buffer.

--- a/crates/query-engine/execution/src/mutation.rs
+++ b/crates/query-engine/execution/src/mutation.rs
@@ -8,6 +8,7 @@ use sqlx::{Postgres, Row};
 use tracing::{info_span, Instrument};
 
 use crate::database_info::DatabaseInfo;
+use crate::error::{Error, QueryError};
 use crate::metrics;
 use query_engine_sql::sql;
 use query_engine_sql::sql::execution_plan::{ExecutionPlan, Mutations};
@@ -263,73 +264,4 @@ pub async fn explain(
     }
 
     Ok(results)
-}
-
-/// Errors
-pub enum Error {
-    Query(QueryError),
-    DB(sqlx::Error),
-    Multiple(Box<Error>, Box<Error>),
-}
-
-/// Query planning error.
-pub enum QueryError {
-    NotSupported(String),
-    DBError(sqlx::Error),
-    DBConstraintError(sqlx::Error),
-}
-
-impl std::fmt::Display for QueryError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            QueryError::NotSupported(thing) => {
-                write!(f, "{} are not supported.", thing)
-            }
-            QueryError::DBError(thing) => {
-                write!(f, "{}", thing)
-            }
-            QueryError::DBConstraintError(thing) => {
-                write!(f, "{}", thing)
-            }
-        }
-    }
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Error::Query(err) => {
-                write!(f, "{}", err)
-            }
-            Error::DB(err) => {
-                write!(f, "{}", err)
-            }
-            Error::Multiple(err1, err2) => {
-                write!(f, "1. {}\n2. {}", err1, err2)
-            }
-        }
-    }
-}
-
-impl From<sqlx::Error> for Error {
-    fn from(err: sqlx::Error) -> Error {
-        match err
-            .as_database_error()
-            .and_then(|e| e.try_downcast_ref())
-            .map(|e: &sqlx::postgres::PgDatabaseError| e.code())
-        {
-            None => Error::DB(err),
-            Some(code) => {
-                // We want to map data and constraint exceptions to query errors
-                // https://www.postgresql.org/docs/current/errcodes-appendix.html
-                if code.starts_with("22") {
-                    Error::Query(QueryError::DBError(err))
-                } else if code.starts_with("23") {
-                    Error::Query(QueryError::DBConstraintError(err))
-                } else {
-                    Error::DB(err)
-                }
-            }
-        }
-    }
 }


### PR DESCRIPTION
### What

I started trying to re-use the transaction handling logic we have around mutations for queries too, but got stuck because I either needed to duplicate a lot of code, which felt suspect and error-prone, or deduplicate a lot of other code first.

I chose the latter.

This deduplicates the error types between queries and mutations in a new `query_engine_execution::error::Error` type.

I have also deduplicated the use of this type and the `query_engine_translation::translation::error::Error` type, particularly when it comes to (a) recording the error for tracing and metrics, and (b) converting the error to an ndc-sdk `connector::QueryError`.

I think the separation of concerns in the resulting code makes it easier to read (large `.map_err` blocks can be something of a handful). This will also make it much easier to share transaction code between queries and mutations.

### How

First, I made the new error type. This meant I had to handle some extra cases in certain places, and I didn't like adding the code, so I decided instead to remove it.

I created two new files:

1. `record.rs`, which records errors with the tracing and metrics services.
2. `convert.rs, which converts errors.

From there it was a fairly mechanical process of using those new functions instead of the inline recording and conversion from before.

I removed the `Multiple` error case, instead deciding to just throw away the second error from rolling back in favor of the first one, which is more likely to contain useful information.

I also removed a bit of code:

* `ndc_postgres::query::plan_query` was duplicated in `ndc_postgres::query::explain::plan_query`, with different error-handling. By moving error-handling up a layer, the discrepancy went away and I was able to reuse the first one.
* `ndc_postgres::mutation::explain` had an additional error conversion function which converted the ndc-sdk error _back_ to an internal error. Again, by moving error-handling up a layer, this was no longer necessary.