### PR TITLE
update command should not override the config file in some cases

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,12 @@
 - The ndc-postgres-cli `initialize` command will now generate
   the jsonschema of the configuration format as well.
   ([#361](https://github.com/hasura/ndc-postgres/pull/361))
+- The ndc-postgres-cli `update` command will check that the configuration file has
+  not changed in the middle of the introspection process, and will retry if it did.
+  ([#362](https://github.com/hasura/ndc-postgres/pull/362))
+- The ndc-postgres-cli `update` command will not write the introspection result to
+  file if the configuration file is already up to date.
+  ([#362](https://github.com/hasura/ndc-postgres/pull/362))
 - A few fields in the configuration format has been changed:
 
   - `configureOptions` was renamed to `introspectionOptions`

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -133,7 +133,7 @@ async fn update(context: Context<impl Environment>) -> anyhow::Result<()> {
     // It is possible to change the file in the middle of introspection.
     // We want to detect these scenario and try again, or fail if we are unable to.
     // We do that with a few attempts.
-    for _attempt in 1..UPDATE_ATTEMPTS {
+    for _attempt in 1..=UPDATE_ATTEMPTS {
         let configuration_file_path = context
             .context_path
             .join(configuration::CONFIGURATION_FILENAME);
@@ -153,7 +153,7 @@ async fn update(context: Context<impl Environment>) -> anyhow::Result<()> {
 
         // and skip this attempt if it has.
         if input_again_before_write != input {
-            println!("Input file changed before write, trying again.");
+            println!("Input file changed before write.");
         } else {
             // If the introspection result is different than the current config,
             // change it. Otherwise, continue.

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -152,9 +152,7 @@ async fn update(context: Context<impl Environment>) -> anyhow::Result<()> {
         };
 
         // and skip this attempt if it has.
-        if input_again_before_write != input {
-            println!("Input file changed before write.");
-        } else {
+        if input_again_before_write == input {
             // If the introspection result is different than the current config,
             // change it. Otherwise, continue.
             if input != output {
@@ -166,8 +164,9 @@ async fn update(context: Context<impl Environment>) -> anyhow::Result<()> {
             } else {
                 println!("The configuration is up-to-date. Nothing to do.");
             }
-
             return Ok(());
+        } else {
+            println!("Input file changed before write.");
         }
     }
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -166,9 +166,9 @@ async fn update(context: Context<impl Environment>) -> anyhow::Result<()> {
             } else {
                 println!("The configuration is up-to-date. Nothing to do.");
             }
-        }
 
-        return Ok(());
+            return Ok(());
+        }
     }
 
     // We ran out of attempts.

--- a/crates/cli/tests/initialize_tests.rs
+++ b/crates/cli/tests/initialize_tests.rs
@@ -23,6 +23,10 @@ async fn test_initialize_directory() -> anyhow::Result<()> {
 
     let configuration_file_path = dir.path().join("configuration.json");
     assert!(configuration_file_path.exists());
+
+    let configuration_schema_file_path = dir.path().join("schema.json");
+    assert!(configuration_schema_file_path.exists());
+
     let contents = fs::read_to_string(configuration_file_path).await?;
     let _: RawConfiguration = serde_json::from_str(&contents)?;
 
@@ -87,6 +91,9 @@ async fn test_initialize_directory_with_metadata() -> anyhow::Result<()> {
     let configuration_file_path = dir.path().join("configuration.json");
     assert!(configuration_file_path.exists());
 
+    let configuration_schema_file_path = dir.path().join("schema.json");
+    assert!(configuration_schema_file_path.exists());
+
     let metadata_file_path = dir
         .path()
         .join(".hasura-connector")
@@ -117,6 +124,9 @@ async fn test_initialize_directory_with_metadata_and_release_version() -> anyhow
 
     let configuration_file_path = dir.path().join("configuration.json");
     assert!(configuration_file_path.exists());
+
+    let configuration_schema_file_path = dir.path().join("schema.json");
+    assert!(configuration_schema_file_path.exists());
 
     let metadata_file_path = dir
         .path()

--- a/crates/configuration/src/configuration.rs
+++ b/crates/configuration/src/configuration.rs
@@ -17,7 +17,7 @@ pub const CONFIGURATION_FILENAME: &str = "configuration.json";
 pub const CONFIGURATION_JSONSCHEMA_FILENAME: &str = "schema.json";
 
 /// The parsed connector configuration.
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(tag = "version")]
 pub enum RawConfiguration {
     #[serde(rename = "3")]

--- a/crates/configuration/src/values/isolation_level.rs
+++ b/crates/configuration/src/values/isolation_level.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// The isolation level of the transaction in which a query is executed.
-#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default, Deserialize, Serialize, JsonSchema)]
 pub enum IsolationLevel {
     /// Prevents reading data from another uncommitted transaction.
     #[default]

--- a/crates/configuration/src/values/pool_settings.rs
+++ b/crates/configuration/src/values/pool_settings.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Settings for the PostgreSQL connection pool
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PoolSettings {
     /// maximum number of pool connections

--- a/crates/configuration/src/version3/comparison.rs
+++ b/crates/configuration/src/version3/comparison.rs
@@ -5,7 +5,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Define the names that comparison operators will be exposed as by the automatic introspection.
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ComparisonOperatorMapping {
     /// The name of the operator as defined by the database

--- a/crates/configuration/src/version3/connection_settings.rs
+++ b/crates/configuration/src/version3/connection_settings.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 pub const DEFAULT_CONNECTION_URI_VARIABLE: &str = "CONNECTION_URI";
 
 /// Database connection settings.
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseConnectionSettings {
     /// Connection string for a Postgres-compatible database.

--- a/crates/configuration/src/version3/mod.rs
+++ b/crates/configuration/src/version3/mod.rs
@@ -24,7 +24,7 @@ const CONFIGURATION_QUERY: &str = include_str!("version3.sql");
 
 /// Initial configuration, just enough to connect to a database and elaborate a full
 /// 'Configuration'.
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RawConfiguration {
     /// Jsonschema of the configuration format.

--- a/crates/configuration/src/version3/options.rs
+++ b/crates/configuration/src/version3/options.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use super::comparison::ComparisonOperatorMapping;
 
 /// Options which only influence how the configuration is updated.
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct IntrospectionOptions {
     /// Schemas which are excluded from introspection. The default setting will exclude the

--- a/crates/query-engine/metadata/src/metadata/database.rs
+++ b/crates/query-engine/metadata/src/metadata/database.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
 /// Map of all known composite types.
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CompositeTypes(pub BTreeMap<String, CompositeType>);
 
@@ -79,7 +79,7 @@ fn default_true() -> bool {
 }
 
 /// Mapping from a "table" name to its information.
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct TablesInfo(pub BTreeMap<String, TableInfo>);
 

--- a/crates/query-engine/metadata/src/metadata/mod.rs
+++ b/crates/query-engine/metadata/src/metadata/mod.rs
@@ -12,7 +12,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Metadata information.
-#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Metadata {
     #[serde(default)]

--- a/crates/query-engine/metadata/src/metadata/mutations.rs
+++ b/crates/query-engine/metadata/src/metadata/mutations.rs
@@ -4,7 +4,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Which version of the generated mutations will be included in the schema
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum MutationsVersion {
     V1,

--- a/crates/query-engine/metadata/src/metadata/native_queries.rs
+++ b/crates/query-engine/metadata/src/metadata/native_queries.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeMap;
 // Types
 
 /// Metadata information of native queries.
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct NativeQueries(pub BTreeMap<String, NativeQueryInfo>);
 


### PR DESCRIPTION
### What

We want the update command in ndc-postgres-cli to not override changed made after we started introspecting but before we wrote the changes to file, and not to write to the filesystem when the file does not need changing.

### How

1. We loop the update operation 3 times
2. We read the input file after the introspection took place as well
3. If the input from before the introspection and the input from after the introspection are the same we continue, otherwise we try again
4. Before writing to file, we check that if the output is going to be the same as the input, if it is the same, we skip writing, if not, we write.
5. We add the `Eq` trait everywhere so we can compare the config.
