### PR TITLE
Run `cargo machete` with metadata.

### DIFF
--- a/.github/workflows/cargo-machete.yaml
+++ b/.github/workflows/cargo-machete.yaml
@@ -25,4 +25,4 @@ jobs:
 
       - name: find unused dependencies
         run: |
-          cargo machete
+          cargo machete --with-metadata

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,26 +1480,16 @@ name = "ndc-postgres"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "axum",
- "axum-test-helper",
- "env_logger",
- "hyper",
- "insta",
- "ndc-client",
  "ndc-postgres-configuration",
  "ndc-sdk",
- "ndc-test",
  "percent-encoding",
  "prometheus",
  "query-engine-execution",
  "query-engine-metadata",
  "query-engine-sql",
  "query-engine-translation",
- "reqwest",
  "serde_json",
- "similar-asserts",
  "sqlx",
- "tests-common",
  "thiserror",
  "tokio",
  "tracing",
@@ -1750,7 +1740,6 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 name = "openapi-generator"
 version = "0.1.0"
 dependencies = [
- "insta",
  "ndc-postgres-configuration",
  "schemars",
  "serde_json",

--- a/crates/connectors/ndc-postgres/Cargo.toml
+++ b/crates/connectors/ndc-postgres/Cargo.toml
@@ -30,21 +30,8 @@ async-trait = "0.1.77"
 percent-encoding = "2.3.1"
 prometheus = "0.13.3"
 serde_json = { version = "1.0.114", features = ["raw_value"] }
-sqlx = { version = "0.7.3", features = [ "json", "postgres", "runtime-tokio-rustls" ] }
+sqlx = { version = "0.7.3", features = ["json", "postgres", "runtime-tokio-rustls"] }
 thiserror = "1.0"
 tokio = { version = "1.36.0", features = ["full"] }
 tracing = "0.1.40"
 url = "2.5.0"
-
-[dev-dependencies]
-ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.18" }
-ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.18" }
-tests-common = { path = "../../tests/tests-common" }
-
-axum = "0.6.20"
-axum-test-helper = "0.3.0"
-env_logger = "0.10.2"
-hyper = { version = "0.14.28", features = ["tcp"] }
-insta = { version = "1.35.1", features = ["json"] }
-reqwest = "0.11.24"
-similar-asserts = "1.5.0"

--- a/crates/documentation/openapi/Cargo.toml
+++ b/crates/documentation/openapi/Cargo.toml
@@ -19,6 +19,3 @@ path = "src/main.rs"
 ndc-postgres-configuration = { path = "../../configuration" }
 schemars = { version = "0.8.16", features = ["smol_str", "preserve_order"] }
 serde_json = { version = "1.0.114", features = ["raw_value"] }
-
-[dev-dependencies]
-insta = { version = "1.35.1", features = ["json"] }

--- a/justfile
+++ b/justfile
@@ -299,7 +299,7 @@ format-check:
 # run `cargo machete`
 find-unused-dependencies:
   # note: you can install cargo-machete with `cargo install cargo-machete`, or use the Nix shell
-  cargo machete
+  cargo machete --with-metadata
 
 # check the nix builds work
 build-with-nix:


### PR DESCRIPTION
### What

This finds more unused dependencies.

I decided to dig into this when I found out that `ndc-postgres` had an entirely-unused `dev-dependencies` section.

### How

`--with-metadata`.