### PR TITLE
Update ndc-sdk to use `ConnectorSetup`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ dependencies = [
 [[package]]
 name = "ndc-sdk"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-hub.git?rev=393213d#393213d3db73cc75cb53de45f82afcbe662b7be3"
+source = "git+https://github.com/hasura/ndc-hub.git?rev=1e6f53b#1e6f53b92cbee395b9b83e0d1a9a02b5c44c9cc4"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/configuration/Cargo.toml
+++ b/crates/configuration/Cargo.toml
@@ -9,7 +9,7 @@ workspace = true
 [dependencies]
 query-engine-metadata = { path = "../query-engine/metadata" }
 
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "393213d" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "1e6f53b" }
 
 anyhow = "1.0.80"
 schemars = { version = "0.8.16", features = ["smol_str", "preserve_order"] }

--- a/crates/connectors/ndc-postgres/Cargo.toml
+++ b/crates/connectors/ndc-postgres/Cargo.toml
@@ -24,7 +24,7 @@ query-engine-metadata = { path = "../../query-engine/metadata" }
 query-engine-sql = { path = "../../query-engine/sql" }
 query-engine-translation = { path = "../../query-engine/translation" }
 
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "393213d" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "1e6f53b" }
 
 async-trait = "0.1.77"
 percent-encoding = "2.3.1"

--- a/crates/connectors/ndc-postgres/bin/main.rs
+++ b/crates/connectors/ndc-postgres/bin/main.rs
@@ -1,7 +1,10 @@
-use ndc_postgres::connector::Postgres;
-use ndc_sdk::default_main::default_main;
+use ndc_postgres::connector::PostgresSetup;
+use ndc_postgres_configuration::environment::ProcessEnvironment;
+use ndc_sdk::default_main::default_main_with;
 
 #[tokio::main]
 pub async fn main() {
-    default_main::<Postgres>().await.unwrap()
+    default_main_with(PostgresSetup::new(ProcessEnvironment))
+        .await
+        .unwrap()
 }

--- a/crates/query-engine/translation/Cargo.toml
+++ b/crates/query-engine/translation/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 query-engine-metadata = { path = "../metadata" }
 query-engine-sql = { path = "../sql" }
 
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "393213d" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "1e6f53b" }
 
 indexmap = "2"
 multimap = "0.9.1"

--- a/crates/tests/databases-tests/src/postgres/mutation_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/mutation_tests.rs
@@ -13,7 +13,7 @@ mod basic {
                 .unwrap();
 
         let result = run_mutation(
-            tests_common::router::create_router_from_ndc_metadata(
+            tests_common::router::create_router(
                 &ndc_metadata.ndc_metadata_path,
                 &ndc_metadata.connection_uri,
             )
@@ -32,7 +32,7 @@ mod basic {
                 .await
                 .unwrap();
 
-        let router = tests_common::router::create_router_from_ndc_metadata(
+        let router = tests_common::router::create_router(
             &ndc_metadata.ndc_metadata_path,
             &ndc_metadata.connection_uri,
         )
@@ -56,7 +56,7 @@ mod basic {
                 .unwrap();
 
         let result = run_mutation(
-            tests_common::router::create_router_from_ndc_metadata(
+            tests_common::router::create_router(
                 &ndc_metadata.ndc_metadata_path,
                 &ndc_metadata.connection_uri,
             )
@@ -75,7 +75,7 @@ mod basic {
                 .await
                 .unwrap();
 
-        let router = tests_common::router::create_router_from_ndc_metadata(
+        let router = tests_common::router::create_router(
             &ndc_metadata.ndc_metadata_path,
             &ndc_metadata.connection_uri,
         )
@@ -104,7 +104,7 @@ mod negative {
                 .await
                 .unwrap();
 
-        let router = tests_common::router::create_router_from_ndc_metadata(
+        let router = tests_common::router::create_router(
             &ndc_metadata.ndc_metadata_path,
             &ndc_metadata.connection_uri,
         )
@@ -133,7 +133,7 @@ mod negative {
                 .await
                 .unwrap();
 
-        let router = tests_common::router::create_router_from_ndc_metadata(
+        let router = tests_common::router::create_router(
             &ndc_metadata.ndc_metadata_path,
             &ndc_metadata.connection_uri,
         )

--- a/crates/tests/databases-tests/src/postgres/query_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/query_tests.rs
@@ -549,7 +549,7 @@ mod negative {
     /// Check that a very broken native query doesn't impact subsequent queries.
     #[tokio::test(flavor = "multi_thread")]
     async fn broken_query() {
-        let router = tests_common::router::create_router_from_ndc_metadata(
+        let router = tests_common::router::create_router(
             common::BROKEN_QUERIES_NDC_METADATA_PATH,
             &format!("{}/empty", common::CONNECTION_URI),
         )

--- a/crates/tests/tests-common/Cargo.toml
+++ b/crates/tests/tests-common/Cargo.toml
@@ -16,7 +16,7 @@ ndc-postgres = { path = "../../connectors/ndc-postgres" }
 ndc-postgres-configuration = { path = "../../configuration" }
 
 ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.18" }
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "393213d" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "1e6f53b" }
 ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.18" }
 
 anyhow = "1.0.80"

--- a/crates/tests/tests-common/src/router.rs
+++ b/crates/tests/tests-common/src/router.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use super::ndc_metadata::helpers::get_path_from_project_root;
 use ndc_postgres::connector::PostgresSetup;
 
-/// Creates a router with a fresh state from the test NDC metadata.
+/// Creates a router with a fresh state from the provided configuration directory.
 pub async fn create_router(
     configuration_directory: impl AsRef<Path>,
     connection_uri: &str,
@@ -11,8 +12,7 @@ pub async fn create_router(
     let _ = env_logger::builder().is_test(true).try_init();
 
     // work out where the NDC metadata configs live
-    let absolute_configuration_directory =
-        super::ndc_metadata::helpers::get_path_from_project_root(configuration_directory);
+    let absolute_configuration_directory = get_path_from_project_root(configuration_directory);
 
     // Initialize server state with the configuration above, injecting the URI.
     let environment = HashMap::from([(
@@ -25,12 +25,4 @@ pub async fn create_router(
         .unwrap();
 
     ndc_sdk::default_main::create_router(state, None)
-}
-
-/// Creates a router with a fresh state from a NDC metadata file path
-pub async fn create_router_from_ndc_metadata(
-    configuration_directory: impl AsRef<Path>,
-    connection_uri: &str,
-) -> axum::Router {
-    create_router(configuration_directory, connection_uri).await
 }

--- a/crates/tests/tests-common/src/router.rs
+++ b/crates/tests/tests-common/src/router.rs
@@ -1,15 +1,7 @@
 use std::collections::HashMap;
-use std::error::Error;
 use std::path::Path;
-use std::sync::Arc;
 
-use tracing::{info_span, Instrument};
-
-use ndc_sdk::connector::Connector;
-use ndc_sdk::default_main::ServerState;
-
-use ndc_postgres::connector::Postgres;
-use ndc_postgres_configuration as configuration;
+use ndc_postgres::connector::PostgresSetup;
 
 /// Creates a router with a fresh state from the test NDC metadata.
 pub async fn create_router(
@@ -22,8 +14,13 @@ pub async fn create_router(
     let absolute_configuration_directory =
         super::ndc_metadata::helpers::get_path_from_project_root(configuration_directory);
 
-    // initialise server state with the static configuration.
-    let state = init_server_state(absolute_configuration_directory, connection_uri)
+    // Initialize server state with the configuration above, injecting the URI.
+    let environment = HashMap::from([(
+        ndc_postgres_configuration::version3::DEFAULT_CONNECTION_URI_VARIABLE.into(),
+        connection_uri.to_string(),
+    )]);
+    let setup = PostgresSetup::new(environment);
+    let state = ndc_sdk::default_main::init_server_state(setup, absolute_configuration_directory)
         .await
         .unwrap();
 
@@ -35,34 +32,5 @@ pub async fn create_router_from_ndc_metadata(
     configuration_directory: impl AsRef<Path>,
     connection_uri: &str,
 ) -> axum::Router {
-    let _ = env_logger::builder().is_test(true).try_init();
-
-    // work out where the NDC metadata configs live
-    let absolute_configuration_directory =
-        super::ndc_metadata::helpers::get_path_from_project_root(configuration_directory);
-
-    // initialise server state with the static configuration.
-    let state = init_server_state(absolute_configuration_directory, connection_uri)
-        .await
-        .unwrap();
-
-    ndc_sdk::default_main::create_router(state, None)
-}
-
-/// Initialize the server state just like `default_main`, but injecting a custom environment.
-async fn init_server_state(
-    configuration_directory: impl AsRef<Path>,
-    connection_uri: &str,
-) -> Result<ServerState<Postgres>, Box<dyn Error + Send + Sync>> {
-    let mut metrics = Default::default();
-    let environment = HashMap::from([(
-        ndc_postgres_configuration::version3::DEFAULT_CONNECTION_URI_VARIABLE.into(),
-        connection_uri.to_string(),
-    )]);
-    let configuration = configuration::parse_configuration(configuration_directory, environment)
-        .instrument(info_span!("parse configuration"))
-        .await
-        .map(Arc::new)?;
-    let state = Postgres::try_init_state(&configuration, &mut metrics).await?;
-    Ok(ServerState::new(configuration, state, metrics))
+    create_router(configuration_directory, connection_uri).await
 }


### PR DESCRIPTION
### What

This allows us to inject values into the configuration and state setup, which means we can remove our copy of `init_server_state`.

### How

Mostly moving code around.