### PR TITLE
Add a Docker Compose watch item to the connector metadata.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- The CLI plugin now integrates with the DDN CLI's `watch` functionality.
+  ([#360](https://github.com/hasura/ndc-postgres/pull/360))
+
 ## [v0.4.1] - 2024-03-06
 
 ### Fixed

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -102,7 +102,12 @@ async fn initialize(with_metadata: bool, context: Context<impl Environment>) -> 
                 name: "ndc-postgres".to_string(),
                 version: context.release_version.unwrap_or("latest").to_string(),
             }),
-            docker_compose_watch: vec![],
+            docker_compose_watch: vec![metadata::DockerComposeWatchItem {
+                path: "./".to_string(),
+                target: Some("/etc/connector".to_string()),
+                action: metadata::DockerComposeWatchAction::SyncAndRestart,
+                ignore: vec![],
+            }],
         };
 
         fs::write(metadata_file, serde_yaml::to_string(&metadata)?).await?;

--- a/crates/cli/src/metadata.rs
+++ b/crates/cli/src/metadata.rs
@@ -60,9 +60,9 @@ pub type DockerComposeWatch = Vec<DockerComposeWatchItem>;
 #[serde(rename_all = "camelCase")]
 pub struct DockerComposeWatchItem {
     pub path: String,
-    pub action: DockerComposeWatchAction,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target: Option<String>,
+    pub action: DockerComposeWatchAction,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub ignore: Vec<String>,
 }

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
@@ -13,3 +13,7 @@ commands:
 cliPlugin:
   name: ndc-postgres
   version: latest
+dockerComposeWatch:
+- path: ./
+  target: /etc/connector
+  action: sync+restart

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
@@ -13,3 +13,7 @@ commands:
 cliPlugin:
   name: ndc-postgres
   version: v1.2.3
+dockerComposeWatch:
+- path: ./
+  target: /etc/connector
+  action: sync+restart


### PR DESCRIPTION
### What

This teaches the DDN CLI that the configuration should be synced, and the connector container restarted, whenever the configuration changes.

### How

When emitting connector metadata, we include a `dockerComposeWatch` item.