### PR TITLE
Support enum types

### DIFF
--- a/crates/configuration/src/version3/version3.sql
+++ b/crates/configuration/src/version3/version3.sql
@@ -672,6 +672,9 @@ WITH
     ORDER BY op.oprname
   ),
 
+  -- Enum types are totally ordered and support the conventional comparison operators.
+  -- They are defined implicitly (i.e., not registered in `pg_proc` or
+  -- `pg_operator`) so we have to make up some definitions for them.
   enum_comparison_operators AS
   (
     SELECT

--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__schema_tests__schema_test__get_schema.snap
@@ -198,6 +198,65 @@ expression: result
         }
       }
     },
+    "card_suit": {
+      "aggregate_functions": {
+        "max": {
+          "result_type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        },
+        "min": {
+          "result_type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        }
+      },
+      "comparison_operators": {
+        "_eq": {
+          "type": "equal"
+        },
+        "_gt": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        },
+        "_gte": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        },
+        "_in": {
+          "type": "in"
+        },
+        "_lt": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        },
+        "_lte": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        },
+        "_neq": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        }
+      }
+    },
     "char": {
       "aggregate_functions": {
         "max": {
@@ -2539,6 +2598,22 @@ expression: result
         }
       }
     },
+    "deck_of_cards": {
+      "fields": {
+        "pips": {
+          "type": {
+            "type": "named",
+            "name": "int2"
+          }
+        },
+        "suit": {
+          "type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        }
+      }
+    },
     "delete_playlist_track": {
       "fields": {
         "PlaylistId": {
@@ -3711,6 +3786,44 @@ expression: result
         }
       }
     },
+    "v1_insert_deck_of_cards_object": {
+      "fields": {
+        "pips": {
+          "type": {
+            "type": "named",
+            "name": "int2"
+          }
+        },
+        "suit": {
+          "type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        }
+      }
+    },
+    "v1_insert_deck_of_cards_response": {
+      "description": "Responses from the 'v1_insert_deck_of_cards' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "deck_of_cards"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_even_numbers_object": {
       "fields": {
         "the_number": {
@@ -4112,6 +4225,13 @@ expression: result
           "foreign_collection": "MediaType"
         }
       }
+    },
+    {
+      "name": "deck_of_cards",
+      "arguments": {},
+      "type": "deck_of_cards",
+      "uniqueness_constraints": {},
+      "foreign_keys": {}
     },
     {
       "name": "even_numbers",
@@ -4876,6 +4996,22 @@ expression: result
       "result_type": {
         "type": "named",
         "name": "v1_insert_Track_response"
+      }
+    },
+    {
+      "name": "v1_insert_deck_of_cards",
+      "description": "Insert into the deck_of_cards table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_deck_of_cards_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "v1_insert_deck_of_cards_response"
       }
     },
     {

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__schema_tests__schema_test__get_schema.snap
@@ -69,6 +69,65 @@ expression: result
         }
       }
     },
+    "card_suit": {
+      "aggregate_functions": {
+        "max": {
+          "result_type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        },
+        "min": {
+          "result_type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        }
+      },
+      "comparison_operators": {
+        "_eq": {
+          "type": "equal"
+        },
+        "_gt": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        },
+        "_gte": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        },
+        "_in": {
+          "type": "in"
+        },
+        "_lt": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        },
+        "_lte": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        },
+        "_neq": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        }
+      }
+    },
     "char": {
       "aggregate_functions": {
         "concat_agg": {
@@ -2238,6 +2297,28 @@ expression: result
         }
       }
     },
+    "deck_of_cards": {
+      "fields": {
+        "pips": {
+          "type": {
+            "type": "named",
+            "name": "int2"
+          }
+        },
+        "rowid": {
+          "type": {
+            "type": "named",
+            "name": "int8"
+          }
+        },
+        "suit": {
+          "type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        }
+      }
+    },
     "delete_playlist_track": {
       "fields": {
         "PlaylistId": {
@@ -2610,6 +2691,28 @@ expression: result
             "element_type": {
               "type": "named",
               "name": "Track"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_deck_of_cards_by_rowid_response": {
+      "description": "Responses from the 'v1_delete_deck_of_cards_by_rowid' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "deck_of_cards"
             }
           }
         }
@@ -3387,6 +3490,50 @@ expression: result
         }
       }
     },
+    "v1_insert_deck_of_cards_object": {
+      "fields": {
+        "pips": {
+          "type": {
+            "type": "named",
+            "name": "int2"
+          }
+        },
+        "rowid": {
+          "type": {
+            "type": "named",
+            "name": "int8"
+          }
+        },
+        "suit": {
+          "type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        }
+      }
+    },
+    "v1_insert_deck_of_cards_response": {
+      "description": "Responses from the 'v1_insert_deck_of_cards' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "deck_of_cards"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_pg_extension_spatial_ref_sys_object": {
       "fields": {
         "auth_name": {
@@ -3827,6 +3974,19 @@ expression: result
           "foreign_collection": "MediaType"
         }
       }
+    },
+    {
+      "name": "deck_of_cards",
+      "arguments": {},
+      "type": "deck_of_cards",
+      "uniqueness_constraints": {
+        "deck_of_cards_pkey": {
+          "unique_columns": [
+            "rowid"
+          ]
+        }
+      },
+      "foreign_keys": {}
     },
     {
       "name": "pg_extension_spatial_ref_sys",
@@ -4371,6 +4531,22 @@ expression: result
       }
     },
     {
+      "name": "v1_delete_deck_of_cards_by_rowid",
+      "description": "Delete any value on the deck_of_cards table using the rowid key",
+      "arguments": {
+        "rowid": {
+          "type": {
+            "type": "named",
+            "name": "int8"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "v1_delete_deck_of_cards_by_rowid_response"
+      }
+    },
+    {
       "name": "v1_insert_Album",
       "description": "Insert into the Album table",
       "arguments": {
@@ -4544,6 +4720,22 @@ expression: result
       "result_type": {
         "type": "named",
         "name": "v1_insert_Track_response"
+      }
+    },
+    {
+      "name": "v1_insert_deck_of_cards",
+      "description": "Insert into the deck_of_cards table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_deck_of_cards_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "v1_insert_deck_of_cards_response"
       }
     },
     {

--- a/crates/tests/databases-tests/src/postgres/mutation_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/mutation_tests.rs
@@ -87,6 +87,26 @@ mod basic {
 
         insta::assert_json_snapshot!(result)
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn v1_insert_enum() {
+        let ndc_metadata =
+            FreshDeployment::create(common::CONNECTION_URI, common::CHINOOK_NDC_METADATA_PATH)
+                .await
+                .unwrap();
+
+        let router = tests_common::router::create_router(
+            &ndc_metadata.ndc_metadata_path,
+            &ndc_metadata.connection_uri,
+        )
+        .await;
+
+        let mutation_result = run_mutation(router.clone(), "v1_insert_enum").await;
+
+        let result = mutation_result;
+
+        insta::assert_json_snapshot!(result)
+    }
 }
 
 #[cfg(test)]
@@ -149,5 +169,30 @@ mod negative {
         let result = mutation_result;
 
         insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn v1_insert_enum_invalid_label() {
+        let ndc_metadata =
+            FreshDeployment::create(common::CONNECTION_URI, common::CHINOOK_NDC_METADATA_PATH)
+                .await
+                .unwrap();
+
+        let router = tests_common::router::create_router(
+            &ndc_metadata.ndc_metadata_path,
+            &ndc_metadata.connection_uri,
+        )
+        .await;
+
+        let mutation_result = run_mutation_fail(
+            router.clone(),
+            "v1_insert_enum_invalid_label",
+            StatusCode::UNPROCESSABLE_ENTITY,
+        )
+        .await;
+
+        let result = mutation_result;
+
+        insta::assert_json_snapshot!(result)
     }
 }

--- a/crates/tests/databases-tests/src/postgres/query_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/query_tests.rs
@@ -16,6 +16,12 @@ mod basic {
     }
 
     #[tokio::test]
+    async fn select_enum() {
+        let result = run_query(create_router().await, "select_enum").await;
+        insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test]
     async fn select_5() {
         let result = run_query(create_router().await, "select_5").await;
         insta::assert_json_snapshot!(result);
@@ -394,6 +400,12 @@ mod aggregation {
             "aggregate_count_artist_albums_plus_field",
         )
         .await;
+        insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test]
+    async fn aggregate_max_enum() {
+        let result = run_query(create_router().await, "aggregate_max_enum").await;
         insta::assert_json_snapshot!(result);
     }
 }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__postgres_current_only_configure_v3_initial_configuration_is_unchanged.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__postgres_current_only_configure_v3_initial_configuration_is_unchanged.snap
@@ -823,6 +823,31 @@ expression: default_configuration
         "foreignRelations": {},
         "description": null
       },
+      "deck_of_cards": {
+        "schemaName": "public",
+        "tableName": "deck_of_cards",
+        "columns": {
+          "pips": {
+            "name": "pips",
+            "type": {
+              "scalarType": "int2"
+            },
+            "nullable": "nonNullable",
+            "description": null
+          },
+          "suit": {
+            "name": "suit",
+            "type": {
+              "scalarType": "card_suit"
+            },
+            "nullable": "nonNullable",
+            "description": null
+          }
+        },
+        "uniquenessConstraints": {},
+        "foreignRelations": {},
+        "description": null
+      },
       "even_numbers": {
         "schemaName": "public",
         "tableName": "even_numbers",
@@ -1058,6 +1083,14 @@ expression: default_configuration
           "returnType": "bool"
         }
       },
+      "card_suit": {
+        "max": {
+          "returnType": "card_suit"
+        },
+        "min": {
+          "returnType": "card_suit"
+        }
+      },
       "date": {
         "max": {
           "returnType": "date"
@@ -1137,6 +1170,47 @@ expression: default_configuration
         },
         "variance": {
           "returnType": "float8"
+        }
+      },
+      "int2": {
+        "avg": {
+          "returnType": "numeric"
+        },
+        "bit_and": {
+          "returnType": "int2"
+        },
+        "bit_or": {
+          "returnType": "int2"
+        },
+        "bit_xor": {
+          "returnType": "int2"
+        },
+        "max": {
+          "returnType": "int2"
+        },
+        "min": {
+          "returnType": "int2"
+        },
+        "stddev": {
+          "returnType": "numeric"
+        },
+        "stddev_pop": {
+          "returnType": "numeric"
+        },
+        "stddev_samp": {
+          "returnType": "numeric"
+        },
+        "sum": {
+          "returnType": "int8"
+        },
+        "var_pop": {
+          "returnType": "numeric"
+        },
+        "var_samp": {
+          "returnType": "numeric"
+        },
+        "variance": {
+          "returnType": "numeric"
         }
       },
       "int4": {
@@ -1323,6 +1397,50 @@ expression: default_configuration
           "isInfix": true
         }
       },
+      "card_suit": {
+        "_eq": {
+          "operatorName": "=",
+          "operatorKind": "equal",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_gt": {
+          "operatorName": ">",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_gte": {
+          "operatorName": ">=",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_in": {
+          "operatorName": "IN",
+          "operatorKind": "in",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_lt": {
+          "operatorName": "<",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_lte": {
+          "operatorName": "<=",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_neq": {
+          "operatorName": "<>",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
+        }
+      },
       "date": {
         "_eq": {
           "operatorName": "=",
@@ -1452,6 +1570,50 @@ expression: default_configuration
           "operatorName": "<>",
           "operatorKind": "custom",
           "argumentType": "float8",
+          "isInfix": true
+        }
+      },
+      "int2": {
+        "_eq": {
+          "operatorName": "=",
+          "operatorKind": "equal",
+          "argumentType": "int2",
+          "isInfix": true
+        },
+        "_gt": {
+          "operatorName": ">",
+          "operatorKind": "custom",
+          "argumentType": "int2",
+          "isInfix": true
+        },
+        "_gte": {
+          "operatorName": ">=",
+          "operatorKind": "custom",
+          "argumentType": "int2",
+          "isInfix": true
+        },
+        "_in": {
+          "operatorName": "IN",
+          "operatorKind": "in",
+          "argumentType": "int2",
+          "isInfix": true
+        },
+        "_lt": {
+          "operatorName": "<",
+          "operatorKind": "custom",
+          "argumentType": "int2",
+          "isInfix": true
+        },
+        "_lte": {
+          "operatorName": "<=",
+          "operatorKind": "custom",
+          "argumentType": "int2",
+          "isInfix": true
+        },
+        "_neq": {
+          "operatorName": "<>",
+          "operatorKind": "custom",
+          "argumentType": "int2",
           "isInfix": true
         }
       },

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__v1_insert_enum.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__v1_insert_enum.snap
@@ -1,0 +1,20 @@
+---
+source: crates/tests/databases-tests/src/postgres/mutation_tests.rs
+expression: result
+---
+{
+  "operation_results": [
+    {
+      "type": "procedure",
+      "result": {
+        "returning": [
+          {
+            "pips": 14,
+            "suit": "hearts"
+          }
+        ],
+        "affected_rows": 1
+      }
+    }
+  ]
+}

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__negative__v1_insert_enum_invalid_label.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__negative__v1_insert_enum_invalid_label.snap
@@ -1,0 +1,10 @@
+---
+source: crates/tests/databases-tests/src/postgres/mutation_tests.rs
+expression: result
+---
+{
+  "message": "Unprocessable content",
+  "details": {
+    "detail": "error returned from database: invalid input value for enum card_suit: \"horses\""
+  }
+}

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__aggregation__aggregate_max_enum.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__aggregation__aggregate_max_enum.snap
@@ -1,0 +1,11 @@
+---
+source: crates/tests/databases-tests/src/postgres/query_tests.rs
+expression: result
+---
+[
+  {
+    "aggregates": {
+      "max_suit": "spades"
+    }
+  }
+]

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__basic__select_enum.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__basic__select_enum.snap
@@ -1,0 +1,26 @@
+---
+source: crates/tests/databases-tests/src/postgres/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": [
+      {
+        "Pips": 13,
+        "Suit": "hearts"
+      },
+      {
+        "Pips": 13,
+        "Suit": "clubs"
+      },
+      {
+        "Pips": 13,
+        "Suit": "diamonds"
+      },
+      {
+        "Pips": 13,
+        "Suit": "spades"
+      }
+    ]
+  }
+]

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
@@ -226,6 +226,65 @@ expression: result
         }
       }
     },
+    "card_suit": {
+      "aggregate_functions": {
+        "max": {
+          "result_type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        },
+        "min": {
+          "result_type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        }
+      },
+      "comparison_operators": {
+        "_eq": {
+          "type": "equal"
+        },
+        "_gt": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        },
+        "_gte": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        },
+        "_in": {
+          "type": "in"
+        },
+        "_lt": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        },
+        "_lte": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        },
+        "_neq": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        }
+      }
+    },
     "char": {
       "aggregate_functions": {
         "max": {
@@ -2697,6 +2756,22 @@ expression: result
         }
       }
     },
+    "deck_of_cards": {
+      "fields": {
+        "pips": {
+          "type": {
+            "type": "named",
+            "name": "int2"
+          }
+        },
+        "suit": {
+          "type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        }
+      }
+    },
     "delete_playlist_track": {
       "fields": {
         "PlaylistId": {
@@ -4145,6 +4220,44 @@ expression: result
         }
       }
     },
+    "v1_insert_deck_of_cards_object": {
+      "fields": {
+        "pips": {
+          "type": {
+            "type": "named",
+            "name": "int2"
+          }
+        },
+        "suit": {
+          "type": {
+            "type": "named",
+            "name": "card_suit"
+          }
+        }
+      }
+    },
+    "v1_insert_deck_of_cards_response": {
+      "description": "Responses from the 'v1_insert_deck_of_cards' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "deck_of_cards"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_even_numbers_object": {
       "fields": {
         "the_number": {
@@ -4759,6 +4872,13 @@ expression: result
           ]
         }
       },
+      "foreign_keys": {}
+    },
+    {
+      "name": "deck_of_cards",
+      "arguments": {},
+      "type": "deck_of_cards",
+      "uniqueness_constraints": {},
       "foreign_keys": {}
     },
     {
@@ -5663,6 +5783,22 @@ expression: result
       "result_type": {
         "type": "named",
         "name": "v1_insert_custom_dog_response"
+      }
+    },
+    {
+      "name": "v1_insert_deck_of_cards",
+      "description": "Insert into the deck_of_cards table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_deck_of_cards_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "v1_insert_deck_of_cards_response"
       }
     },
     {

--- a/crates/tests/tests-common/goldenfiles/aggregate_max_enum.json
+++ b/crates/tests/tests-common/goldenfiles/aggregate_max_enum.json
@@ -1,0 +1,14 @@
+{
+  "collection": "deck_of_cards",
+  "query": {
+    "aggregates": {
+      "max_suit": {
+        "type": "single_column",
+        "column": "suit",
+        "function": "max"
+      }
+    }
+  },
+  "arguments": {},
+  "collection_relationships": {}
+}

--- a/crates/tests/tests-common/goldenfiles/mutations/v1_insert_enum.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/v1_insert_enum.json
@@ -1,0 +1,45 @@
+{
+  "operations": [
+    {
+      "type": "procedure",
+      "name": "v1_insert_deck_of_cards",
+      "arguments": {
+        "_object": {
+          "pips": 14,
+          "suit": "hearts"
+        }
+      },
+      "fields": {
+        "type": "object",
+        "fields": {
+          "affected_rows": {
+            "column": "affected_rows",
+            "type": "column"
+          },
+
+          "returning": {
+            "type": "column",
+            "column": "returning",
+            "fields": {
+              "type": "array",
+              "fields": {
+                "type": "object",
+                "fields": {
+                  "pips": {
+                    "type": "column",
+                    "column": "pips"
+                  },
+                  "suit": {
+                    "type": "column",
+                    "column": "suit"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "collection_relationships": {}
+}

--- a/crates/tests/tests-common/goldenfiles/mutations/v1_insert_enum_invalid_label.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/v1_insert_enum_invalid_label.json
@@ -1,0 +1,45 @@
+{
+  "operations": [
+    {
+      "type": "procedure",
+      "name": "v1_insert_deck_of_cards",
+      "arguments": {
+        "_object": {
+          "pips": 1,
+          "suit": "horses"
+        }
+      },
+      "fields": {
+        "type": "object",
+        "fields": {
+          "affected_rows": {
+            "column": "affected_rows",
+            "type": "column"
+          },
+
+          "returning": {
+            "type": "column",
+            "column": "returning",
+            "fields": {
+              "type": "array",
+              "fields": {
+                "type": "object",
+                "fields": {
+                  "pips": {
+                    "type": "column",
+                    "column": "pips"
+                  },
+                  "suit": {
+                    "type": "column",
+                    "column": "suit"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "collection_relationships": {}
+}

--- a/crates/tests/tests-common/goldenfiles/select_enum.json
+++ b/crates/tests/tests-common/goldenfiles/select_enum.json
@@ -1,0 +1,32 @@
+{
+  "collection": "deck_of_cards",
+  "query": {
+    "fields": {
+      "Pips": {
+        "type": "column",
+        "column": "pips",
+        "arguments": {}
+      },
+      "Suit": {
+        "type": "column",
+        "column": "suit",
+        "arguments": {}
+      }
+    },
+    "predicate": {
+      "type": "binary_comparison_operator",
+      "column": {
+        "type": "column",
+        "name": "pips",
+        "path": []
+      },
+      "operator": "_eq",
+      "value": {
+        "type": "scalar",
+        "value": 13
+      }
+    }
+  },
+  "arguments": {},
+  "collection_relationships": {}
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,12 +35,18 @@ services:
         target: /docker-entrypoint-initdb.d/05-custom-tables.sql
         read_only: true
       - type: bind
-        source: ./static/copy-chinook.sql
-        target: /docker-entrypoint-initdb.d/06-copy-chinook.sql
+        source: ./static/domain-types.sql
+        target: /docker-entrypoint-initdb.d/06-domain-types.sql
         read_only: true
       - type: bind
-        source: ./static/domain-types.sql
-        target: /docker-entrypoint-initdb.d/07-domain-types.sql
+        source: ./static/enum-types.sql
+        target: /docker-entrypoint-initdb.d/07-enum-types.sql
+        read_only: true
+      # The script to copy the database template for mutations tests should
+      # come in last in order to capture all aspects.
+      - type: bind
+        source: ./static/copy-chinook.sql
+        target: /docker-entrypoint-initdb.d/08-copy-chinook.sql
         read_only: true
     healthcheck:
       test:
@@ -72,6 +78,10 @@ services:
       - type: bind
         source: ./static/composite-types-simple.sql
         target: /docker-entrypoint-initdb.d/01-composite-simple.sql
+        read_only: true
+      - type: bind
+        source: ./static/enum-types.sql
+        target: /docker-entrypoint-initdb.d/02-enum-types.sql
         read_only: true
     healthcheck:
       test:
@@ -112,6 +122,10 @@ services:
         source: ./static/domain-types.sql
         target: /docker-entrypoint-initdb.d/03-domain-types.sql
         read_only: true
+      - type: bind
+        source: ./static/enum-types.sql
+        target: /docker-entrypoint-initdb.d/04-enum-types.sql
+        read_only: true
     healthcheck:
       test:
         - CMD-SHELL
@@ -147,6 +161,10 @@ services:
       - type: bind
         source: ./static/domain-types.sql
         target: /home/yugabyte/04-domain-types.sql
+        read_only: true
+      - type: bind
+        source: ./static/enum-types.sql
+        target: /home/yugabyte/05-enum-types.sql
         read_only: true
       - type: bind
         source: ./static/yugabyte/start.sh

--- a/static/citus/v3-chinook-ndc-metadata/configuration.json
+++ b/static/citus/v3-chinook-ndc-metadata/configuration.json
@@ -732,6 +732,31 @@
         },
         "description": null
       },
+      "deck_of_cards": {
+        "schemaName": "public",
+        "tableName": "deck_of_cards",
+        "columns": {
+          "pips": {
+            "name": "pips",
+            "type": {
+              "scalarType": "int2"
+            },
+            "nullable": "nonNullable",
+            "description": null
+          },
+          "suit": {
+            "name": "suit",
+            "type": {
+              "scalarType": "card_suit"
+            },
+            "nullable": "nonNullable",
+            "description": null
+          }
+        },
+        "uniquenessConstraints": {},
+        "foreignRelations": {},
+        "description": null
+      },
       "even_numbers": {
         "schemaName": "public",
         "tableName": "even_numbers",
@@ -1580,6 +1605,14 @@
           "returnType": "bpchar"
         }
       },
+      "card_suit": {
+        "max": {
+          "returnType": "card_suit"
+        },
+        "min": {
+          "returnType": "card_suit"
+        }
+      },
       "char": {
         "max": {
           "returnType": "text"
@@ -2072,6 +2105,50 @@
           "operatorKind": "custom",
           "argumentType": "bpchar",
           "isInfix": false
+        }
+      },
+      "card_suit": {
+        "_eq": {
+          "operatorName": "=",
+          "operatorKind": "equal",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_gt": {
+          "operatorName": ">",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_gte": {
+          "operatorName": ">=",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_in": {
+          "operatorName": "IN",
+          "operatorKind": "in",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_lt": {
+          "operatorName": "<",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_lte": {
+          "operatorName": "<=",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_neq": {
+          "operatorName": "<>",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
         }
       },
       "char": {

--- a/static/cockroach/v3-chinook-ndc-metadata/configuration.json
+++ b/static/cockroach/v3-chinook-ndc-metadata/configuration.json
@@ -732,6 +732,42 @@
         },
         "description": null
       },
+      "deck_of_cards": {
+        "schemaName": "public",
+        "tableName": "deck_of_cards",
+        "columns": {
+          "pips": {
+            "name": "pips",
+            "type": {
+              "scalarType": "int2"
+            },
+            "nullable": "nonNullable",
+            "description": null
+          },
+          "rowid": {
+            "name": "rowid",
+            "type": {
+              "scalarType": "int8"
+            },
+            "nullable": "nonNullable",
+            "hasDefault": "hasDefault",
+            "description": null
+          },
+          "suit": {
+            "name": "suit",
+            "type": {
+              "scalarType": "card_suit"
+            },
+            "nullable": "nonNullable",
+            "description": null
+          }
+        },
+        "uniquenessConstraints": {
+          "deck_of_cards_pkey": ["rowid"]
+        },
+        "foreignRelations": {},
+        "description": null
+      },
       "pg_extension_spatial_ref_sys": {
         "schemaName": "pg_extension",
         "tableName": "spatial_ref_sys",
@@ -1478,6 +1514,14 @@
           "returnType": "bool"
         }
       },
+      "card_suit": {
+        "max": {
+          "returnType": "card_suit"
+        },
+        "min": {
+          "returnType": "card_suit"
+        }
+      },
       "char": {
         "concat_agg": {
           "returnType": "text"
@@ -1762,6 +1806,50 @@
           "operatorName": "!=",
           "operatorKind": "custom",
           "argumentType": "bool",
+          "isInfix": true
+        }
+      },
+      "card_suit": {
+        "_eq": {
+          "operatorName": "=",
+          "operatorKind": "equal",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_gt": {
+          "operatorName": ">",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_gte": {
+          "operatorName": ">=",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_in": {
+          "operatorName": "IN",
+          "operatorKind": "in",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_lt": {
+          "operatorName": "<",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_lte": {
+          "operatorName": "<=",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_neq": {
+          "operatorName": "<>",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
           "isInfix": true
         }
       },

--- a/static/enum-types.sql
+++ b/static/enum-types.sql
@@ -1,0 +1,13 @@
+-- This file is used to test the support of enum types
+
+CREATE TYPE card_suit AS ENUM ('hearts', 'clubs', 'diamonds', 'spades');
+
+CREATE TABLE deck_of_cards (pips int2 not null, suit card_suit not null);
+
+INSERT INTO deck_of_cards
+  SELECT
+    pips,
+    suit
+  FROM
+    generate_series(1, 13) AS pips(pips),
+    unnest(enum_range(null::card_suit)) AS suits(suit);

--- a/static/postgres/v3-chinook-ndc-metadata/configuration.json
+++ b/static/postgres/v3-chinook-ndc-metadata/configuration.json
@@ -795,6 +795,31 @@
         "foreignRelations": {},
         "description": null
       },
+      "deck_of_cards": {
+        "schemaName": "public",
+        "tableName": "deck_of_cards",
+        "columns": {
+          "pips": {
+            "name": "pips",
+            "type": {
+              "scalarType": "int2"
+            },
+            "nullable": "nonNullable",
+            "description": null
+          },
+          "suit": {
+            "name": "suit",
+            "type": {
+              "scalarType": "card_suit"
+            },
+            "nullable": "nonNullable",
+            "description": null
+          }
+        },
+        "uniquenessConstraints": {},
+        "foreignRelations": {},
+        "description": null
+      },
       "even_numbers": {
         "schemaName": "public",
         "tableName": "even_numbers",
@@ -1837,6 +1862,14 @@
           "returnType": "bpchar"
         }
       },
+      "card_suit": {
+        "max": {
+          "returnType": "card_suit"
+        },
+        "min": {
+          "returnType": "card_suit"
+        }
+      },
       "char": {
         "max": {
           "returnType": "text"
@@ -2353,6 +2386,50 @@
           "operatorKind": "custom",
           "argumentType": "bpchar",
           "isInfix": false
+        }
+      },
+      "card_suit": {
+        "_eq": {
+          "operatorName": "=",
+          "operatorKind": "equal",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_gt": {
+          "operatorName": ">",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_gte": {
+          "operatorName": ">=",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_in": {
+          "operatorName": "IN",
+          "operatorKind": "in",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_lt": {
+          "operatorName": "<",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_lte": {
+          "operatorName": "<=",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_neq": {
+          "operatorName": "<>",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
         }
       },
       "char": {

--- a/static/yugabyte/v3-chinook-ndc-metadata/configuration.json
+++ b/static/yugabyte/v3-chinook-ndc-metadata/configuration.json
@@ -732,6 +732,31 @@
         },
         "description": null
       },
+      "deck_of_cards": {
+        "schemaName": "public",
+        "tableName": "deck_of_cards",
+        "columns": {
+          "pips": {
+            "name": "pips",
+            "type": {
+              "scalarType": "int2"
+            },
+            "nullable": "nonNullable",
+            "description": null
+          },
+          "suit": {
+            "name": "suit",
+            "type": {
+              "scalarType": "card_suit"
+            },
+            "nullable": "nonNullable",
+            "description": null
+          }
+        },
+        "uniquenessConstraints": {},
+        "foreignRelations": {},
+        "description": null
+      },
       "even_numbers": {
         "schemaName": "public",
         "tableName": "even_numbers",
@@ -1554,6 +1579,14 @@
           "returnType": "bpchar"
         }
       },
+      "card_suit": {
+        "max": {
+          "returnType": "card_suit"
+        },
+        "min": {
+          "returnType": "card_suit"
+        }
+      },
       "char": {
         "max": {
           "returnType": "text"
@@ -2034,6 +2067,50 @@
           "operatorKind": "custom",
           "argumentType": "bpchar",
           "isInfix": false
+        }
+      },
+      "card_suit": {
+        "_eq": {
+          "operatorName": "=",
+          "operatorKind": "equal",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_gt": {
+          "operatorName": ">",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_gte": {
+          "operatorName": ">=",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_in": {
+          "operatorName": "IN",
+          "operatorKind": "in",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_lt": {
+          "operatorName": "<",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_lte": {
+          "operatorName": "<=",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
+        },
+        "_neq": {
+          "operatorName": "<>",
+          "operatorKind": "custom",
+          "argumentType": "card_suit",
+          "isInfix": true
         }
       },
       "char": {


### PR DESCRIPTION
### What

This PR improves introspection support for enum types.

Comparison operators and aggregation functions on enum types are implicitly defined in PostgreSQL and thus were not detected prior to this PR.

### How

We simply collect which enum types are defined and make up the conventional comparison operators and the min/max aggregation functions for all enum types.

We test that we can select and aggregate enum types, and that we can insert enum values which PostgreSQL validates.

We also collect the enum value labels, which we will be using once ndc-spec v0.1.1 is released.