### PR TITLE
When writing configuration files, always end them in a newline.

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -74,7 +74,7 @@ async fn initialize(with_metadata: bool, context: Context<impl Environment>) -> 
     // create the configuration file
     fs::write(
         configuration_file,
-        serde_json::to_string_pretty(&configuration::RawConfiguration::empty())?,
+        serde_json::to_string_pretty(&configuration::RawConfiguration::empty())? + "\n",
     )
     .await?;
 
@@ -86,7 +86,7 @@ async fn initialize(with_metadata: bool, context: Context<impl Environment>) -> 
     let output = schemars::schema_for!(ndc_postgres_configuration::RawConfiguration);
     fs::write(
         &configuration_jsonschema_file_path,
-        serde_json::to_string_pretty(&output)?,
+        serde_json::to_string_pretty(&output)? + "\n",
     )
     .await?;
 
@@ -163,7 +163,7 @@ async fn update(context: Context<impl Environment>) -> anyhow::Result<()> {
             if input != output {
                 fs::write(
                     &configuration_file_path,
-                    serde_json::to_string_pretty(&output)?,
+                    serde_json::to_string_pretty(&output)? + "\n",
                 )
                 .await?;
             } else {

--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)] // required because this is included mulitple times
-                     //
+
 use std::path::Path;
 
 use tokio::fs;

--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -1,0 +1,15 @@
+#![allow(dead_code)] // required because this is included mulitple times
+                     //
+use std::path::Path;
+
+use tokio::fs;
+
+pub async fn assert_file_ends_with_newline(path: impl AsRef<Path>) -> anyhow::Result<()> {
+    let contents = fs::read_to_string(path).await?;
+    assert_ends_with_newline(&contents).await;
+    Ok(())
+}
+
+pub async fn assert_ends_with_newline(contents: &str) {
+    assert_eq!(contents.chars().last(), Some('\n'));
+}

--- a/crates/cli/tests/initialize_tests.rs
+++ b/crates/cli/tests/initialize_tests.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use tokio::fs;
 
 use ndc_postgres_cli::*;
@@ -21,13 +23,14 @@ async fn test_initialize_directory() -> anyhow::Result<()> {
     )
     .await?;
 
-    let configuration_file_path = dir.path().join("configuration.json");
-    assert!(configuration_file_path.exists());
-
     let configuration_schema_file_path = dir.path().join("schema.json");
     assert!(configuration_schema_file_path.exists());
+    common::assert_file_ends_with_newline(&configuration_schema_file_path).await?;
 
+    let configuration_file_path = dir.path().join("configuration.json");
+    assert!(configuration_file_path.exists());
     let contents = fs::read_to_string(configuration_file_path).await?;
+    common::assert_ends_with_newline(&contents).await;
     let _: RawConfiguration = serde_json::from_str(&contents)?;
 
     let metadata_file_path = dir
@@ -88,11 +91,13 @@ async fn test_initialize_directory_with_metadata() -> anyhow::Result<()> {
     )
     .await?;
 
-    let configuration_file_path = dir.path().join("configuration.json");
-    assert!(configuration_file_path.exists());
-
     let configuration_schema_file_path = dir.path().join("schema.json");
     assert!(configuration_schema_file_path.exists());
+    common::assert_file_ends_with_newline(&configuration_schema_file_path).await?;
+
+    let configuration_file_path = dir.path().join("configuration.json");
+    assert!(configuration_file_path.exists());
+    common::assert_file_ends_with_newline(&configuration_file_path).await?;
 
     let metadata_file_path = dir
         .path()
@@ -100,6 +105,7 @@ async fn test_initialize_directory_with_metadata() -> anyhow::Result<()> {
         .join("connector-metadata.yaml");
     assert!(metadata_file_path.exists());
     let contents = fs::read_to_string(metadata_file_path).await?;
+    common::assert_ends_with_newline(&contents).await;
     insta::assert_snapshot!(contents);
 
     Ok(())
@@ -122,11 +128,13 @@ async fn test_initialize_directory_with_metadata_and_release_version() -> anyhow
     )
     .await?;
 
-    let configuration_file_path = dir.path().join("configuration.json");
-    assert!(configuration_file_path.exists());
-
     let configuration_schema_file_path = dir.path().join("schema.json");
     assert!(configuration_schema_file_path.exists());
+    common::assert_file_ends_with_newline(&configuration_schema_file_path).await?;
+
+    let configuration_file_path = dir.path().join("configuration.json");
+    assert!(configuration_file_path.exists());
+    common::assert_file_ends_with_newline(&configuration_file_path).await?;
 
     let metadata_file_path = dir
         .path()
@@ -134,6 +142,7 @@ async fn test_initialize_directory_with_metadata_and_release_version() -> anyhow
         .join("connector-metadata.yaml");
     assert!(metadata_file_path.exists());
     let contents = fs::read_to_string(metadata_file_path).await?;
+    common::assert_ends_with_newline(&contents).await;
     insta::assert_snapshot!(contents);
 
     Ok(())

--- a/crates/cli/tests/update_tests.rs
+++ b/crates/cli/tests/update_tests.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use tokio::fs;
 
 use ndc_postgres_cli::*;
@@ -41,6 +43,7 @@ async fn test_update_configuration() -> anyhow::Result<()> {
     let configuration_file_path = dir.path().join("configuration.json");
     assert!(configuration_file_path.exists());
     let contents = fs::read_to_string(configuration_file_path).await?;
+    common::assert_ends_with_newline(&contents).await;
     let output: RawConfiguration = serde_json::from_str(&contents)?;
     match output {
         RawConfiguration::Version3(configuration::version3::RawConfiguration {


### PR DESCRIPTION
### What

This is a personal pet peeve, mostly brought on by Git highlighting this in diffs.

### How

I have scattered `+ "\n"` throughout the code, and added some test assertions to match.