### PR TITLE
Print errors at the top level using `Display`.

### DIFF
--- a/crates/connectors/ndc-postgres/bin/main.rs
+++ b/crates/connectors/ndc-postgres/bin/main.rs
@@ -1,10 +1,17 @@
+use std::process::ExitCode;
+
 use ndc_postgres::connector::PostgresSetup;
 use ndc_postgres_configuration::environment::ProcessEnvironment;
 use ndc_sdk::default_main::default_main_with;
 
 #[tokio::main]
-pub async fn main() {
-    default_main_with(PostgresSetup::new(ProcessEnvironment))
-        .await
-        .unwrap()
+pub async fn main() -> ExitCode {
+    let result = default_main_with(PostgresSetup::new(ProcessEnvironment)).await;
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("{error}");
+            ExitCode::FAILURE
+        }
+    }
 }


### PR DESCRIPTION
### What

By default, errors are printed using their `Debug` implementation, which is unpleasant to read.

The errors have a `Display` implementation, which we can opt to use by capturing it and printing it explicitly.

### How

We capture the error, print it to STDERR with `eprintln!`, then return `ExitCode::FAILURE` (mapped to `EXIT_FAILURE` from libc, which is exit code 1 on POSIX systems).