### PR TITLE
CI: Update the Docker Compose action owner.

### DIFF
--- a/.github/workflows/cargo-test.yaml
+++ b/.github/workflows/cargo-test.yaml
@@ -77,7 +77,7 @@ jobs:
           echo "configuration=$(jq -c --arg package '${{ matrix.package }}' '.[$package]' .github/test-configuration.json)" >> "$GITHUB_OUTPUT"
 
       - name: start dependencies
-        uses: isbang/compose-action@v1.5.1
+        uses: hoverkraft-tech/compose-action@v1.5.1
         with:
           compose-file: "./docker-compose.yaml"
           down-flags: "--volumes"
@@ -186,7 +186,7 @@ jobs:
           save-if: false
 
       - name: start dependencies
-        uses: isbang/compose-action@v1.5.1
+        uses: hoverkraft-tech/compose-action@v1.5.1
         with:
           compose-file: "./docker-compose.yaml"
           down-flags: "--volumes"


### PR DESCRIPTION
The Docker Compose action we rely on has changed ownership and GitHub Actions doesn't seem to want to automatically resolve the redirect.

We need to update this ourselves to fix our builds.