### PR TITLE
Fix changelog references for 0.4.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -107,7 +107,8 @@ Initial release.
 
 <!-- end -->
 
-[Unreleased]: https://github.com/hasura/ndc-postgres/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/hasura/ndc-postgres/compare/v0.4.1...HEAD
+[v0.4.1]: https://github.com/hasura/ndc-postgres/releases/tag/v0.4.1
 [v0.4.0]: https://github.com/hasura/ndc-postgres/releases/tag/v0.4.0
 [v0.3.0]: https://github.com/hasura/ndc-postgres/releases/tag/v0.3.0
 [v0.2.0]: https://github.com/hasura/ndc-postgres/releases/tag/v0.2.0


### PR DESCRIPTION
### What

Fix the references in the links at the bottom of the changelog after 0.4.1.
