### PR TITLE
Add the CLI binary name to the connector manifest.

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -95,7 +95,7 @@ async fn initialize(with_metadata: bool, context: Context<impl Environment>) -> 
                 default_value: None,
             }],
             commands: metadata::Commands {
-                update: Some("update".to_string()),
+                update: Some("hasura-ndc-postgres update".to_string()),
                 watch: None,
             },
             cli_plugin: Some(metadata::CliPluginDefinition {

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
@@ -9,7 +9,7 @@ supportedEnvironmentVariables:
 - name: CONNECTION_URI
   description: The PostgreSQL connection URI
 commands:
-  update: update
+  update: hasura-ndc-postgres update
 cliPlugin:
   name: ndc-postgres
   version: latest

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
@@ -9,7 +9,7 @@ supportedEnvironmentVariables:
 - name: CONNECTION_URI
   description: The PostgreSQL connection URI
 commands:
-  update: update
+  update: hasura-ndc-postgres update
 cliPlugin:
   name: ndc-postgres
   version: v1.2.3


### PR DESCRIPTION
### What

This is required for the CLI to work. The binary name chosen is the one in the [CLI plugins index][CLI plugin manifest].

This couples the connector manifest to the CLI plugin manifest, which isn't ideal. We may re-negotiate this at a future time, e.g. by adding syntax to this file to instruct the CLI to prefix the binary.

[CLI plugin manifest]: https://github.com/hasura/cli-plugins-index/blob/master/plugins/ndc-postgres/v0.4.0/manifest.yaml

### How

Typing.