### PR TITLE
Prepare for releasing v0.4.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "databases-tests"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "axum",
  "insta",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-postgres"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "ndc-postgres-configuration",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-postgres-cli"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "build-data",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-postgres-configuration"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "query-engine-metadata",
@@ -1762,7 +1762,7 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openapi-generator"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "ndc-postgres-configuration",
  "schemars",
@@ -2160,7 +2160,7 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "query-engine-execution"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "prometheus",
@@ -2174,7 +2174,7 @@ dependencies = [
 
 [[package]]
 name = "query-engine-metadata"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "schemars",
  "serde",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "query-engine-sql"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "schemars",
  "serde",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "query-engine-translation"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "indexmap 2.2.5",
  "insta",
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "tests-common"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 
-package.version = "0.1.0"
+package.version = "0.4.0"
 package.edition = "2021"
 package.license = "Apache-2.0"
 

--- a/changelog.md
+++ b/changelog.md
@@ -33,7 +33,7 @@
 - When configuration is initialized, it is expected that the connection URI will
   now be specified using an environment variable, instead of written directly.
   This can be overridden.
-  ([#325](https://github.com/hasura/ndc-postgres/pull/325)
+  ([#325](https://github.com/hasura/ndc-postgres/pull/325))
 - The default port was changed from 8100 to 8080. This is configurable with
   the `HASURA_CONNECTOR_PORT` environment variable.
 - Types and procedures are only supported in unqualified schemas, specified in

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,10 @@
   automatically introspect the database on demand.
   ([#307](https://github.com/hasura/ndc-postgres/pull/307) and
   [#312](https://github.com/hasura/ndc-postgres/pull/312))
+- Support for explaining mutations via the `/mutation/explain` endpoint.
+  ([#283](https://github.com/hasura/ndc-postgres/pull/283))
+- Support filtering using `in` by columns and variables.
+  ([#283](https://github.com/hasura/ndc-postgres/pull/283))
 
 ### Changed
 
@@ -17,6 +21,9 @@
   - The `equal` and `in` operators are now understood by the spec, and are
     integrated accordingly.
     ([#304](https://github.com/hasura/ndc-postgres/pull/304))
+  - Procedures, which previously had a built-in response structure in ndc-spec,
+    now return a nested field structure instead.
+    ([#296](https://github.com/hasura/ndc-postgres/pull/296))
 - Version 1 and 2 of the configuration and NDC metadata have been deprecated
   and removed.
 - Configuration is now a file, `configuration.json`, in the specified
@@ -32,6 +39,9 @@
 - Types and procedures are only supported in unqualified schemas, specified in
   `unqualifiedSchemasForTypesAndProcedures`.
   ([#271](https://github.com/hasura/ndc-postgres/pull/271)
+- The configuration server has been removed in favor of a cli interface.
+  ([#307](https://github.com/hasura/ndc-postgres/pull/307) and
+  [#312](https://github.com/hasura/ndc-postgres/pull/312))
 
 ### Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,20 +2,43 @@
 
 ## [Unreleased]
 
+## [v0.4.0] - 2024-03-04
+
 ### Added
 
-- Support ndc-spec-0.1.0.rc16 and introduce version 3 of the ndc-metadata.
+- There is now a CLI plugin for the Hasura v3 CLI, which allows the CLI to
+  automatically introspect the database on demand.
+  ([#307](https://github.com/hasura/ndc-postgres/pull/307) and
+  [#312](https://github.com/hasura/ndc-postgres/pull/312))
 
 ### Changed
 
-- Version 1 and 2 of the ndc-metadata have been deprecated and removed.
+- We have upgraded to [ndc-spec v0.1.0], which demands a few changes:
+  - The `equal` and `in` operators are now understood by the spec, and are
+    integrated accordingly.
+    ([#304](https://github.com/hasura/ndc-postgres/pull/304))
+- Version 1 and 2 of the configuration and NDC metadata have been deprecated
+  and removed.
+- Configuration is now a file, `configuration.json`, in the specified
+  configuration directory. It is now version 3, but little has changed from
+  version 2. This brings ndc-postgres in line with the connector specification.
+  ([#305](https://github.com/hasura/ndc-postgres/pull/305)
+- When configuration is initialized, it is expected that the connection URI will
+  now be specified using an environment variable, instead of written directly.
+  This can be overridden.
+  ([#325](https://github.com/hasura/ndc-postgres/pull/325)
 - The default port was changed from 8100 to 8080. This is configurable with
   the `HASURA_CONNECTOR_PORT` environment variable.
+- Types and procedures are only supported in unqualified schemas, specified in
+  `unqualifiedSchemasForTypesAndProcedures`.
+  ([#271](https://github.com/hasura/ndc-postgres/pull/271)
 
 ### Fixed
 
 - Fix queries including an IN operator on an empty list.
   ([#309](https://github.com/hasura/ndc-postgres/pull/309))
+
+[ndc-spec v0.1.0]: https://github.com/hasura/ndc-spec/releases/tag/v0.1.0
 
 ## [v0.3.0] - 2024-01-31
 
@@ -64,7 +87,8 @@ Initial release.
 
 <!-- end -->
 
-[Unreleased]: https://github.com/hasura/ndc-postgres/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/hasura/ndc-postgres/compare/v0.4.0...HEAD
+[v0.4.0]: https://github.com/hasura/ndc-postgres/releases/tag/v0.4.0
 [v0.3.0]: https://github.com/hasura/ndc-postgres/releases/tag/v0.3.0
 [v0.2.0]: https://github.com/hasura/ndc-postgres/releases/tag/v0.2.0
 [v0.1.0]: https://github.com/hasura/ndc-postgres/releases/tag/v0.1.0

--- a/changelog.md
+++ b/changelog.md
@@ -29,7 +29,7 @@
 - Configuration is now a file, `configuration.json`, in the specified
   configuration directory. It is now version 3, but little has changed from
   version 2. This brings ndc-postgres in line with the connector specification.
-  ([#305](https://github.com/hasura/ndc-postgres/pull/305)
+  ([#305](https://github.com/hasura/ndc-postgres/pull/305))
 - When configuration is initialized, it is expected that the connection URI will
   now be specified using an environment variable, instead of written directly.
   This can be overridden.
@@ -38,7 +38,7 @@
   the `HASURA_CONNECTOR_PORT` environment variable.
 - Types and procedures are only supported in unqualified schemas, specified in
   `unqualifiedSchemasForTypesAndProcedures`.
-  ([#271](https://github.com/hasura/ndc-postgres/pull/271)
+  ([#271](https://github.com/hasura/ndc-postgres/pull/271))
 - The configuration server has been removed in favor of a cli interface.
   ([#307](https://github.com/hasura/ndc-postgres/pull/307) and
   [#312](https://github.com/hasura/ndc-postgres/pull/312))


### PR DESCRIPTION
This updates the changelog and Cargo version in preparation for releasing v0.4.0.