### PR TITLE
Set docker image Cmd to `serve`

### DIFF
--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -17,6 +17,9 @@ let
       Entrypoint = [
         "/bin/${package.pname}"
       ];
+      Cmd = [
+        "serve"
+      ];
       Env = [
         ''HASURA_CONFIGURATION_DIRECTORY=/etc/connector''
       ];


### PR DESCRIPTION
### What

As per the [NDC deployment specification](https://github.com/hasura/ndc-hub/blob/main/rfcs/0000-deployment.md), the `ENTRYPOINT` and `CMD` of the image of a connector should be set such that running the image starts the connector such that it may serve requests.

This PR makes it so.

### How

* Add the `serve` command line argument to the `CMD` attribute.