### PR TITLE
Add a healthcheck to the Docker image.

### DIFF
--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -9,6 +9,7 @@
 }:
 
 let
+  seconds = 1000 * 1000 * 1000; # nanoseconds in 1 second
   args = {
     name = image-name;
     created = "now";
@@ -24,6 +25,17 @@ let
         ''HASURA_CONFIGURATION_DIRECTORY=/etc/connector''
       ];
       ExposedPorts = { "8080/tcp" = { }; };
+      Healthcheck = {
+        Test = [
+          "CMD"
+          "/bin/${package.pname}"
+          "check-health"
+        ];
+        StartInterval = 1 * seconds;
+        Interval = 5 * seconds;
+        Timeout = 10 * seconds;
+        Retries = 3;
+      };
     } // extraConfig;
   }
   // lib.optionalAttrs (tag != null) {


### PR DESCRIPTION
### What

This allows users to wait until it's started.

### How

We add a healthcheck to the Docker image, following the [spec][Docker image spec]. This uses the `check-health` subcommand, which will adopt the container's `HASURA_CONNECTOR_PORT` if it is overridden.

[Docker image spec]: https://github.com/moby/docker-image-spec/blob/main/spec.md