### PR TITLE
CI: Publish releases automatically from tags.

### DIFF
--- a/.github/workflows/ship.yaml
+++ b/.github/workflows/ship.yaml
@@ -171,6 +171,10 @@ jobs:
             declare "CARGO_TARGET_${TARGET_SCREAMING}_LINKER"='${{ matrix.linker }}'
             export "CARGO_TARGET_${TARGET_SCREAMING}_LINKER"
           fi
+          # If we're on a tag, use the tag as the release version.
+          if [[ "$GITHUB_REF" == 'refs/tags/'* ]]; then
+            export RELEASE_VERSION="${GITHUB_REF#refs/tags/}"
+          fi
           echo "Building for target: ${CARGO_BUILD_TARGET}"
           cargo build --release --package=ndc-postgres-cli
 

--- a/.github/workflows/ship.yaml
+++ b/.github/workflows/ship.yaml
@@ -165,23 +165,34 @@ jobs:
 
       - name: build the CLI
         run: |
+          # If we're on a tag, use the tag name as the release version.
+          if [[ "$GITHUB_REF_TYPE" == 'tag' ]]; then
+            # Ensure that the version specified in Cargo.toml is the same as the tag (with a 'v' prefix).
+            CARGO_VERSION="$(cargo metadata --format-version=1 | jq -r '.packages.[] | select(.name == "ndc-postgres") | .version')"
+            echo "Git tag: ${GIT_REF_NAME}"
+            echo "Cargo version: ${CARGO_VERSION}"
+
+            if [[ "$GITHUB_REF_NAME" != "v${CARGO_VERSION}" ]]; then
+              echo >&2 "The Git tag is \"${GITHUB_REF_NAME}\", but the version in Cargo.toml is \"${CARGO_VERSION}\"."
+              echo >&2 'These must be the same, with a "v" prefix for the tag. Aborting.'
+              exit 1
+            fi
+            export RELEASE_VERSION="$GITHUB_REF_NAME"
+            echo "RELEASE_VERSION = ${RELEASE_VERSION}"
+          fi
+
           if [[ -n '${{ matrix.linker }}' ]]; then
             TARGET_SCREAMING="$(echo '${{ matrix.target }}' | tr '[:lower:]' '[:upper:]' | tr '-' '_')"
             echo "CARGO_TARGET_${TARGET_SCREAMING}_LINKER"='${{ matrix.linker }}'
             declare "CARGO_TARGET_${TARGET_SCREAMING}_LINKER"='${{ matrix.linker }}'
             export "CARGO_TARGET_${TARGET_SCREAMING}_LINKER"
           fi
-          # If we're on a tag, use the tag as the release version.
-          if [[ "$GITHUB_REF" == 'refs/tags/'* ]]; then
-            export RELEASE_VERSION="${GITHUB_REF#refs/tags/}"
-          fi
+
           echo "Building for target: ${CARGO_BUILD_TARGET}"
           cargo build --release --package=ndc-postgres-cli
 
-      - name: wrap the CLI in a directory
-        run: |
           mkdir -p release
-          mv target/${{ matrix.target }}/release/ndc-postgres-cli release/ndc-postgres-cli-${{ matrix.target }}${{ matrix.extension }}
+          mv -v target/${{ matrix.target }}/release/ndc-postgres-cli release/ndc-postgres-cli-${{ matrix.target }}${{ matrix.extension }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ship.yaml
+++ b/.github/workflows/ship.yaml
@@ -113,8 +113,8 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.BROKEN_BUILD_SLACK_WEBHOOK_URL }}
 
-  build-cli-binary:
-    name: build the CLI binary
+  build-cli-binaries:
+    name: build the CLI binaries
     strategy:
       matrix:
         include:
@@ -130,6 +130,7 @@ jobs:
             target: aarch64-apple-darwin
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
+            extension: .exe
     runs-on: ${{ matrix.runner }}
     env:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
@@ -175,14 +176,47 @@ jobs:
 
       - name: wrap the CLI in a directory
         run: |
-          mkdir -p release/ndc-postgres-cli-${{ matrix.target }}
-          mv target/${{ matrix.target }}/release/ndc-postgres-cli release/ndc-postgres-cli-${{ matrix.target }}/
+          mkdir -p release
+          mv target/${{ matrix.target }}/release/ndc-postgres-cli release/ndc-postgres-cli-${{ matrix.target }}${{ matrix.extension }}
 
       - uses: actions/upload-artifact@v4
         with:
           name: ndc-postgres-cli-${{ matrix.target }}
-          path: release/ndc-postgres-cli-${{ matrix.target }}
+          path: release
           if-no-files-found: error
+
+  release:
+    name: release to GitHub
+    needs:
+      - push-docker-images # not strictly necessary, but if this fails, we should abort
+      - build-cli-binaries
+    runs-on: ubuntu-latest
+    # We release when a tag is pushed.
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: release/artifacts
+          merge-multiple: true
+
+      - name: generate a changelog
+        run: |
+          ./scripts/release-notes.py "${GITHUB_REF_NAME}" >> release/notes.md
+
+      - name: generate a connector package
+        run: |
+          chmod +x ./release/artifacts/ndc-postgres-cli-*
+          ./release/artifacts/ndc-postgres-cli-x86_64-unknown-linux-gnu --context=release/package initialize --with-metadata
+          tar vczf release/artifacts/package.tar.gz -C release/package .
+
+      - name: create a draft release
+        uses: ncipollo/release-action@v1
+        with:
+          draft: true
+          bodyFile: release/notes.md
+          artifacts: release/artifacts/*
 
   e2e-testing:
     name: check against end-to-end tests

--- a/.github/workflows/ship.yaml
+++ b/.github/workflows/ship.yaml
@@ -168,7 +168,7 @@ jobs:
           # If we're on a tag, use the tag name as the release version.
           if [[ "$GITHUB_REF_TYPE" == 'tag' ]]; then
             # Ensure that the version specified in Cargo.toml is the same as the tag (with a 'v' prefix).
-            CARGO_VERSION="$(cargo metadata --format-version=1 | jq -r '.packages.[] | select(.name == "ndc-postgres") | .version')"
+            CARGO_VERSION="$(cargo metadata --format-version=1 | jq -r '.packages | .[] | select(.name == "ndc-postgres") | .version')"
             echo "Git tag: ${GIT_REF_NAME}"
             echo "Cargo version: ${CARGO_VERSION}"
 

--- a/changelog.md
+++ b/changelog.md
@@ -17,7 +17,7 @@
 - Fix queries including an IN operator on an empty list.
   ([#309](https://github.com/hasura/ndc-postgres/pull/309))
 
-## [0.3.0] - 2023-01-31
+## [v0.3.0] - 2024-01-31
 
 ### Added
 
@@ -45,7 +45,7 @@
   emitted at the relevant scenarios
   ([#239](https://github.com/hasura/ndc-postgres/pull/239))
 
-## [0.2.0] - 2023-12-21
+## [v0.2.0] - 2023-12-21
 
 ### Added
 
@@ -58,11 +58,13 @@
 - Support array types ([#191](https://github.com/hasura/ndc-postgres/pull/191), ...)
 - Support Native Query Mutations ([#189](https://github.com/hasura/ndc-postgres/pull/189), [#198](https://github.com/hasura/ndc-postgres/pull/198), [#222](https://github.com/hasura/ndc-postgres/pull/222))
 
-## [0.1.0] - 2023-11-29
+## [v0.1.0] - 2023-11-29
 
 Initial release.
 
+<!-- end -->
+
 [Unreleased]: https://github.com/hasura/ndc-postgres/compare/v0.3.0...HEAD
-[0.3.0]: https://github.com/hasura/ndc-postgres/releases/tag/v0.3.0
-[0.2.0]: https://github.com/hasura/ndc-postgres/releases/tag/v0.2.0
-[0.1.0]: https://github.com/hasura/ndc-postgres/releases/tag/v0.1.0
+[v0.3.0]: https://github.com/hasura/ndc-postgres/releases/tag/v0.3.0
+[v0.2.0]: https://github.com/hasura/ndc-postgres/releases/tag/v0.2.0
+[v0.1.0]: https://github.com/hasura/ndc-postgres/releases/tag/v0.1.0

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+# Generates the release notes for a GitHub release automatically.
+#
+# These notes consist of:
+#   1. the Docker image name
+#   2. the part of the changelog corresponding to the given version
+
+import argparse
+import sys
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version")
+    args = parser.parse_args()
+
+    print_docker_image(args.version)
+    print_changelog_for_version(args.version)
+
+def print_docker_image(version):
+    print('The connector Docker image is:')
+    print('')
+    print(f'    ghcr.io/hasura/ndc-postgres:{version}')
+    print('')
+
+def print_changelog_for_version(version):
+    recording = False
+    changelog_lines = []
+    with open("changelog.md") as file:
+        for line in file:
+            line = line.rstrip() # remove trailing spaces and newline
+            # start recording lines when we find the entry corresponding to the
+            # given version
+            if line.startswith(f"## [{version}]"):
+                recording = True
+                continue
+            if recording:
+                # stop when we hit the next section or the end
+                if line.startswith("## ") or line == "<!-- end -->":
+                    break
+                changelog_lines.append(line)
+
+        # discard blank lines at the start or end
+        try:
+            while changelog_lines[0] == "":
+                changelog_lines.pop(0)
+            while changelog_lines[-1] == "":
+                changelog_lines.pop()
+        except IndexError:
+            pass
+
+    # if it's empty, we have failed
+    if not changelog_lines:
+        print(f"Could not find a changelog for version {version}.", file=sys.stderr)
+        sys.exit(1)
+
+    # print the result
+    print('## Changelog')
+    print()
+    for line in changelog_lines:
+        print(line)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### What

When we tag a commit with a version number (e.g. `v1.2.34`), a new job will now:

1. Create a GitHub release (in draft).
2. Populate the release notes automatically from `changelog.md`.
3. Build CLI binaries with the version baked in.
4. Generate the connector metadata using the CLI.
5. Upload the metadata and CLI binaries as assets.

### How

Scripting shenanigans.

There's a new job to make the release, and a script that pulls out the relevant section from the changelog to build the release notes.