### PR TITLE
fix names of fields in schema generation

### DIFF
--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
@@ -2207,7 +2207,7 @@ expression: result
     },
     "artist_below_id": {
       "fields": {
-        "ArtistId": {
+        "id": {
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -2216,7 +2216,7 @@ expression: result
             }
           }
         },
-        "Name": {
+        "name": {
           "type": {
             "type": "nullable",
             "underlying_type": {
@@ -2397,7 +2397,7 @@ expression: result
     },
     "organization": {
       "fields": {
-        "committees": {
+        "members": {
           "type": {
             "type": "array",
             "element_type": {

--- a/crates/tests/tests-common/goldenfiles/native_queries/select_artists_below_id.json
+++ b/crates/tests/tests-common/goldenfiles/native_queries/select_artists_below_id.json
@@ -4,7 +4,7 @@
     "fields": {
       "Name": {
         "type": "column",
-        "column": "Name",
+        "column": "name",
         "arguments": {}
       }
     },
@@ -14,7 +14,7 @@
           "order_direction": "asc",
           "target": {
             "type": "column",
-            "name": "ArtistId",
+            "name": "id",
             "path": []
           }
         }

--- a/static/postgres/v3-chinook-ndc-metadata/configuration.json
+++ b/static/postgres/v3-chinook-ndc-metadata/configuration.json
@@ -1265,7 +1265,7 @@
       "artist_below_id": {
         "sql": "SELECT * FROM public.\"Artist\" WHERE \"ArtistId\" < {{id}}",
         "columns": {
-          "ArtistId": {
+          "id": {
             "name": "ArtistId",
             "type": {
               "scalarType": "int4"
@@ -1273,7 +1273,7 @@
             "nullable": "nullable",
             "description": null
           },
-          "Name": {
+          "name": {
             "name": "Name",
             "type": {
               "scalarType": "varchar"


### PR DESCRIPTION
### What

The `/schema` endpoint was exposing the wrong column names in object types. This PR fixes this.

### How

columns, referenced by tables, native queries, etc. Have a type that looks somewhat like this: `BTreeMap<String, ColumnInfo>`.

`ColumnInfo` looks somewhat like this: `ColumnInfo { name: String, ... }`.

The `String` in the map refers to the external name that ndc-spec queries should reference, while the `ColumnInfo` name refers to the database column name.

By mistake, were reporting the `ColumnInfo` name in the schema, instead of the String from the map.

We fix this by referring to the right name, and use `iter()` on the BTreeMap instead of `values()`.