### PR TITLE
Bump Nix inputs to bring in the latest version of Crane.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,17 @@
 [workspace]
 resolver = "2"
 
+package.version = "0.1.0"
+package.edition = "2021"
+package.license = "Apache-2.0"
+
 members = [
-  "crates/cli",
-  "crates/configuration",
-  "crates/connectors/*",
-  "crates/documentation/*",
-  "crates/query-engine/*",
-  "crates/tests/*",
+    "crates/cli",
+    "crates/configuration",
+    "crates/connectors/*",
+    "crates/documentation/*",
+    "crates/query-engine/*",
+    "crates/tests/*",
 ]
 
 [workspace.lints.clippy]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "ndc-postgres-cli"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/crates/configuration/Cargo.toml
+++ b/crates/configuration/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "ndc-postgres-configuration"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true
@@ -15,6 +16,6 @@ anyhow = "1.0.80"
 schemars = { version = "0.8.16", features = ["smol_str", "preserve_order"] }
 serde = "1.0.197"
 serde_json = { version = "1.0.114", features = ["raw_value"] }
-sqlx = { version = "0.7.3", features = [ "json", "postgres", "runtime-tokio-rustls" ] }
+sqlx = { version = "0.7.3", features = ["json", "postgres", "runtime-tokio-rustls"] }
 thiserror = "1.0.57"
 tracing = "0.1.40"

--- a/crates/connectors/ndc-postgres/Cargo.toml
+++ b/crates/connectors/ndc-postgres/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ndc-postgres"
-version = "0.1.0"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 default-run = "ndc-postgres"
 

--- a/crates/documentation/openapi/Cargo.toml
+++ b/crates/documentation/openapi/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "openapi-generator"
-version = "0.1.0"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/crates/query-engine/execution/Cargo.toml
+++ b/crates/query-engine/execution/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "query-engine-execution"
-version = "0.1.0"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true
@@ -13,7 +13,7 @@ query-engine-sql = { path = "../sql" }
 prometheus = "0.13.3"
 serde_json = "1.0.114"
 sqlformat = "0.2.3"
-sqlx = { version = "0.7.3", features = [ "json", "postgres", "runtime-tokio-rustls", "uuid" ] }
+sqlx = { version = "0.7.3", features = ["json", "postgres", "runtime-tokio-rustls", "uuid"] }
 thiserror = "1.0.57"
 tracing = "0.1.40"
 bytes = "1.5.0"

--- a/crates/query-engine/metadata/Cargo.toml
+++ b/crates/query-engine/metadata/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "query-engine-metadata"
-version = "0.1.0"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/crates/query-engine/sql/Cargo.toml
+++ b/crates/query-engine/sql/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "query-engine-sql"
-version = "0.1.0"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/crates/query-engine/translation/Cargo.toml
+++ b/crates/query-engine/translation/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "query-engine-translation"
-version = "0.1.0"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/crates/tests/databases-tests/Cargo.toml
+++ b/crates/tests/databases-tests/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "databases-tests"
-version = "0.1.0"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/crates/tests/tests-common/Cargo.toml
+++ b/crates/tests/tests-common/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "tests-common"
-version = "0.1.0"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707685877,
-        "narHash": "sha256-XoXRS+5whotelr1rHiZle5t5hDg9kpguS5yk8c8qzOc=",
+        "lastModified": 1708794349,
+        "narHash": "sha256-jX+B1VGHT0ruHHL5RwS8L21R6miBn4B6s9iVyUJsJJY=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "2c653e4478476a52c6aa3ac0495e4dea7449ea0e",
+        "rev": "2c94ff9a6fbeb9f3ea0107f28688edbe9c81deaa",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707863367,
-        "narHash": "sha256-LdBbCSSP7VHaHA4KXcPGKqkvsowT2+7W4jlEHJj6rPg=",
+        "lastModified": 1708807242,
+        "narHash": "sha256-sRTRkhMD4delO/hPxxi+XwLqPn8BuUq6nnj4JqLwOu0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "35ff7e87ee05199a8003f438ec11a174bcbd98ea",
+        "rev": "73de017ef2d18a04ac4bfd0c02650007ccb31c2a",
         "type": "github"
       },
       "original": {
@@ -72,11 +72,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707963067,
-        "narHash": "sha256-1vmNGzAIenei+keS8vIUNYVkEGwEwF+3FR7/bXU/r18=",
+        "lastModified": 1708999822,
+        "narHash": "sha256-X55GxqI3oDEfqy38Pt7xyypYNly4bkd/RajFE+FGn+A=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "23f224428779539eb4dc13f6a77c97ffe4680d74",
+        "rev": "1a618c62479a6896ac497aaa0d969c6bd8e24911",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### What

The latest version of Crane has some bug fixes which should allow us to use workspace values for `version`, `edition`, and `license` again.

### How

I ran `nix flake update`, and then `git revert 991f25f89f6cdadcc0214a13bc636db223c7cf78`, and manually updated the crates that have been added since.