### PR TITLE
Publish CLI binaries for all target platforms.

### DIFF
--- a/.github/workflows/ship.yaml
+++ b/.github/workflows/ship.yaml
@@ -124,6 +124,10 @@ jobs:
             target: aarch64-unknown-linux-gnu
             packages: gcc-aarch64-linux-gnu
             linker: /usr/bin/aarch64-linux-gnu-gcc
+          - runner: macos-latest
+            target: x86_64-apple-darwin
+          - runner: macos-latest
+            target: aarch64-apple-darwin
     runs-on: ${{ matrix.runner }}
     env:
       CARGO_BUILD_TARGET: ${{ matrix.target }}

--- a/.github/workflows/ship.yaml
+++ b/.github/workflows/ship.yaml
@@ -122,17 +122,22 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - runner: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            packages: gcc-aarch64-linux-gnu
+            linux-packages: gcc-aarch64-linux-gnu
             linker: /usr/bin/aarch64-linux-gnu-gcc
           - runner: macos-latest
             target: x86_64-apple-darwin
           - runner: macos-latest
             target: aarch64-apple-darwin
+          - runner: windows-latest
+            target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.runner }}
     env:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
       RUSTFLAGS: "-D warnings" # fail on warnings
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v4
 
@@ -148,10 +153,10 @@ jobs:
           rustup target add ${{ matrix.target }}
 
       - name: install other packages required
-        if: matrix.packages
+        if: matrix.linux-packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y ${{ matrix.packages }}
+          sudo apt-get install -y ${{ matrix.linux-packages }}
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ship.yaml
+++ b/.github/workflows/ship.yaml
@@ -45,7 +45,8 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.BROKEN_BUILD_SLACK_WEBHOOK_URL }}
 
-  deploy:
+  push-docker-images:
+    name: push Docker images
     needs:
       - nix-build
     runs-on: ubuntu-latest
@@ -112,10 +113,46 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.BROKEN_BUILD_SLACK_WEBHOOK_URL }}
 
+  build-cli-binary:
+    name: build the CLI binary
+    runs-on:
+      - ubuntu-latest
+      # - macos-latest
+      # - windows-latest
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+      RUSTFLAGS: "-D warnings" # fail on warnings
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "25.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: install tools
+        run: |
+          rustup show
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "build" # share the cache across jobs
+
+      - name: build the CLI
+        run: |
+          cargo build --release --package=ndc-postgres-cli
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ndc-postgres-cli-${{ runner.os }}
+          path: target/release/ndc-postgres-cli
+          if-no-files-found: error
+
   e2e-testing:
     name: check against end-to-end tests
     needs:
-      - deploy
+      - push-docker-images
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ship.yaml
+++ b/.github/workflows/ship.yaml
@@ -164,10 +164,15 @@ jobs:
           echo "Building for target: ${CARGO_BUILD_TARGET}"
           cargo build --release --package=ndc-postgres-cli
 
+      - name: wrap the CLI in a directory
+        run: |
+          mkdir -p release/ndc-postgres-cli-${{ matrix.target }}
+          mv target/${{ matrix.target }}/release/ndc-postgres-cli release/ndc-postgres-cli-${{ matrix.target }}/
+
       - uses: actions/upload-artifact@v4
         with:
           name: ndc-postgres-cli-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/ndc-postgres-cli
+          path: release/ndc-postgres-cli-${{ matrix.target }}
           if-no-files-found: error
 
   e2e-testing:

--- a/.github/workflows/ship.yaml
+++ b/.github/workflows/ship.yaml
@@ -115,11 +115,18 @@ jobs:
 
   build-cli-binary:
     name: build the CLI binary
-    runs-on:
-      - ubuntu-latest
-      # - macos-latest
-      # - windows-latest
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            packages: gcc-aarch64-linux-gnu
+            linker: /usr/bin/aarch64-linux-gnu-gcc
+    runs-on: ${{ matrix.runner }}
     env:
+      CARGO_BUILD_TARGET: ${{ matrix.target }}
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
       RUSTFLAGS: "-D warnings" # fail on warnings
     steps:
@@ -134,6 +141,13 @@ jobs:
       - name: install tools
         run: |
           rustup show
+          rustup target add ${{ matrix.target }}
+
+      - name: install other packages required
+        if: matrix.packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ matrix.packages }}
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -141,12 +155,19 @@ jobs:
 
       - name: build the CLI
         run: |
+          if [[ -n '${{ matrix.linker }}' ]]; then
+            TARGET_SCREAMING="$(echo '${{ matrix.target }}' | tr '[:lower:]' '[:upper:]' | tr '-' '_')"
+            echo "CARGO_TARGET_${TARGET_SCREAMING}_LINKER"='${{ matrix.linker }}'
+            declare "CARGO_TARGET_${TARGET_SCREAMING}_LINKER"='${{ matrix.linker }}'
+            export "CARGO_TARGET_${TARGET_SCREAMING}_LINKER"
+          fi
+          echo "Building for target: ${CARGO_BUILD_TARGET}"
           cargo build --release --package=ndc-postgres-cli
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ndc-postgres-cli-${{ runner.os }}
-          path: target/release/ndc-postgres-cli
+          name: ndc-postgres-cli-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/ndc-postgres-cli
           if-no-files-found: error
 
   e2e-testing:

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 ndc-postgres-configuration = { path = "../configuration" }
 
 anyhow = "1.0.80"
-clap = { version = "4.5.1", features = ["derive"] }
+clap = { version = "4.5.1", features = ["derive", "env"] }
 serde_json = { version = "1.0.114", features = ["raw_value"] }
 thiserror = "1.0.57"
 tokio = { version = "1.36.0", features = ["full"] }


### PR DESCRIPTION
### What

In order for the Hasura CLI to work with ndc-postgres, it needs to know about our CLI.

Which means we need to build it.

For now, we just store it in GitHub artifacts. Later, we will make this part of the release process, and releases will have binaries attached to them.

### How

I have added a GitHub Actions job to build the CLI and publish an artifact.

It does this for 5 platforms:

- Linux on x86_64 (`x86_64-unknown-linux-gnu`)
- Linux on aarch64 (`aarch64-unknown-linux-gnu`)
- macOS on x86_64 (`x86_64-apple-darwin`)
- macOS on aarch64 (`aarch64-apple-darwin`)
- Windows on x86_64 (`x86_64-pc-windows-msvc`)