### PR TITLE
Run the binaries with Nix.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,20 @@
           };
         };
 
+        apps = {
+          default = self.apps.${localSystem}.connector;
+
+          connector = {
+            type = "app";
+            program = "${self.packages.${localSystem}.default}/bin/ndc-postgres";
+          };
+
+          cli = {
+            type = "app";
+            program = "${self.packages.${localSystem}.default}/bin/ndc-postgres-cli";
+          };
+        };
+
         checks = {
           # Build the crate as part of `nix flake check`
           ndc-postgres = self.packages.${localSystem}.default;

--- a/nix/app.nix
+++ b/nix/app.nix
@@ -53,5 +53,4 @@ craneLib.buildPackage
   (buildArgs // {
     inherit cargoArtifacts;
     doCheck = false;
-    cargoExtraArgs = "--locked --bin ${buildArgs.pname}";
   })


### PR DESCRIPTION
### What

It can be pretty useful to run `nix run` and get a binary running which has been built in the exact same way as the production binary shipped in the Docker image.

I also added the CLI so we can run `nix run .#cli`.

### How

Bit of typing, really.