### PR TITLE
Build the CLI on Ubuntu 20.04.

### DIFF
--- a/.github/workflows/ship.yaml
+++ b/.github/workflows/ship.yaml
@@ -118,9 +118,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: ubuntu-latest
+          - runner: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
-          - runner: ubuntu-latest
+          - runner: ubuntu-20.04
             target: aarch64-unknown-linux-gnu
             linux-packages: gcc-aarch64-linux-gnu
             linker: /usr/bin/aarch64-linux-gnu-gcc
@@ -161,7 +161,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "build" # share the cache across jobs
+          shared-key: "build-${matrix.runner}" # share the cache across jobs
 
       - name: build the CLI
         run: |


### PR DESCRIPTION
### What

Downgrading Ubuntu from "latest" (22.04) to 20.04 means that it will also be supported on that version and all subsequent versions. Currently it fails to start on Ubuntu 20.04 because the version of glibc linked against is too new.

### How

I have downgraded the Ubuntu runner we use for building the CLI from 22.04 to 20.04.

I have also fixed the Rust build cache to take the runner into account.