### PR TITLE
Roll back queries on failure.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3183,7 +3183,6 @@ dependencies = [
  "reqwest",
  "schemars",
  "serde",
- "serde_derive",
  "serde_json",
  "similar-asserts",
  "sqlx",

--- a/crates/query-engine/execution/src/execute.rs
+++ b/crates/query-engine/execution/src/execute.rs
@@ -1,0 +1,34 @@
+use sqlx::pool::PoolConnection;
+use sqlx::postgres::Postgres;
+
+use query_engine_sql::sql;
+
+use crate::error::Error;
+
+/// Execute a single SQL statement against the database.
+pub(crate) async fn execute_statement(
+    connection: &mut PoolConnection<Postgres>,
+    sql::string::Statement(statement): &sql::string::Statement,
+) -> Result<(), Error> {
+    tracing::info!(
+        statement = statement.sql,
+        params = ?&statement.params,
+    );
+    sqlx::query(&statement.sql)
+        .execute(connection.as_mut())
+        .await?;
+    Ok(())
+}
+
+/// Match on the result and execute a rollback statement against the database if we run into an
+/// error.
+pub(crate) async fn rollback_on_exception<T>(
+    result: Result<T, Error>,
+    connection: &mut PoolConnection<Postgres>,
+) -> Result<T, Error> {
+    if result.is_err() {
+        // If rolling back fails, ignore it.
+        let _ = execute_statement(connection, &sql::helpers::transaction_rollback()).await;
+    }
+    result
+}

--- a/crates/query-engine/execution/src/helpers.rs
+++ b/crates/query-engine/execution/src/helpers.rs
@@ -1,3 +1,5 @@
+//! Helper functions for working with the database, shared between query and mutation operations.
+
 use sqlx::pool::PoolConnection;
 use sqlx::postgres::Postgres;
 
@@ -5,7 +7,7 @@ use query_engine_sql::sql;
 
 use crate::error::Error;
 
-/// Execute a single SQL statement against the database.
+/// Execute a single SQL statement against the database, with tracing.
 pub(crate) async fn execute_statement(
     connection: &mut PoolConnection<Postgres>,
     sql::string::Statement(statement): &sql::string::Statement,

--- a/crates/query-engine/execution/src/helpers.rs
+++ b/crates/query-engine/execution/src/helpers.rs
@@ -24,13 +24,15 @@ pub(crate) async fn execute_statement(
 
 /// Match on the result and execute a rollback statement against the database if we run into an
 /// error.
+///
+/// This consumes the connection so we cannot use it any more.
 pub(crate) async fn rollback_on_exception<T>(
     result: Result<T, Error>,
-    connection: &mut PoolConnection<Postgres>,
+    mut connection: PoolConnection<Postgres>,
 ) -> Result<T, Error> {
     if result.is_err() {
         // If rolling back fails, ignore it.
-        let _ = execute_statement(connection, &sql::helpers::transaction_rollback()).await;
+        let _ = execute_statement(&mut connection, &sql::helpers::transaction_rollback()).await;
     }
     result
 }

--- a/crates/query-engine/execution/src/lib.rs
+++ b/crates/query-engine/execution/src/lib.rs
@@ -6,3 +6,5 @@ pub mod error;
 pub mod metrics;
 pub mod mutation;
 pub mod query;
+
+mod execute;

--- a/crates/query-engine/execution/src/lib.rs
+++ b/crates/query-engine/execution/src/lib.rs
@@ -7,4 +7,4 @@ pub mod metrics;
 pub mod mutation;
 pub mod query;
 
-mod execute;
+mod helpers;

--- a/crates/query-engine/execution/src/mutation.rs
+++ b/crates/query-engine/execution/src/mutation.rs
@@ -10,7 +10,7 @@ use query_engine_sql::sql;
 
 use crate::database_info::DatabaseInfo;
 use crate::error::{Error, QueryError};
-use crate::execute::{execute_statement, rollback_on_exception};
+use crate::helpers::{execute_statement, rollback_on_exception};
 use crate::metrics;
 
 /// Execute mutations against postgres.

--- a/crates/query-engine/execution/src/mutation.rs
+++ b/crates/query-engine/execution/src/mutation.rs
@@ -35,7 +35,7 @@ pub async fn execute(
     let query_timer = metrics.time_query_execution();
     let rows_result = rollback_on_exception(
         execute_mutations(&mut connection, database_info, plan).await,
-        &mut connection,
+        connection,
     )
     .await;
     query_timer.complete_with(rows_result)

--- a/crates/query-engine/execution/src/query.rs
+++ b/crates/query-engine/execution/src/query.rs
@@ -12,7 +12,7 @@ use query_engine_sql::sql;
 
 use crate::database_info::DatabaseInfo;
 use crate::error::{Error, QueryError};
-use crate::execute::{execute_statement, rollback_on_exception};
+use crate::helpers::{execute_statement, rollback_on_exception};
 use crate::metrics;
 
 /// Execute a query against postgres.

--- a/crates/query-engine/execution/src/query.rs
+++ b/crates/query-engine/execution/src/query.rs
@@ -37,7 +37,7 @@ pub async fn execute(
     let query_timer = metrics.time_query_execution();
     let rows_result = rollback_on_exception(
         execute_query(&mut connection, database_info, plan).await,
-        &mut connection,
+        connection,
     )
     .await;
 

--- a/crates/tests/databases-tests/src/citus/configuration_tests.rs
+++ b/crates/tests/databases-tests/src/citus/configuration_tests.rs
@@ -1,6 +1,6 @@
 //! Tests that configuration generation has not changed.
 //!
-//! If you have changed it intentionally, run `just generate-chinook-configuration`.
+//! If you have changed it intentionally, run `just generate-configuration`.
 
 #![cfg(test)]
 

--- a/crates/tests/databases-tests/src/cockroach/configuration_tests.rs
+++ b/crates/tests/databases-tests/src/cockroach/configuration_tests.rs
@@ -1,6 +1,6 @@
 //! Tests that configuration generation has not changed.
 //!
-//! If you have changed it intentionally, run `just generate-chinook-configuration`.
+//! If you have changed it intentionally, run `just generate-configuration`.
 
 #![cfg(test)]
 

--- a/crates/tests/databases-tests/src/ndc_metadata_snapshot_tests.rs
+++ b/crates/tests/databases-tests/src/ndc_metadata_snapshot_tests.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 #[allow(dead_code)]
 // we don't have any snapshots right now
-// each time we run `just generate-chinook-configuration` we save the old Postgres NDC metadata
+// each time we run `just generate-configuration` we save the old Postgres NDC metadata
 // file in `static/ndc-metadata-snapshots`. This test parses each snapshot to ensure we are
 // still able to understand old versions
 #[test_each::path(glob = "static/ndc-metadata-snapshots/*.json", name(segments = 2))]

--- a/crates/tests/databases-tests/src/postgres/common.rs
+++ b/crates/tests/databases-tests/src/postgres/common.rs
@@ -2,6 +2,8 @@
 
 pub const CHINOOK_NDC_METADATA_PATH: &str = "static/postgres/v3-chinook-ndc-metadata";
 
+pub const BROKEN_QUERIES_NDC_METADATA_PATH: &str = "static/postgres/broken-queries-ndc-metadata";
+
 pub const CONNECTION_STRING: &str = "postgresql://postgres:password@localhost:64002";
 
 /// Creates a router with a fresh state from the test ndc_metadata.

--- a/crates/tests/databases-tests/src/postgres/configuration_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/configuration_tests.rs
@@ -1,6 +1,6 @@
 //! Tests that configuration generation has not changed.
 //!
-//! If you have changed it intentionally, run `just generate-chinook-configuration`.
+//! If you have changed it intentionally, run `just generate-configuration`.
 //!
 //! The github CI setup runs these tests subject to the filtering logic in
 //! '.github/test-configuration.json'. Naming a test with the prefix 'postgres_current_only` will

--- a/crates/tests/databases-tests/src/postgres/query_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/query_tests.rs
@@ -548,7 +548,6 @@ mod negative {
     }
 
     /// Check that a very broken native query doesn't impact subsequent queries.
-    #[ignore = "not working yet"]
     #[tokio::test(flavor = "multi_thread")]
     async fn broken_query() {
         let ndc_metadata = FreshDeployment::create(

--- a/crates/tests/databases-tests/src/postgres/query_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/query_tests.rs
@@ -531,7 +531,6 @@ mod types {
 #[cfg(test)]
 mod negative {
     use super::super::common;
-    use tests_common::ndc_metadata::FreshDeployment;
     use tests_common::request::{create_client, models, run_query_expecting, StatusCode};
 
     /// Ensure that a value of the wrong datatype is rejected.
@@ -550,16 +549,10 @@ mod negative {
     /// Check that a very broken native query doesn't impact subsequent queries.
     #[tokio::test(flavor = "multi_thread")]
     async fn broken_query() {
-        let ndc_metadata = FreshDeployment::create(
-            common::CONNECTION_STRING,
+        let router = tests_common::router::create_router_from_ndc_metadata(
             common::BROKEN_QUERIES_NDC_METADATA_PATH,
         )
-        .await
-        .unwrap();
-
-        let router =
-            tests_common::router::create_router_from_ndc_metadata(&ndc_metadata.ndc_metadata_path)
-                .await;
+        .await;
         let client = create_client(router);
 
         let broken_result: models::ErrorResponse = run_query_expecting(

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__negative__broken_query.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__negative__broken_query.snap
@@ -1,0 +1,21 @@
+---
+source: crates/tests/databases-tests/src/postgres/query_tests.rs
+expression: result
+---
+[
+  {
+    "message": "Internal error",
+    "details": {
+      "cause": "error returned from database: syntax error at or near \"AS\""
+    }
+  },
+  [
+    {
+      "rows": [
+        {
+          "result": 1
+        }
+      ]
+    }
+  ]
+]

--- a/crates/tests/tests-common/Cargo.toml
+++ b/crates/tests/tests-common/Cargo.toml
@@ -28,7 +28,6 @@ jsonschema = { version = "0.17.1", default-features = false, features = ["resolv
 reqwest = "0.11.24"
 schemars = { version = "0.8.16", features = ["smol_str", "preserve_order"] }
 serde = "1.0.196"
-serde_derive = "^1.0"
 serde_json = { version = "1.0.113", features = ["raw_value"] }
 similar-asserts = "1.5.0"
 sqlx = { version = "0.7.3", features = [ "json", "postgres", "runtime-tokio-rustls" ] }

--- a/crates/tests/tests-common/goldenfiles/broken_queries/broken.json
+++ b/crates/tests/tests-common/goldenfiles/broken_queries/broken.json
@@ -1,0 +1,14 @@
+{
+  "collection": "broken",
+  "query": {
+    "fields": {
+      "result": {
+        "type": "column",
+        "column": "result",
+        "arguments": {}
+      }
+    }
+  },
+  "arguments": {},
+  "collection_relationships": {}
+}

--- a/crates/tests/tests-common/goldenfiles/broken_queries/working.json
+++ b/crates/tests/tests-common/goldenfiles/broken_queries/working.json
@@ -1,0 +1,14 @@
+{
+  "collection": "working",
+  "query": {
+    "fields": {
+      "result": {
+        "type": "column",
+        "column": "result",
+        "arguments": {}
+      }
+    }
+  },
+  "arguments": {},
+  "collection_relationships": {}
+}

--- a/crates/tests/tests-common/src/common_tests/configuration_v3_tests.rs
+++ b/crates/tests/tests-common/src/common_tests/configuration_v3_tests.rs
@@ -14,7 +14,7 @@ use crate::schemas::check_value_conforms_to_schema;
 // This test does not use insta snapshots because it checks the NDC metadata file that is shared with
 // other tests.
 //
-// If you have changed it intentionally, run `just generate-chinook-configuration`.
+// If you have changed it intentionally, run `just generate-configuration`.
 pub async fn configure_is_idempotent(
     connection_string: &str,
     chinook_ndc_metadata_path: impl AsRef<Path>,

--- a/crates/tests/tests-common/src/request.rs
+++ b/crates/tests/tests-common/src/request.rs
@@ -3,18 +3,16 @@
 use std::fs;
 
 pub use axum::http::StatusCode;
-use axum::Router;
-use axum_test_helper::RequestBuilder;
 pub use axum_test_helper::TestClient;
 pub use ndc_client::models;
 
 /// Create a test client from a router.
-pub fn create_client(router: Router) -> TestClient {
+pub fn create_client(router: axum::Router) -> TestClient {
     TestClient::new(router)
 }
 
 /// Run a query against the server, get the result, and compare against the snapshot.
-pub async fn run_query(router: Router, testname: &str) -> ndc_sdk::models::QueryResponse {
+pub async fn run_query(router: axum::Router, testname: &str) -> ndc_sdk::models::QueryResponse {
     let client = create_client(router);
     run_against_server(&client, "query", testname, StatusCode::OK).await
 }
@@ -43,13 +41,13 @@ pub struct ExplainDetails {
 }
 
 /// Run a query against the server, get the result, and compare against the snapshot.
-pub async fn run_query_explain(router: Router, testname: &str) -> ExactExplainResponse {
+pub async fn run_query_explain(router: axum::Router, testname: &str) -> ExactExplainResponse {
     let client = create_client(router);
     run_against_server(&client, "query/explain", testname, StatusCode::OK).await
 }
 
 /// Run a mutation against the server, get the result, and compare against the snapshot.
-pub async fn run_mutation_explain(router: Router, testname: &str) -> models::ExplainResponse {
+pub async fn run_mutation_explain(router: axum::Router, testname: &str) -> models::ExplainResponse {
     let client = create_client(router);
     run_against_server(
         &client,
@@ -61,7 +59,10 @@ pub async fn run_mutation_explain(router: Router, testname: &str) -> models::Exp
 }
 
 /// Run a mutation against the server, get the result, and compare against the snapshot.
-pub async fn run_mutation(router: Router, testname: &str) -> ndc_sdk::models::MutationResponse {
+pub async fn run_mutation(
+    router: axum::Router,
+    testname: &str,
+) -> ndc_sdk::models::MutationResponse {
     let client = create_client(router);
     run_against_server(
         &client,
@@ -75,7 +76,7 @@ pub async fn run_mutation(router: Router, testname: &str) -> ndc_sdk::models::Mu
 /// Run a mutation that is expected to fail against the server,
 /// get the result, and compare against the snapshot.
 pub async fn run_mutation_fail(
-    router: Router,
+    router: axum::Router,
     testname: &str,
     status_code: StatusCode,
 ) -> ndc_sdk::models::ErrorResponse {
@@ -90,7 +91,7 @@ pub async fn run_mutation_fail(
 }
 
 /// Run a query against the server, get the result, and compare against the snapshot.
-pub async fn get_schema(router: Router) -> ndc_sdk::models::SchemaResponse {
+pub async fn get_schema(router: axum::Router) -> ndc_sdk::models::SchemaResponse {
     let client = create_client(router);
     make_request(&client, |client| client.get("/schema"), StatusCode::OK).await
 }
@@ -129,7 +130,7 @@ async fn run_against_server<Response: for<'a> serde::Deserialize<'a>>(
 /// Make a single request against a new server, and get the response.
 async fn make_request<Response: for<'a> serde::Deserialize<'a>>(
     client: &TestClient,
-    request: impl FnOnce(&TestClient) -> RequestBuilder,
+    request: impl FnOnce(&TestClient) -> axum_test_helper::RequestBuilder,
     expected_status: StatusCode,
 ) -> Response {
     // make the request

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,24 +15,28 @@ services:
       - type: tmpfs
         target: /var/lib/postgresql/data
       - type: bind
+        source: ./static/empty-database.sql
+        target: /docker-entrypoint-initdb.d/01-empty-database.sql
+        read_only: true
+      - type: bind
         source: ./static/chinook-postgres.sql
-        target: /docker-entrypoint-initdb.d/00-chinook-postgres.sql
+        target: /docker-entrypoint-initdb.d/02-chinook-postgres.sql
         read_only: true
       - type: bind
         source: ./static/composite-types-simple.sql
-        target: /docker-entrypoint-initdb.d/01-composite-simple.sql
+        target: /docker-entrypoint-initdb.d/03-composite-simple.sql
         read_only: true
       - type: bind
         source: ./static/composite-types-complex.sql
-        target: /docker-entrypoint-initdb.d/02-composite-complex.sql
+        target: /docker-entrypoint-initdb.d/04-composite-complex.sql
         read_only: true
       - type: bind
         source: ./static/custom-tables.sql
-        target: /docker-entrypoint-initdb.d/03-custom-tables.sql
+        target: /docker-entrypoint-initdb.d/05-custom-tables.sql
         read_only: true
       - type: bind
         source: ./static/copy-chinook.sql
-        target: /docker-entrypoint-initdb.d/04-copy-chinook.sql
+        target: /docker-entrypoint-initdb.d/06-copy-chinook.sql
         read_only: true
     healthcheck:
       test:

--- a/justfile
+++ b/justfile
@@ -11,7 +11,9 @@ CONNECTOR_IMAGE_TAG := "dev"
 CONNECTOR_IMAGE := CONNECTOR_IMAGE_NAME + ":" + CONNECTOR_IMAGE_TAG
 
 POSTGRESQL_CONNECTION_STRING := "postgresql://postgres:password@localhost:64002"
+POSTGRESQL_EMPTY_CONNECTION_STRING := "postgresql://postgres:password@localhost:64002/empty"
 POSTGRES_V3_CHINOOK_NDC_METADATA := "static/postgres/v3-chinook-ndc-metadata"
+POSTGRES_BROKEN_QUERIES_NDC_METADATA := "static/postgres/broken-queries-ndc-metadata"
 
 COCKROACH_CONNECTION_STRING := "postgresql://postgres:password@localhost:64003/defaultdb"
 COCKROACH_V3_CHINOOK_NDC_METADATA := "static/cockroach/v3-chinook-ndc-metadata"
@@ -163,8 +165,11 @@ test *args: start-dependencies create-aurora-ndc-metadata
 
 # re-generate the NDC metadata configuration file
 generate-chinook-configuration: build start-dependencies
+  ./scripts/generate-chinook-configuration.sh 'ndc-postgres' '{{POSTGRESQL_EMPTY_CONNECTION_STRING}}' '{{POSTGRES_BROKEN_QUERIES_NDC_METADATA}}/configuration.json'
+
   # right now, we are breaking things, so archiving old configuration is meaningless
   # ./scripts/archive-old-ndc-metadata.sh '{{POSTGRES_V3_CHINOOK_NDC_METADATA}}'
+
   ./scripts/generate-chinook-configuration.sh 'ndc-postgres' '{{POSTGRESQL_CONNECTION_STRING}}' '{{POSTGRES_V3_CHINOOK_NDC_METADATA}}/configuration.json'
   ./scripts/generate-chinook-configuration.sh 'ndc-postgres' '{{CITUS_CONNECTION_STRING}}' '{{CITUS_V3_CHINOOK_NDC_METADATA}}/configuration.json'
   ./scripts/generate-chinook-configuration.sh 'ndc-postgres' '{{COCKROACH_CONNECTION_STRING}}' '{{COCKROACH_V3_CHINOOK_NDC_METADATA}}/configuration.json'

--- a/justfile
+++ b/justfile
@@ -164,25 +164,25 @@ test *args: start-dependencies create-aurora-ndc-metadata
   RUST_LOG=DEBUG "${TEST_COMMAND[@]}"
 
 # re-generate the NDC metadata configuration file
-generate-chinook-configuration: build start-dependencies
-  ./scripts/generate-chinook-configuration.sh 'ndc-postgres' '{{POSTGRESQL_EMPTY_CONNECTION_STRING}}' '{{POSTGRES_BROKEN_QUERIES_NDC_METADATA}}/configuration.json'
+generate-configuration: build start-dependencies
+  ./scripts/generate-configuration.sh 'ndc-postgres' '{{POSTGRESQL_EMPTY_CONNECTION_STRING}}' '{{POSTGRES_BROKEN_QUERIES_NDC_METADATA}}/configuration.json'
 
   # right now, we are breaking things, so archiving old configuration is meaningless
   # ./scripts/archive-old-ndc-metadata.sh '{{POSTGRES_V3_CHINOOK_NDC_METADATA}}'
 
-  ./scripts/generate-chinook-configuration.sh 'ndc-postgres' '{{POSTGRESQL_CONNECTION_STRING}}' '{{POSTGRES_V3_CHINOOK_NDC_METADATA}}/configuration.json'
-  ./scripts/generate-chinook-configuration.sh 'ndc-postgres' '{{CITUS_CONNECTION_STRING}}' '{{CITUS_V3_CHINOOK_NDC_METADATA}}/configuration.json'
-  ./scripts/generate-chinook-configuration.sh 'ndc-postgres' '{{COCKROACH_CONNECTION_STRING}}' '{{COCKROACH_V3_CHINOOK_NDC_METADATA}}/configuration.json'
+  ./scripts/generate-configuration.sh 'ndc-postgres' '{{POSTGRESQL_CONNECTION_STRING}}' '{{POSTGRES_V3_CHINOOK_NDC_METADATA}}/configuration.json'
+  ./scripts/generate-configuration.sh 'ndc-postgres' '{{CITUS_CONNECTION_STRING}}' '{{CITUS_V3_CHINOOK_NDC_METADATA}}/configuration.json'
+  ./scripts/generate-configuration.sh 'ndc-postgres' '{{COCKROACH_CONNECTION_STRING}}' '{{COCKROACH_V3_CHINOOK_NDC_METADATA}}/configuration.json'
 
   @ if [[ "$(uname -m)" == 'x86_64' ]]; then \
-    echo "$(tput bold)./scripts/generate-chinook-configuration.sh 'ndc-postgres' '{{YUGABYTE_CONNECTION_STRING}}' '{{YUGABYTE_V3_CHINOOK_NDC_METADATA}}/configuration.json'$(tput sgr0)"; \
-    ./scripts/generate-chinook-configuration.sh 'ndc-postgres' '{{YUGABYTE_CONNECTION_STRING}}' '{{YUGABYTE_V3_CHINOOK_NDC_METADATA}}/configuration.json'; \
+    echo "$(tput bold)./scripts/generate-configuration.sh 'ndc-postgres' '{{YUGABYTE_CONNECTION_STRING}}' '{{YUGABYTE_V3_CHINOOK_NDC_METADATA}}/configuration.json'$(tput sgr0)"; \
+    ./scripts/generate-configuration.sh 'ndc-postgres' '{{YUGABYTE_CONNECTION_STRING}}' '{{YUGABYTE_V3_CHINOOK_NDC_METADATA}}/configuration.json'; \
   else \
     echo "$(tput bold)$(tput setaf 3)WARNING:$(tput sgr0) Not updating the Yugabyte configuration because we are running on a non-x86_64 architecture."; \
   fi
   @ if [[ -n '{{AURORA_CONNECTION_STRING}}' ]]; then \
-    echo "$(tput bold)./scripts/generate-chinook-configuration.sh 'ndc-postgres' '{{AURORA_CONNECTION_STRING}}' '{{AURORA_V3_CHINOOK_NDC_METADATA}}/template.json'$(tput sgr0)"; \
-    ./scripts/generate-chinook-configuration.sh "ndc-postgres" '{{AURORA_CONNECTION_STRING}}' '{{AURORA_V3_CHINOOK_NDC_METADATA}}/template.json'; \
+    echo "$(tput bold)./scripts/generate-configuration.sh 'ndc-postgres' '{{AURORA_CONNECTION_STRING}}' '{{AURORA_V3_CHINOOK_NDC_METADATA}}/template.json'$(tput sgr0)"; \
+    ./scripts/generate-configuration.sh "ndc-postgres" '{{AURORA_CONNECTION_STRING}}' '{{AURORA_V3_CHINOOK_NDC_METADATA}}/template.json'; \
     just create-aurora-ndc-metadata; \
   else \
     echo "$(tput bold)$(tput setaf 3)WARNING:$(tput sgr0) Not updating the Aurora configuration because the connection string is unset."; \

--- a/scripts/generate-configuration.sh
+++ b/scripts/generate-configuration.sh
@@ -8,7 +8,7 @@ CURRENT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" > /dev/null && echo "$P
 
 EXECUTABLE="$1"
 CONNECTION_STRING="$2"
-CHINOOK_NDC_METADATA="$3"
+CONFIGURATION_FILE="$3"
 
 # Ensure we clean up.
 function stop {
@@ -24,10 +24,10 @@ cargo build
 CLI="${PWD}/target/debug/ndc-postgres-cli"
 
 # We want to preserve the connectionUri unchanged in the NDC metadata file, for secrets templating purposes.
-PRESERVED_DATA="$(jq '{"connectionUri": .connectionUri}' "$CHINOOK_NDC_METADATA")"
+PRESERVED_DATA="$(jq '{"connectionUri": .connectionUri}' "$CONFIGURATION_FILE")"
 
 # Native queries should inform the initial configuration call.
-INITIAL_DATA="$(jq '{"version": .version, "connectionUri": .connectionUri, "poolSettings": (.poolSettings // {}), "metadata": {"nativeQueries": .metadata.nativeQueries, "compositeTypes": .metadata.compositeTypes}, "configureOptions": {"mutationsVersion": .configureOptions.mutationsVersion}}' "$CHINOOK_NDC_METADATA")"
+INITIAL_DATA="$(jq '{"version": .version, "connectionUri": .connectionUri, "poolSettings": (.poolSettings // {}), "metadata": {"nativeQueries": .metadata.nativeQueries, "compositeTypes": .metadata.compositeTypes}, "configureOptions": {"mutationsVersion": .configureOptions.mutationsVersion}}' "$CONFIGURATION_FILE")"
 
 # Create a temporary directory for the output so we don't overwrite data by accident.
 # The CLI will read from and write to the directory specified by this environment variable.
@@ -53,5 +53,5 @@ jq \
   > "${HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH}/configuration.spliced.json"
 
 # If the above succeeded, overwrite the configuration.
-rm -f "$CHINOOK_NDC_METADATA"
-mv -nv "${HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH}/configuration.spliced.json" "$CHINOOK_NDC_METADATA"
+rm -f "$CONFIGURATION_FILE"
+mv -nv "${HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH}/configuration.spliced.json" "$CONFIGURATION_FILE"

--- a/static/empty-database.sql
+++ b/static/empty-database.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE empty;

--- a/static/postgres/broken-queries-ndc-metadata/configuration.json
+++ b/static/postgres/broken-queries-ndc-metadata/configuration.json
@@ -1,0 +1,362 @@
+{
+  "version": "3",
+  "connectionUri": {
+    "uri": {
+      "value": "postgresql://postgres:password@localhost:64002/empty"
+    }
+  },
+  "isolationLevel": "ReadCommitted",
+  "metadata": {
+    "tables": {},
+    "compositeTypes": {},
+    "nativeQueries": {
+      "broken": {
+        "sql": "SELECT ) AS result",
+        "columns": {
+          "result": {
+            "name": "result",
+            "type": {
+              "scalarType": "int4"
+            },
+            "nullable": "nonNullable",
+            "description": null
+          }
+        },
+        "arguments": {},
+        "description": "A native query that is so broken that it will abort an entire transaction"
+      },
+      "working": {
+        "sql": "SELECT 1 AS result",
+        "columns": {
+          "result": {
+            "name": "result",
+            "type": {
+              "scalarType": "int4"
+            },
+            "nullable": "nonNullable",
+            "description": null
+          }
+        },
+        "arguments": {},
+        "description": "A working native query that simply returns 1"
+      }
+    },
+    "aggregateFunctions": {
+      "int4": {
+        "bit_and": {
+          "returnType": "int4"
+        },
+        "bit_or": {
+          "returnType": "int4"
+        },
+        "bit_xor": {
+          "returnType": "int4"
+        },
+        "max": {
+          "returnType": "int4"
+        },
+        "min": {
+          "returnType": "int4"
+        }
+      }
+    },
+    "comparisonOperators": {
+      "int4": {
+        "_eq": {
+          "operatorName": "=",
+          "operatorKind": "equal",
+          "argumentType": "int4",
+          "isInfix": true
+        },
+        "_gt": {
+          "operatorName": ">",
+          "operatorKind": "custom",
+          "argumentType": "int4",
+          "isInfix": true
+        },
+        "_gte": {
+          "operatorName": ">=",
+          "operatorKind": "custom",
+          "argumentType": "int4",
+          "isInfix": true
+        },
+        "_in": {
+          "operatorName": "IN",
+          "operatorKind": "in",
+          "argumentType": "int4",
+          "isInfix": true
+        },
+        "_lt": {
+          "operatorName": "<",
+          "operatorKind": "custom",
+          "argumentType": "int4",
+          "isInfix": true
+        },
+        "_lte": {
+          "operatorName": "<=",
+          "operatorKind": "custom",
+          "argumentType": "int4",
+          "isInfix": true
+        },
+        "_neq": {
+          "operatorName": "<>",
+          "operatorKind": "custom",
+          "argumentType": "int4",
+          "isInfix": true
+        }
+      }
+    }
+  },
+  "configureOptions": {
+    "excludedSchemas": [
+      "information_schema",
+      "pg_catalog",
+      "tiger",
+      "crdb_internal",
+      "columnar",
+      "columnar_internal"
+    ],
+    "unqualifiedSchemasForTables": ["public"],
+    "unqualifiedSchemasForTypesAndProcedures": [
+      "public",
+      "pg_catalog",
+      "tiger"
+    ],
+    "comparisonOperatorMapping": [
+      {
+        "operatorName": "=",
+        "exposedName": "_eq",
+        "operatorKind": "equal"
+      },
+      {
+        "operatorName": "<=",
+        "exposedName": "_lte",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": ">",
+        "exposedName": "_gt",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": ">=",
+        "exposedName": "_gte",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "<",
+        "exposedName": "_lt",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "!=",
+        "exposedName": "_neq",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "LIKE",
+        "exposedName": "_like",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "NOT LIKE",
+        "exposedName": "_nlike",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "ILIKE",
+        "exposedName": "_ilike",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "NOT ILIKE",
+        "exposedName": "_nilike",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "SIMILAR TO",
+        "exposedName": "_similar",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "NOT SIMILAR TO",
+        "exposedName": "_nsimilar",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "<>",
+        "exposedName": "_neq",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "~~",
+        "exposedName": "_like",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "!~~",
+        "exposedName": "_nlike",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "~~*",
+        "exposedName": "_ilike",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "!~~*",
+        "exposedName": "_nilike",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "~",
+        "exposedName": "_regex",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "!~",
+        "exposedName": "_nregex",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "~*",
+        "exposedName": "_iregex",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "!~*",
+        "exposedName": "_niregex",
+        "operatorKind": "custom"
+      }
+    ],
+    "mutationsVersion": "v1",
+    "introspectPrefixFunctionComparisonOperators": [
+      "box_above",
+      "box_below",
+      "box_contain",
+      "box_contain_pt",
+      "box_contained",
+      "box_left",
+      "box_overabove",
+      "box_overbelow",
+      "box_overlap",
+      "box_overleft",
+      "box_overright",
+      "box_right",
+      "box_same",
+      "circle_above",
+      "circle_below",
+      "circle_contain",
+      "circle_contain_pt",
+      "circle_contained",
+      "circle_left",
+      "circle_overabove",
+      "circle_overbelow",
+      "circle_overlap",
+      "circle_overleft",
+      "circle_overright",
+      "circle_right",
+      "circle_same",
+      "contains_2d",
+      "equals",
+      "geography_overlaps",
+      "geometry_above",
+      "geometry_below",
+      "geometry_contained_3d",
+      "geometry_contains",
+      "geometry_contains_3d",
+      "geometry_contains_nd",
+      "geometry_left",
+      "geometry_overabove",
+      "geometry_overbelow",
+      "geometry_overlaps",
+      "geometry_overlaps_3d",
+      "geometry_overlaps_nd",
+      "geometry_overleft",
+      "geometry_overright",
+      "geometry_right",
+      "geometry_same",
+      "geometry_same_3d",
+      "geometry_same_nd",
+      "geometry_within",
+      "geometry_within_nd",
+      "inet_same_family",
+      "inter_lb",
+      "inter_sb",
+      "inter_sl",
+      "is_contained_2d",
+      "ishorizontal",
+      "isparallel",
+      "isperp",
+      "isvertical",
+      "jsonb_contained",
+      "jsonb_contains",
+      "jsonb_exists",
+      "jsonb_path_exists_opr",
+      "jsonb_path_match_opr",
+      "line_intersect",
+      "line_parallel",
+      "line_perp",
+      "lseg_intersect",
+      "lseg_parallel",
+      "lseg_perp",
+      "network_overlap",
+      "network_sub",
+      "network_sup",
+      "on_pb",
+      "on_pl",
+      "on_ppath",
+      "on_ps",
+      "on_sb",
+      "on_sl",
+      "overlaps_2d",
+      "path_contain_pt",
+      "path_inter",
+      "point_above",
+      "point_below",
+      "point_horiz",
+      "point_left",
+      "point_right",
+      "point_vert",
+      "poly_above",
+      "poly_below",
+      "poly_contain",
+      "poly_contain_pt",
+      "poly_contained",
+      "poly_left",
+      "poly_overabove",
+      "poly_overbelow",
+      "poly_overlap",
+      "poly_overleft",
+      "poly_overright",
+      "poly_right",
+      "poly_same",
+      "pt_contained_poly",
+      "st_3dintersects",
+      "st_contains",
+      "st_containsproperly",
+      "st_coveredby",
+      "st_covers",
+      "st_crosses",
+      "st_disjoint",
+      "st_equals",
+      "st_intersects",
+      "st_isvalid",
+      "st_orderingequals",
+      "st_overlaps",
+      "st_relatematch",
+      "st_touches",
+      "st_within",
+      "starts_with",
+      "ts_match_qv",
+      "ts_match_tq",
+      "ts_match_tt",
+      "ts_match_vq",
+      "tsq_mcontained",
+      "tsq_mcontains",
+      "xmlexists",
+      "xmlvalidate",
+      "xpath_exists"
+    ]
+  }
+}


### PR DESCRIPTION
### What

We need to end transactions if they fail. This ensures we do in the case of queries.

Mutations were already handled.

### How

I have moved the `rollback_on_exception` function to its own module and ensured that it is used in `query_engine_execution::query`.

To test this, I have constructed new metadata with just a couple of native queries: one broken, one working. The broken one is run first, then the working one afterwards. Before this change, the test failed because the working query would fail with the error:

```
error returned from database: current transaction is aborted, commands ignored until end of transaction block
```

### Limitations

Note that there are a couple of limitations with this implementation:

1. This behavior is optional. Adding more entrypoints into query execution will require us to remember to correctly handle transactions there too.
2. On a panic, the transaction will not be rolled back.

In the future, we may want to consider:

1. Delegating this behavior to `sqlx`. (We tried this but it meant an extra query to compensate for the `begin` function not taking transaction options, which degrades performance.)
2. Wrapping all database access to ensure we handle transactions correctly.
3. Handling panics.