### PR TITLE
Update the default port to 8080

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@
 ### Changed
 
 - Version 1 and 2 of the ndc-metadata have been deprecated and removed.
+- The default port was changed from 8100 to 8080. This is configurable with
+  the `HASURA_CONNECTOR_PORT` environment variable.
 
 ## [0.3.0] - 2023-01-31
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -33,7 +33,7 @@ Using host libthread_db library "/lib64/libthread_db.so.1".
 [New Thread 0x7ffff753f6c0 (LWP 143305)]
 ...
 [New Thread 0x7ffff57306c0 (LWP 143320)]
-Starting server on 0.0.0.0:8100
+Starting server on 0.0.0.0:8080
 
 ```
 
@@ -43,7 +43,7 @@ For example, running a test:
 ```sh
 curl -H "Content-Type: application/json" \
   --data "@crates/ndc-postgres/tests/goldenfiles/dup_array_relationship.json" \
-  http://localhost:8100/query
+  http://localhost:8080/query
 ```
 
 Then we can go back to our GDB window:

--- a/docs/development.md
+++ b/docs/development.md
@@ -41,7 +41,7 @@ just run
    ```
    curl -H "Content-Type: application/json" \
      --data "@crates/tests/tests-common/goldenfiles/select_where_variable.json" \
-     http://localhost:8100/query \
+     http://localhost:8080/query \
      | jq
    ```
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -59,7 +59,7 @@ services:
       - serve
       - --configuration=/ndc-metadata.json
     ports:
-      - 8100:8100
+      - 8080:8080
     volumes:
       - type: bind
         source: ./ndc-metadata.json
@@ -79,6 +79,6 @@ services:
         condition: service_healthy
 ```
 
-Running `docker compose up --detach --wait` will start the container running on port 8100.
+Running `docker compose up --detach --wait` will start the container running on port 8080.
 
 Note that the `healthcheck` section refers to the binary `ndc-postgres`. This will vary per connector flavor.

--- a/metrics/grafana/dashboards/ndc-postgres.json
+++ b/metrics/grafana/dashboards/ndc-postgres.json
@@ -481,7 +481,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "{instance=\"host.docker.internal:8100\", job=\"ndc-postgres\", le=\"0.005\"}"
+              "options": "{instance=\"host.docker.internal:8080\", job=\"ndc-postgres\", le=\"0.005\"}"
             },
             "properties": [
               {

--- a/metrics/prometheus/prometheus.yml
+++ b/metrics/prometheus/prometheus.yml
@@ -27,4 +27,4 @@ scrape_configs:
     scheme: http
     static_configs:
       - targets:
-          - host.docker.internal:8100
+          - host.docker.internal:8080

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -20,7 +20,7 @@ let
       Env = [
         ''HASURA_CONFIGURATION_DIRECTORY=/etc/connector''
       ];
-      ExposedPorts = { "8100/tcp" = { }; };
+      ExposedPorts = { "8080/tcp" = { }; };
     } // extraConfig;
   }
   // lib.optionalAttrs (tag != null) {

--- a/static/postgres/chinook-metadata.json
+++ b/static/postgres/chinook-metadata.json
@@ -4,7 +4,7 @@
       "name": "db",
       "url": {
         "singleUrl": {
-          "value": "http://localhost:8100"
+          "value": "http://localhost:8080"
         }
       },
       "schema": {


### PR DESCRIPTION
### What

According to the [deployment rfc](https://github.com/hasura/ndc-hub/blob/09edbd53d3d96a6b557c3f6918e272ce7739a6ae/rfcs/0000-deployment.md?plain=1#L26), the default port should be 8080, and indeed that was changed in latest ndc-sdk. Updating the documentation

### How

Replace 8100 with 8080 everywhere.
