### PR TITLE
Optionally initialize the configuration directory with metadata.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,8 +1502,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "insta",
  "ndc-postgres-configuration",
+ "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2689,6 +2692,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f"
+dependencies = [
+ "indexmap 2.2.3",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3586,6 +3602,12 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-data"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aed3884e2cab7c973c8fd2d150314b6a932df7fdc830edcaf1e8e7c4ae9db3c0"
+dependencies = [
+ "chrono",
+ "safe-lock",
+ "safe-regex",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1501,6 +1512,7 @@ name = "ndc-postgres-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "build-data",
  "clap",
  "insta",
  "ndc-postgres-configuration",
@@ -2457,6 +2469,59 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "safe-lock"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "077d73db7973cccf63eb4aff1e5a34dc2459baa867512088269ea5f2f4253c90"
+
+[[package]]
+name = "safe-proc-macro2"
+version = "1.0.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd85be67db87168aa3c13fd0da99f48f2ab005dccad5af5626138dc1df20eb6"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "safe-quote"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e530f7831f3feafcd5f1aae406ac205dd998436b4007c8e80f03eca78a88f7"
+dependencies = [
+ "safe-proc-macro2",
+]
+
+[[package]]
+name = "safe-regex"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15289bf322e0673d52756a18194167f2378ec1a15fe884af6e2d2cb934822b0"
+dependencies = [
+ "safe-regex-macro",
+]
+
+[[package]]
+name = "safe-regex-compiler"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba76fae590a2aa665279deb1f57b5098cbace01a0c5e60e262fcf55f7c51542"
+dependencies = [
+ "safe-proc-macro2",
+ "safe-quote",
+]
+
+[[package]]
+name = "safe-regex-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c2e96b5c03f158d1b16ba79af515137795f4ad4e8de3f790518aae91f1d127"
+dependencies = [
+ "safe-proc-macro2",
+ "safe-regex-compiler",
+]
 
 [[package]]
 name = "schannel"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -12,9 +12,12 @@ ndc-postgres-configuration = { path = "../configuration" }
 
 anyhow = "1.0.80"
 clap = { version = "4.5.1", features = ["derive", "env"] }
+serde = { version = "1.0.197", features = ["derive"] }
 serde_json = { version = "1.0.114", features = ["raw_value"] }
+serde_yaml = "0.9.32"
 thiserror = "1.0.57"
 tokio = { version = "1.36.0", features = ["full"] }
 
 [dev-dependencies]
+insta = "1.35.1"
 tempfile = "3.10.0"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,6 +18,12 @@ serde_yaml = "0.9.32"
 thiserror = "1.0.57"
 tokio = { version = "1.36.0", features = ["full"] }
 
+[build-dependencies]
+build-data = "0.1.5"
+
 [dev-dependencies]
 insta = "1.35.1"
 tempfile = "3.10.0"
+
+[package.metadata.cargo-machete]
+ignored = ["build_data"] # apparently cargo-machete doesn't find dependencies used by build scripts

--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    // Ensure that we rebuild if the version is specified.
+    println!("cargo:rerun-if-env-changed=RELEASE_VERSION");
+}

--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -1,4 +1,19 @@
-fn main() {
+fn main() -> Result<(), String> {
     // Ensure that we rebuild if the version is specified.
     println!("cargo:rerun-if-env-changed=RELEASE_VERSION");
+
+    // On release builds, use the Git commit as a backup if the version is not set.
+    // On debug builds, don't bother.
+    let build_profile = std::env::var("PROFILE").unwrap();
+    if build_profile == "release" && option_env!("RELEASE_VERSION").is_none() {
+        let git_commit_ref = build_data::get_git_commit_short()?;
+        let git_dirty = build_data::get_git_dirty()?;
+        let release_version = if git_dirty {
+            format!("{git_commit_ref}-dirty")
+        } else {
+            git_commit_ref
+        };
+        println!("cargo:rustc-env=RELEASE_VERSION={release_version}");
+    }
+    Ok(())
 }

--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -4,16 +4,18 @@ fn main() -> Result<(), String> {
 
     // On release builds, use the Git commit as a backup if the version is not set.
     // On debug builds, don't bother.
+    // If we fail to get the Git information, give up and proceed anyway.
     let build_profile = std::env::var("PROFILE").unwrap();
     if build_profile == "release" && option_env!("RELEASE_VERSION").is_none() {
-        let git_commit_ref = build_data::get_git_commit_short()?;
-        let git_dirty = build_data::get_git_dirty()?;
-        let release_version = if git_dirty {
-            format!("{git_commit_ref}-dirty")
-        } else {
-            git_commit_ref
-        };
-        println!("cargo:rustc-env=RELEASE_VERSION={release_version}");
+        if let Ok(git_commit_ref) = build_data::get_git_commit_short() {
+            let git_dirty = build_data::get_git_dirty().unwrap_or(false);
+            let release_version = if git_dirty {
+                format!("{git_commit_ref}-dirty")
+            } else {
+                git_commit_ref
+            };
+            println!("cargo:rustc-env=RELEASE_VERSION={release_version}");
+        }
     }
     Ok(())
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -6,11 +6,19 @@
 mod metadata;
 
 use std::fs;
-use std::path::Path;
+use std::path::PathBuf;
 
 use clap::Subcommand;
 
 use ndc_postgres_configuration as configuration;
+use ndc_postgres_configuration::environment::Environment;
+
+/// The various contextual bits and bobs we need to run.
+pub struct Context<Env: Environment> {
+    pub context_path: PathBuf,
+    pub environment: Env,
+    pub release_version: Option<&'static str>,
+}
 
 /// The command invoked by the user.
 #[derive(Debug, Clone, Subcommand)]
@@ -32,14 +40,10 @@ pub enum Error {
 }
 
 /// Run a command in a given directory.
-pub async fn run(
-    command: Command,
-    context_path: &Path,
-    environment: impl configuration::environment::Environment,
-) -> anyhow::Result<()> {
+pub async fn run(command: Command, context: Context<impl Environment>) -> anyhow::Result<()> {
     match command {
-        Command::Initialize { with_metadata } => initialize(context_path, with_metadata)?,
-        Command::Update => update(context_path, environment).await?,
+        Command::Initialize { with_metadata } => initialize(with_metadata, context)?,
+        Command::Update => update(context).await?,
     };
     Ok(())
 }
@@ -52,12 +56,14 @@ pub async fn run(
 ///
 /// Optionally, this can also create the connector metadata, which is used by the Hasura CLI to
 /// automatically work with this CLI as a plugin.
-fn initialize(context_path: &Path, with_metadata: bool) -> anyhow::Result<()> {
-    let configuration_file = context_path.join(configuration::CONFIGURATION_FILENAME);
-    fs::create_dir_all(context_path)?;
+fn initialize(with_metadata: bool, context: Context<impl Environment>) -> anyhow::Result<()> {
+    let configuration_file = context
+        .context_path
+        .join(configuration::CONFIGURATION_FILENAME);
+    fs::create_dir_all(&context.context_path)?;
 
     // refuse to initialize the directory unless it is empty
-    let mut items_in_dir = fs::read_dir(context_path)?;
+    let mut items_in_dir = fs::read_dir(&context.context_path)?;
     if items_in_dir.next().is_some() {
         Err(Error::DirectoryIsNotEmpty)?;
     }
@@ -70,13 +76,16 @@ fn initialize(context_path: &Path, with_metadata: bool) -> anyhow::Result<()> {
 
     // if requested, create the metadata
     if with_metadata {
-        let metadata_dir = context_path.join(".hasura-connector");
+        let metadata_dir = context.context_path.join(".hasura-connector");
         fs::create_dir(&metadata_dir)?;
         let metadata_file = metadata_dir.join("connector-metadata.yaml");
         let metadata = metadata::ConnectorMetadataDefinition {
             packaging_definition: metadata::PackagingDefinition::PrebuiltDockerImage(
                 metadata::PrebuiltDockerImagePackaging {
-                    docker_image: "ghcr.io/hasura/ndc-postgres".to_string(),
+                    docker_image: format!(
+                        "ghcr.io/hasura/ndc-postgres:{}",
+                        context.release_version.unwrap_or("latest")
+                    ),
                 },
             ),
             supported_environment_variables: vec![metadata::EnvironmentVariableDefinition {
@@ -90,7 +99,7 @@ fn initialize(context_path: &Path, with_metadata: bool) -> anyhow::Result<()> {
             },
             cli_plugin: Some(metadata::CliPluginDefinition {
                 name: "ndc-postgres".to_string(),
-                version: "latest".to_string(),
+                version: context.release_version.unwrap_or("latest").to_string(),
             }),
             docker_compose_watch: vec![],
         };
@@ -104,16 +113,15 @@ fn initialize(context_path: &Path, with_metadata: bool) -> anyhow::Result<()> {
 /// Update the configuration in the current directory by introspecting the database.
 ///
 /// This expects a configuration with a valid connection URI.
-async fn update(
-    context_path: &Path,
-    environment: impl configuration::environment::Environment,
-) -> anyhow::Result<()> {
-    let configuration_file_path = context_path.join(configuration::CONFIGURATION_FILENAME);
+async fn update(context: Context<impl Environment>) -> anyhow::Result<()> {
+    let configuration_file_path = context
+        .context_path
+        .join(configuration::CONFIGURATION_FILENAME);
     let input: configuration::RawConfiguration = {
         let reader = fs::File::open(&configuration_file_path)?;
         serde_json::from_reader(reader)?
     };
-    let output = configuration::introspect(input, environment).await?;
+    let output = configuration::introspect(input, &context.environment).await?;
     let writer = fs::File::create(&configuration_file_path)?;
     serde_json::to_writer_pretty(writer, &output)?;
     Ok(())

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -18,6 +18,10 @@ const RELEASE_VERSION: Option<&str> = option_env!("RELEASE_VERSION");
 
 /// The command-line arguments.
 #[derive(Debug, Parser)]
+#[command(
+    version = RELEASE_VERSION.unwrap_or("unknown"),
+    about = "Configuration tool for ndc-postgres"
+)]
 pub struct Args {
     /// The path to the configuration. Defaults to the current directory.
     #[arg(long = "context", env = "HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH")]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -11,6 +11,11 @@ use clap::Parser;
 use ndc_postgres_cli::*;
 use ndc_postgres_configuration as configuration;
 
+/// The release version specified at build time.
+///
+/// We should use the latest version if this is not specified.
+const RELEASE_VERSION: Option<&str> = option_env!("RELEASE_VERSION");
+
 /// The command-line arguments.
 #[derive(Debug, Parser)]
 pub struct Args {
@@ -32,11 +37,11 @@ pub async fn main() -> anyhow::Result<()> {
         Some(path) => path,
         None => env::current_dir()?,
     };
-    run(
-        args.subcommand,
-        &context_path,
-        configuration::environment::ProcessEnvironment,
-    )
-    .await?;
+    let context = Context {
+        context_path,
+        environment: configuration::environment::ProcessEnvironment,
+        release_version: RELEASE_VERSION,
+    };
+    run(args.subcommand, context).await?;
     Ok(())
 }

--- a/crates/cli/src/metadata.rs
+++ b/crates/cli/src/metadata.rs
@@ -1,0 +1,77 @@
+//! Structures that represent the connector metadata definition.
+//!
+//! See https://github.com/hasura/ndc-hub/blob/main/rfcs/0001-packaging.md#connector-definition.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConnectorMetadataDefinition {
+    pub packaging_definition: PackagingDefinition,
+    pub supported_environment_variables: Vec<EnvironmentVariableDefinition>,
+    pub commands: Commands,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cli_plugin: Option<CliPluginDefinition>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub docker_compose_watch: DockerComposeWatch,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase", tag = "type")]
+pub enum PackagingDefinition {
+    PrebuiltDockerImage(PrebuiltDockerImagePackaging),
+    ManagedDockerBuild,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrebuiltDockerImagePackaging {
+    pub docker_image: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnvironmentVariableDefinition {
+    pub name: String,
+    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_value: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Commands {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub update: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub watch: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliPluginDefinition {
+    pub name: String,
+    pub version: String,
+}
+
+pub type DockerComposeWatch = Vec<DockerComposeWatchItem>;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DockerComposeWatchItem {
+    pub path: String,
+    pub action: DockerComposeWatchAction,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub ignore: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum DockerComposeWatchAction {
+    Rebuild,
+    Sync,
+    #[serde(rename = "sync+restart")]
+    SyncAndRestart,
+}

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
@@ -1,0 +1,15 @@
+---
+source: crates/cli/tests/initialize_tests.rs
+expression: contents
+---
+packagingDefinition:
+  type: PrebuiltDockerImage
+  dockerImage: ghcr.io/hasura/ndc-postgres
+supportedEnvironmentVariables:
+- name: CONNECTION_URI
+  description: The PostgreSQL connection URI
+commands:
+  update: update
+cliPlugin:
+  name: ndc-postgres
+  version: latest

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
@@ -4,7 +4,7 @@ expression: contents
 ---
 packagingDefinition:
   type: PrebuiltDockerImage
-  dockerImage: ghcr.io/hasura/ndc-postgres:latest
+  dockerImage: ghcr.io/hasura/ndc-postgres:v1.2.3
 supportedEnvironmentVariables:
 - name: CONNECTION_URI
   description: The PostgreSQL connection URI
@@ -12,4 +12,4 @@ commands:
   update: update
 cliPlugin:
   name: ndc-postgres
-  version: latest
+  version: v1.2.3

--- a/crates/cli/tests/update_tests.rs
+++ b/crates/cli/tests/update_tests.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
 use std::fs;
 
 use ndc_postgres_cli::*;
 use ndc_postgres_configuration as configuration;
+use ndc_postgres_configuration::environment::FixedEnvironment;
 use ndc_postgres_configuration::RawConfiguration;
 
 const CONNECTION_URI: &str = "postgresql://postgres:password@localhost:64002";
@@ -25,8 +25,14 @@ async fn test_update_configuration() -> anyhow::Result<()> {
         serde_json::to_writer(writer, &input)?;
     }
 
-    let environment = HashMap::from([("CONNECTION_URI".into(), CONNECTION_URI.to_string())]);
-    run(Command::Update, dir.path(), environment).await?;
+    let environment =
+        FixedEnvironment::from([("CONNECTION_URI".into(), CONNECTION_URI.to_string())]);
+    let context = Context {
+        context_path: dir.path().to_owned(),
+        environment,
+        release_version: None,
+    };
+    run(Command::Update, context).await?;
 
     let configuration_file_path = dir.path().join("configuration.json");
     assert!(configuration_file_path.exists());


### PR DESCRIPTION
### What

To publish the connector to the NDC Hub, we need to give it some metadata, containing information such as the Docker image + tag, the CLI plugin name, etc.

This information is specified in the [Packaging RFC](https://github.com/hasura/ndc-hub/blob/main/rfcs/0001-packaging.md#connector-definition).

I've added a `--with-metadata` flag to the CLI `initialize` command which creates this metadata. It's unlikely a user will need this, but it feels like the best place for it, and there is no harm in allowing a user to do this themselves.

### How

I've converted the metadata schema into Rust types. We construct the appropriate metadata, serialize it to YAML, and write it to disk in the correct location.

We capture the `RELEASE_VERSION` environment variable at build time, and if it's set, use that for versions. Otherwise we use `latest`. (I've told `clap` about this too so you can run `ndc-postgres-cli --version`.)

In release builds, we capture Git information if `RELEASE_VERSION` is not set; in debug builds, we don't bother.