### PR TITLE
Release: Publish SHA-256 checksums alongside CLI binaries.

### DIFF
--- a/.github/workflows/ship.yaml
+++ b/.github/workflows/ship.yaml
@@ -216,6 +216,11 @@ jobs:
           path: release/artifacts
           merge-multiple: true
 
+      - name: generate SHA-256 checksums
+        run: |
+          cd release/artifacts
+          sha256sum * > ./sha256sum
+
       - name: generate a changelog
         run: |
           ./scripts/release-notes.py "${GITHUB_REF_NAME}" >> release/notes.md


### PR DESCRIPTION
### What

In order to publish this CLI plugin in the index, we need SHA-256 checksums. We currently update the index manually, but let's generate the list while we're publishing so the poor soul updating the index doesn't have to download all the binaries to hash them.

### How

I have added a step to the release job that generates the checksums for all artifacts and stores them in the same directory, so they will be included.