### PR TITLE
Break the dependency on ndc-sdk in the configuration crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,7 +1514,6 @@ name = "ndc-postgres-configuration"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "ndc-sdk",
  "query-engine-metadata",
  "schemars",
  "serde",

--- a/crates/configuration/Cargo.toml
+++ b/crates/configuration/Cargo.toml
@@ -9,12 +9,10 @@ workspace = true
 [dependencies]
 query-engine-metadata = { path = "../query-engine/metadata" }
 
-ndc-sdk = { git = "https://github.com/hasura/ndc-hub.git", rev = "1e6f53b" }
-
 anyhow = "1.0.80"
 schemars = { version = "0.8.16", features = ["smol_str", "preserve_order"] }
 serde = "1.0.197"
 serde_json = { version = "1.0.114", features = ["raw_value"] }
-sqlx = { version = "0.7.3", features = [ "json", "postgres", "runtime-tokio-rustls" ] }
+sqlx = { version = "0.7.3", features = ["json", "postgres", "runtime-tokio-rustls"] }
 thiserror = "1.0.57"
 tracing = "0.1.40"

--- a/crates/configuration/src/error.rs
+++ b/crates/configuration/src/error.rs
@@ -1,0 +1,26 @@
+//! Errors that can be thrown when processing configuration.
+
+/// The errors that can be thrown when processing configuration.
+///
+/// This is effectively a copy of the `ParseError` enum in the `ndc-sdk` crate. However, we don't
+/// want a dependency on that crate here, as this crate is used by the CLI. Duplicating here and
+/// converting the values later means we can avoid that dependency.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("parse error on {file_path}:{line}:{column}: {message}")]
+    ParseError {
+        file_path: std::path::PathBuf,
+        line: usize,
+        column: usize,
+        message: String,
+    },
+    #[error("empty connection URI")]
+    EmptyConnectionUri { file_path: std::path::PathBuf },
+    #[error("missing environment variable when processing {file_path}: {message}")]
+    MissingEnvironmentVariable {
+        file_path: std::path::PathBuf,
+        message: String,
+    },
+    #[error("I/O error: {0}")]
+    IoError(#[from] std::io::Error),
+}

--- a/crates/configuration/src/lib.rs
+++ b/crates/configuration/src/lib.rs
@@ -2,10 +2,12 @@ mod configuration;
 mod values;
 
 pub mod environment;
+mod error;
 pub mod version3;
 
 pub use configuration::{
     introspect, parse_configuration, Configuration, RawConfiguration, CONFIGURATION_FILENAME,
 };
+pub use error::Error;
 pub use values::{ConnectionUri, IsolationLevel, PoolSettings, Secret};
 pub use version3::occurring_scalar_types;


### PR DESCRIPTION
### What

By maintaining our own error type, we can avoid this dependency, which means the CLI also doesn't need to bring in ndc-sdk.

This means that the CLI does not need to depend on OpenSSL.

### How

I copied the `ParseError` enum, with a few variations, into the configuration crate, and used that instead.

The connector crate now maps from one to the other.