### PR TITLE
Allow the CLI user to specify the context with an environment variable.

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4,18 +4,33 @@
 //! It is unlikely that end-users will use it directly.
 
 use std::env;
+use std::path::PathBuf;
 
 use clap::Parser;
 
 use ndc_postgres_cli::*;
 
+/// The command-line arguments.
+#[derive(Debug, Parser)]
+pub struct Args {
+    /// The path to the configuration. Defaults to the current directory.
+    #[arg(long = "context", env = "HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH")]
+    pub context_path: Option<PathBuf>,
+    /// The command to invoke.
+    #[command(subcommand)]
+    pub subcommand: Command,
+}
+
 /// The application entrypoint. It pulls information from the environment and then calls the [run]
-/// function, so all process-level non-determinism is held here.
+/// function. The library remains unaware of the environment, so that we can more easily test it.
 #[tokio::main]
 pub async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
-    // The library is not aware of the current directory so that we can more easily test it.
-    let current_directory = env::current_dir()?;
-    run(args.subcommand, &current_directory).await?;
+    // Default the context path to the current directory.
+    let context_path = match args.context_path {
+        Some(path) => path,
+        None => env::current_dir()?,
+    };
+    run(args.subcommand, &context_path).await?;
     Ok(())
 }

--- a/scripts/generate-chinook-configuration.sh
+++ b/scripts/generate-chinook-configuration.sh
@@ -10,50 +10,48 @@ EXECUTABLE="$1"
 CONNECTION_STRING="$2"
 CHINOOK_NDC_METADATA="$3"
 
-# ensure we clean up
+# Ensure we clean up.
 function stop {
-  if [[ "${CONFIGURATION_SERVER_PID+x}" ]]; then
-    kill "$CONFIGURATION_SERVER_PID"
-  fi
-  if [[ "${NEW_FILE+x}" ]]; then
-    rm -f "$NEW_FILE"
+  if [[ "${HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH+x}" ]]; then
+    rm -rf "$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH"
   fi
 }
 
 trap stop EXIT
 
-# build the CLI
+# Build the CLI.
 cargo build
 CLI="${PWD}/target/debug/ndc-postgres-cli"
 
-# We want to preserve the connectionUri unchanged in the NDC metadata file, for secrets templating purposes
+# We want to preserve the connectionUri unchanged in the NDC metadata file, for secrets templating purposes.
 PRESERVED_DATA="$(jq '{"connectionUri": .connectionUri}' "$CHINOOK_NDC_METADATA")"
 
-# Native queries should inform the initial configuration call
+# Native queries should inform the initial configuration call.
 INITIAL_DATA="$(jq '{"version": .version, "connectionUri": .connectionUri, "poolSettings": (.poolSettings // {}), "metadata": {"nativeQueries": .metadata.nativeQueries, "compositeTypes": .metadata.compositeTypes}, "configureOptions": {"mutationsVersion": .configureOptions.mutationsVersion}}' "$CHINOOK_NDC_METADATA")"
 
-# create a temporary directory for the output so we don't overwrite data by accident
-TEMP_DIRECTORY="$(mktemp)"
-rm -f "$TEMP_DIRECTORY"
-mkdir "$TEMP_DIRECTORY"
+# Create a temporary directory for the output so we don't overwrite data by accident.
+# The CLI will read from and write to the directory specified by this environment variable.
+HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH="$(mktemp)"
+rm -f "$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH"
+mkdir "$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH"
+export HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH
 
-(
-  cd "$TEMP_DIRECTORY"
-  # Initialize an empty configuration.
-  "$CLI" initialize
-  # Overwrite with the initial data.
-  echo "$INITIAL_DATA" \
-    | jq --arg uri "$CONNECTION_STRING" '. + {"connectionUri": {"uri": {"value": $uri}}}' \
-    > configuration.json
-  # Introspect the database.
-  "$CLI" update
-  # Splice in the preserved data.
-  jq --argjson preserved_data "$PRESERVED_DATA" '. + $preserved_data' configuration.json > configuration.new.json
-  mv -fv configuration.new.json configuration.json
-  # Format the result.
-  prettier --write configuration.json
-)
+# Initialize an empty configuration.
+"$CLI" initialize
+# Overwrite with the initial data.
+echo "$INITIAL_DATA" \
+  | jq --arg uri "$CONNECTION_STRING" '. + {"connectionUri": {"uri": {"value": $uri}}}' \
+  > "${HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH}/configuration.json"
+# Introspect the database.
+"$CLI" update
+# Splice in the preserved data.
+jq \
+    --argjson preserved_data "$PRESERVED_DATA" \
+    '. + $preserved_data' \
+    "${HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH}/configuration.json" \
+  | prettier --parser=json \
+  > "${HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH}/configuration.spliced.json"
 
 # If the above succeeded, overwrite the configuration.
 rm -f "$CHINOOK_NDC_METADATA"
-mv -nv "$TEMP_DIRECTORY/configuration.json" "$CHINOOK_NDC_METADATA"
+mv -nv "${HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH}/configuration.spliced.json" "$CHINOOK_NDC_METADATA"


### PR DESCRIPTION
### What

This follows the specification in https://github.com/hasura/ndc-hub/blob/cli-guidelines/rfcs/0002-cli-guidelines.md.

To ensure this works correctly, I have also updated the `generate-chinook-configuration.sh` script to use this environment variable.

### How

We use `clap` to parse either a switch or an environment variable, and only fall back to the current directory if neither is set.