### PR TITLE
Make `poolSettings` an explicit default

### DIFF
--- a/crates/configuration/src/values/pool_settings.rs
+++ b/crates/configuration/src/values/pool_settings.rs
@@ -19,12 +19,6 @@ pub struct PoolSettings {
     pub connection_lifetime: Option<u64>,
 }
 
-impl PoolSettings {
-    pub fn is_default(&self) -> bool {
-        self == &PoolSettings::default()
-    }
-}
-
 /// <https://hasura.io/docs/latest/api-reference/syntax-defs/#pgpoolsettings>
 impl Default for PoolSettings {
     fn default() -> PoolSettings {

--- a/crates/configuration/src/version3/mod.rs
+++ b/crates/configuration/src/version3/mod.rs
@@ -30,7 +30,6 @@ pub const DEFAULT_CONNECTION_URI_VARIABLE: &str = "CONNECTION_URI";
 pub struct RawConfiguration {
     // Connection string for a Postgres-compatible database
     pub connection_uri: ConnectionUri,
-    #[serde(skip_serializing_if = "PoolSettings::is_default")]
     #[serde(default)]
     pub pool_settings: PoolSettings,
     #[serde(default)]

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__get_configuration_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__get_configuration_schema.snap
@@ -25,7 +25,17 @@ expression: schema
           "$ref": "#/definitions/ConnectionUri"
         },
         "poolSettings": {
-          "$ref": "#/definitions/PoolSettings"
+          "default": {
+            "maxConnections": 50,
+            "poolTimeout": 30,
+            "idleTimeout": 180,
+            "connectionLifetime": 600
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/PoolSettings"
+            }
+          ]
         },
         "isolationLevel": {
           "default": "ReadCommitted",

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__get_rawconfiguration_v3_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__get_rawconfiguration_v3_schema.snap
@@ -15,7 +15,17 @@ expression: schema
       "$ref": "#/definitions/ConnectionUri"
     },
     "poolSettings": {
-      "$ref": "#/definitions/PoolSettings"
+      "default": {
+        "maxConnections": 50,
+        "poolTimeout": 30,
+        "idleTimeout": 180,
+        "connectionLifetime": 600
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/PoolSettings"
+        }
+      ]
     },
     "isolationLevel": {
       "default": "ReadCommitted",

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__postgres_current_only_configure_v3_initial_configuration_is_unchanged.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__postgres_current_only_configure_v3_initial_configuration_is_unchanged.snap
@@ -6,6 +6,12 @@ expression: default_configuration
   "connectionUri": {
     "variable": "MAGIC_URI"
   },
+  "poolSettings": {
+    "maxConnections": 50,
+    "poolTimeout": 30,
+    "idleTimeout": 180,
+    "connectionLifetime": 600
+  },
   "isolationLevel": "ReadCommitted",
   "metadata": {
     "tables": {

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__openapi_tests__openapi__up_to_date_generated_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__openapi_tests__openapi__up_to_date_generated_schema.snap
@@ -25,7 +25,17 @@ expression: generated_schema_json
           "$ref": "#/components/schemas/ConnectionUri"
         },
         "poolSettings": {
-          "$ref": "#/components/schemas/PoolSettings"
+          "default": {
+            "maxConnections": 50,
+            "poolTimeout": 30,
+            "idleTimeout": 180,
+            "connectionLifetime": 600
+          },
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/PoolSettings"
+            }
+          ]
         },
         "isolationLevel": {
           "default": "ReadCommitted",

--- a/static/citus/v3-chinook-ndc-metadata/configuration.json
+++ b/static/citus/v3-chinook-ndc-metadata/configuration.json
@@ -3,6 +3,12 @@
   "connectionUri": {
     "variable": "CONNECTION_URI"
   },
+  "poolSettings": {
+    "maxConnections": 50,
+    "poolTimeout": 30,
+    "idleTimeout": 180,
+    "connectionLifetime": 600
+  },
   "isolationLevel": "ReadCommitted",
   "metadata": {
     "tables": {

--- a/static/cockroach/v3-chinook-ndc-metadata/configuration.json
+++ b/static/cockroach/v3-chinook-ndc-metadata/configuration.json
@@ -3,6 +3,12 @@
   "connectionUri": {
     "variable": "CONNECTION_URI"
   },
+  "poolSettings": {
+    "maxConnections": 50,
+    "poolTimeout": 30,
+    "idleTimeout": 180,
+    "connectionLifetime": 600
+  },
   "isolationLevel": "ReadCommitted",
   "metadata": {
     "tables": {

--- a/static/postgres/broken-queries-ndc-metadata/configuration.json
+++ b/static/postgres/broken-queries-ndc-metadata/configuration.json
@@ -3,6 +3,12 @@
   "connectionUri": {
     "variable": "CONNECTION_URI"
   },
+  "poolSettings": {
+    "maxConnections": 50,
+    "poolTimeout": 30,
+    "idleTimeout": 180,
+    "connectionLifetime": 600
+  },
   "isolationLevel": "ReadCommitted",
   "metadata": {
     "tables": {},

--- a/static/postgres/v3-chinook-ndc-metadata/configuration.json
+++ b/static/postgres/v3-chinook-ndc-metadata/configuration.json
@@ -3,6 +3,12 @@
   "connectionUri": {
     "variable": "CONNECTION_URI"
   },
+  "poolSettings": {
+    "maxConnections": 50,
+    "poolTimeout": 30,
+    "idleTimeout": 180,
+    "connectionLifetime": 600
+  },
   "isolationLevel": "ReadCommitted",
   "metadata": {
     "tables": {

--- a/static/yugabyte/v3-chinook-ndc-metadata/configuration.json
+++ b/static/yugabyte/v3-chinook-ndc-metadata/configuration.json
@@ -3,6 +3,12 @@
   "connectionUri": {
     "variable": "CONNECTION_URI"
   },
+  "poolSettings": {
+    "maxConnections": 50,
+    "poolTimeout": 30,
+    "idleTimeout": 180,
+    "connectionLifetime": 600
+  },
   "isolationLevel": "ReadCommitted",
   "metadata": {
     "tables": {


### PR DESCRIPTION
### What

We change the serialization policy of the `poolSettings` field such that the field is always serialized, regardless of its value.

This ensures that:

* It is possible for a user to pin the value, even the the pinned value is the default one.
* The defaults of the field are captured at project initialization time (and optionally when introspecting anew)