### PR TITLE
move the ArrayType option lower in the schema

### DIFF
--- a/crates/query-engine/metadata/src/metadata/database.rs
+++ b/crates/query-engine/metadata/src/metadata/database.rs
@@ -18,9 +18,9 @@ pub struct ScalarType(pub String);
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum Type {
-    ArrayType(Box<Type>),
     ScalarType(ScalarType),
     CompositeType(String),
+    ArrayType(Box<Type>),
 }
 
 /// Information about a composite type. These are very similar to tables, but with the crucial

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__get_configuration_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__get_configuration_schema.snap
@@ -572,18 +572,6 @@ expression: schema
         {
           "type": "object",
           "required": [
-            "arrayType"
-          ],
-          "properties": {
-            "arrayType": {
-              "$ref": "#/definitions/Type"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
             "scalarType"
           ],
           "properties": {
@@ -601,6 +589,18 @@ expression: schema
           "properties": {
             "compositeType": {
               "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "arrayType"
+          ],
+          "properties": {
+            "arrayType": {
+              "$ref": "#/definitions/Type"
             }
           },
           "additionalProperties": false

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__get_rawconfiguration_v3_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__get_rawconfiguration_v3_schema.snap
@@ -560,18 +560,6 @@ expression: schema
         {
           "type": "object",
           "required": [
-            "arrayType"
-          ],
-          "properties": {
-            "arrayType": {
-              "$ref": "#/definitions/Type"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
             "scalarType"
           ],
           "properties": {
@@ -589,6 +577,18 @@ expression: schema
           "properties": {
             "compositeType": {
               "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "arrayType"
+          ],
+          "properties": {
+            "arrayType": {
+              "$ref": "#/definitions/Type"
             }
           },
           "additionalProperties": false

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__openapi_tests__openapi__up_to_date_generated_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__openapi_tests__openapi__up_to_date_generated_schema.snap
@@ -564,18 +564,6 @@ expression: generated_schema_json
         {
           "type": "object",
           "required": [
-            "arrayType"
-          ],
-          "properties": {
-            "arrayType": {
-              "$ref": "#/components/schemas/Type"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
             "scalarType"
           ],
           "properties": {
@@ -593,6 +581,18 @@ expression: generated_schema_json
           "properties": {
             "compositeType": {
               "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "arrayType"
+          ],
+          "properties": {
+            "arrayType": {
+              "$ref": "#/components/schemas/Type"
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
### What

In the enum `Type` we place `ArrayType(Type)`, a recursive type, first in the list of options.
Some tooling such as json-editor, don't seem to like that very much, and would prefer a non-recursive option first.

### How

In the enum definition, we push `ArrayType` down, and that seems to make the tools happy.
