### PR TITLE
removing the prints from the config cli

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Do not print information about when the cli decides not to write to a file.
+  ([#365](https://github.com/hasura/ndc-postgres/pull/365))
+
 ## [v0.5.0] - 2024-03-14
 
 ### Added

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -167,11 +167,11 @@ async fn update(context: Context<impl Environment>) -> anyhow::Result<()> {
                 )
                 .await?;
             } else {
-                println!("The configuration is up-to-date. Nothing to do.");
+                // The configuration is up-to-date. Nothing to do.
             }
             return Ok(());
         } else {
-            println!("Input file changed before write.");
+            // Input file changed before write.
         }
     }
 


### PR DESCRIPTION
### What

The info prints that the config cli is doing something special are printed as part of the cli. We don't like this so we remove them.

https://hasurahq.slack.com/archives/C01RZPEPF0W/p1710504668667279

