### PR TITLE
Read and write asynchronously from the file system.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,6 +1545,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "thiserror",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/cli/tests/initialize_tests.rs
+++ b/crates/cli/tests/initialize_tests.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use tokio::fs;
 
 use ndc_postgres_cli::*;
 use ndc_postgres_configuration as configuration;
@@ -23,7 +23,7 @@ async fn test_initialize_directory() -> anyhow::Result<()> {
 
     let configuration_file_path = dir.path().join("configuration.json");
     assert!(configuration_file_path.exists());
-    let contents = fs::read_to_string(configuration_file_path)?;
+    let contents = fs::read_to_string(configuration_file_path).await?;
     let _: RawConfiguration = serde_json::from_str(&contents)?;
 
     let metadata_file_path = dir
@@ -41,7 +41,8 @@ async fn test_do_not_initialize_when_files_already_exist() -> anyhow::Result<()>
     fs::write(
         dir.path().join("random.file"),
         "this directory is no longer empty",
-    )?;
+    )
+    .await?;
 
     let context = Context {
         context_path: dir.path().to_owned(),
@@ -91,7 +92,7 @@ async fn test_initialize_directory_with_metadata() -> anyhow::Result<()> {
         .join(".hasura-connector")
         .join("connector-metadata.yaml");
     assert!(metadata_file_path.exists());
-    let contents = fs::read_to_string(metadata_file_path)?;
+    let contents = fs::read_to_string(metadata_file_path).await?;
     insta::assert_snapshot!(contents);
 
     Ok(())
@@ -122,7 +123,7 @@ async fn test_initialize_directory_with_metadata_and_release_version() -> anyhow
         .join(".hasura-connector")
         .join("connector-metadata.yaml");
     assert!(metadata_file_path.exists());
-    let contents = fs::read_to_string(metadata_file_path)?;
+    let contents = fs::read_to_string(metadata_file_path).await?;
     insta::assert_snapshot!(contents);
 
     Ok(())

--- a/crates/cli/tests/update_tests.rs
+++ b/crates/cli/tests/update_tests.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use tokio::fs;
 
 use ndc_postgres_cli::*;
 use ndc_postgres_configuration as configuration;
@@ -21,8 +21,7 @@ async fn test_update_configuration() -> anyhow::Result<()> {
             connection_uri: connection_uri.clone(),
             ..configuration::version3::RawConfiguration::empty()
         });
-        let writer = fs::File::create(configuration_file_path)?;
-        serde_json::to_writer(writer, &input)?;
+        fs::write(configuration_file_path, serde_json::to_string(&input)?).await?;
     }
 
     let environment =
@@ -36,7 +35,7 @@ async fn test_update_configuration() -> anyhow::Result<()> {
 
     let configuration_file_path = dir.path().join("configuration.json");
     assert!(configuration_file_path.exists());
-    let contents = fs::read_to_string(configuration_file_path)?;
+    let contents = fs::read_to_string(configuration_file_path).await?;
     let output: RawConfiguration = serde_json::from_str(&contents)?;
     match output {
         RawConfiguration::Version3(configuration::version3::RawConfiguration {

--- a/crates/configuration/Cargo.toml
+++ b/crates/configuration/Cargo.toml
@@ -16,4 +16,5 @@ serde = "1.0.197"
 serde_json = { version = "1.0.114", features = ["raw_value"] }
 sqlx = { version = "0.7.3", features = ["json", "postgres", "runtime-tokio-rustls"] }
 thiserror = "1.0.57"
+tokio = "1.36.0"
 tracing = "0.1.40"

--- a/crates/tests/databases-tests/src/citus/configuration_tests.rs
+++ b/crates/tests/databases-tests/src/citus/configuration_tests.rs
@@ -14,11 +14,13 @@ async fn test_configure_is_idempotent() {
         common::CHINOOK_NDC_METADATA_PATH,
     )
     .await
+    .unwrap()
 }
 
-#[test]
-fn configuration_conforms_to_the_schema() {
+#[tokio::test]
+async fn configuration_conforms_to_the_schema() {
     common_tests::configuration_v3_tests::configuration_conforms_to_the_schema(
         common::CHINOOK_NDC_METADATA_PATH,
     )
+    .await
 }

--- a/crates/tests/databases-tests/src/cockroach/configuration_tests.rs
+++ b/crates/tests/databases-tests/src/cockroach/configuration_tests.rs
@@ -14,11 +14,13 @@ async fn test_configure_is_idempotent() {
         common::CHINOOK_NDC_METADATA_PATH,
     )
     .await
+    .unwrap()
 }
 
-#[test]
-fn configuration_conforms_to_the_schema() {
+#[tokio::test]
+async fn configuration_conforms_to_the_schema() {
     common_tests::configuration_v3_tests::configuration_conforms_to_the_schema(
         common::CHINOOK_NDC_METADATA_PATH,
     )
+    .await
 }

--- a/crates/tests/databases-tests/src/postgres/configuration_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/configuration_tests.rs
@@ -28,13 +28,15 @@ async fn postgres_current_only_configure_v3_is_idempotent() {
         common::CHINOOK_NDC_METADATA_PATH,
     )
     .await
+    .unwrap()
 }
 
-#[test]
-fn configuration_v3_conforms_to_the_schema() {
+#[tokio::test]
+async fn configuration_v3_conforms_to_the_schema() {
     common_tests::configuration_v3_tests::configuration_conforms_to_the_schema(
         common::CHINOOK_NDC_METADATA_PATH,
     )
+    .await
 }
 
 #[tokio::test]

--- a/crates/tests/tests-common/src/ndc_metadata/configuration.rs
+++ b/crates/tests/tests-common/src/ndc_metadata/configuration.rs
@@ -1,9 +1,9 @@
 //! Deployment configuration functions used across test cases.
 //! Use via helpers in `mod.rs` rather than directly.
 
-use std::fs;
-use std::io;
 use std::path::Path;
+
+use tokio::fs;
 
 use ndc_postgres_configuration as configuration;
 use ndc_postgres_configuration::RawConfiguration;
@@ -13,30 +13,34 @@ use super::helpers::get_path_from_project_root;
 /// Load NDC metadata at `main_ndc_metadata_path`
 /// replace url with `new_postgres_url`
 /// save at `new_ndc_metadata_path`
-pub fn copy_ndc_metadata_with_new_postgres_url(
+pub async fn copy_ndc_metadata_with_new_postgres_url(
     main_ndc_metadata_path: impl AsRef<Path>,
     new_connection_uri: &str,
     new_ndc_metadata_path: impl AsRef<Path>,
-) -> io::Result<()> {
+) -> anyhow::Result<()> {
     let ndc_metadata_path =
         get_path_from_project_root(main_ndc_metadata_path).join("configuration.json");
 
     let new_ndc_metadata: RawConfiguration =
-        serde_json::from_str(&fs::read_to_string(ndc_metadata_path).unwrap()).unwrap();
+        serde_json::from_str(&fs::read_to_string(ndc_metadata_path).await?)?;
     let new_ndc_metadata = set_connection_uri(new_ndc_metadata, new_connection_uri.into());
 
     let new_ndc_metadata_dir = get_path_from_project_root(new_ndc_metadata_path);
-    fs::create_dir_all(&new_ndc_metadata_dir)?;
+    fs::create_dir_all(&new_ndc_metadata_dir).await?;
     let new_ndc_metadata_path = new_ndc_metadata_dir.join("configuration.json");
-    let writer = fs::File::create(get_path_from_project_root(new_ndc_metadata_path))?;
-    serde_json::to_writer_pretty(writer, &new_ndc_metadata)?;
+    fs::write(
+        get_path_from_project_root(new_ndc_metadata_path),
+        serde_json::to_string_pretty(&new_ndc_metadata)?,
+    )
+    .await?;
     Ok(())
 }
 
 /// Erase test NDC metadata file created at `ndc_metadata_path`
-pub fn delete_ndc_metadata(ndc_metadata_path: impl AsRef<Path>) -> io::Result<()> {
+pub async fn delete_ndc_metadata(ndc_metadata_path: impl AsRef<Path>) -> anyhow::Result<()> {
     let absolute_path = get_path_from_project_root(ndc_metadata_path);
-    fs::remove_dir_all(absolute_path)
+    fs::remove_dir_all(absolute_path).await?;
+    Ok(())
 }
 
 fn set_connection_uri(input: RawConfiguration, connection_uri: String) -> RawConfiguration {

--- a/crates/tests/tests-common/src/request.rs
+++ b/crates/tests/tests-common/src/request.rs
@@ -1,10 +1,9 @@
 //! Request functions used across test cases.
 
-use std::fs;
-
 pub use axum::http::StatusCode;
 pub use axum_test_helper::TestClient;
 pub use ndc_client::models;
+use tokio::fs;
 
 /// Create a test client from a router.
 pub fn create_client(router: axum::Router) -> TestClient {
@@ -108,7 +107,7 @@ async fn run_against_server<Response: for<'a> serde::Deserialize<'a>>(
         "../../../crates/tests/tests-common/goldenfiles/{}.json",
         testname
     );
-    let body = match fs::read_to_string(&goldenfile_path) {
+    let body = match fs::read_to_string(&goldenfile_path).await {
         Ok(body) => body,
         Err(err) => {
             panic!("Error reading {} : {}", &goldenfile_path, err);


### PR DESCRIPTION
### What

Blocking a Tokio thread with `std::fs` is probably not wise in a server, so I have replaced it with `tokio::fs`, thanks to a kind suggestion from @hallettj. In the CLI and tests it's less of a big deal, but I have changed it regardless.

This has, conveniently, sped up a full test run from 15s to 10s on my MacBook. (On my Linux machine, the tests run very quickly even without this change.)

### How

[`tokio::fs`](https://docs.rs/tokio/latest/tokio/fs/index.html) is Tokio's asynchronous replacement for `std::fs`. It's mostly a drop-in replacement when using the utility functions such as `read_to_string`—just add `await`.

However, `fs::File::open` and `fs::File::create` now return an `AsyncRead` and `AsyncWrite` implementation respectively, which is not compatible with `serde_json::from_reader` and `serde_json::to_writer`. To work around this, I have replaced these operations with `fs::read_to_string` and `fs::write`, and converting to/from strings separately.