### PR TITLE
Support introspecting composite types

### DIFF
--- a/crates/configuration/src/version3/mod.rs
+++ b/crates/configuration/src/version3/mod.rs
@@ -162,14 +162,14 @@ pub async fn introspect(
 
     // We filter our comparison operators and aggregate functions to only include those relevant to
     // types that may actually occur in the schema.
-    //
-    // We don't (yet) filter composite types since that would require iterating over the set of
-    // relevant types until reaching a fix point. (The same would strictly be true for aggregation
-    // functions, if we supported composing them)
     let relevant_comparison_operators =
         filter_comparison_operators(&scalar_types, comparison_operators);
     let relevant_aggregate_functions =
         filter_aggregate_functions(&scalar_types, aggregate_functions);
+    let relevant_composite_types = transitively_occurring_composite_types(
+        occurring_composite_types(&tables, &args.metadata.native_queries),
+        composite_types,
+    );
 
     Ok(RawConfiguration {
         schema: args.schema,
@@ -179,14 +179,91 @@ pub async fn introspect(
             native_queries: args.metadata.native_queries,
             aggregate_functions: relevant_aggregate_functions,
             comparison_operators: relevant_comparison_operators,
-            composite_types,
+            composite_types: relevant_composite_types,
         },
         introspection_options: args.introspection_options,
         mutations_version: args.mutations_version,
     })
 }
 
-/// Collect all the types that can occur in the metadata. This is a bit circumstantial. A better
+/// Collect all the composite types that can occur in the metadata.
+pub fn occurring_composite_types(
+    tables: &metadata::TablesInfo,
+    native_queries: &metadata::NativeQueries,
+) -> BTreeSet<String> {
+    let tables_column_types = tables
+        .0
+        .values()
+        .flat_map(|v| v.columns.values().map(|c| &c.r#type));
+    let native_queries_column_types = native_queries
+        .0
+        .values()
+        .flat_map(|v| v.columns.values().map(|c| &c.r#type));
+    let native_queries_arguments_types = native_queries
+        .0
+        .values()
+        .flat_map(|v| v.arguments.values().map(|c| &c.r#type));
+
+    tables_column_types
+        .chain(native_queries_column_types)
+        .chain(native_queries_arguments_types)
+        .filter_map(|t| match t {
+            metadata::Type::CompositeType(ref t) => Some(t.clone()),
+            metadata::Type::ArrayType(t) => match **t {
+                metadata::Type::CompositeType(ref t) => Some(t.clone()),
+                metadata::Type::ArrayType(_) | metadata::Type::ScalarType(_) => None,
+            },
+            metadata::Type::ScalarType(_) => None,
+        })
+        .collect::<BTreeSet<String>>()
+}
+
+pub fn transitively_occurring_composite_types(
+    occurring_type_names: BTreeSet<String>,
+    mut composite_types: metadata::CompositeTypes,
+) -> metadata::CompositeTypes {
+    let mut discovered_type_names = occurring_type_names.clone();
+
+    for t in &occurring_type_names {
+        match composite_types.0.get(t) {
+            None => (),
+            Some(ct) => {
+                for f in ct.fields.values() {
+                    match &f.r#type {
+                        metadata::Type::CompositeType(ct2) => {
+                            discovered_type_names.insert(ct2.to_string());
+                            ()
+                        }
+                        metadata::Type::ScalarType(_) => (),
+                        metadata::Type::ArrayType(arr_ty) => match **arr_ty {
+                            metadata::Type::CompositeType(ref ct2) => {
+                                discovered_type_names.insert(ct2.to_string());
+                                ()
+                            }
+                            _ => (),
+                        },
+                    }
+                }
+            }
+        }
+    }
+
+    // Since 'discovered_type_names' only grows monotonically starting from 'occurring_type_names'
+    // we just have to compare the number of elements to know if new types have been discovered.
+    if discovered_type_names.len() == occurring_type_names.len() {
+        // Iterating over occurring types discovered no new types
+        composite_types
+            .0
+            .retain(|t, _| occurring_type_names.contains(t));
+        composite_types
+    } else {
+        // Iterating over occurring types did discover new types,
+        // so we keep on going.
+        transitively_occurring_composite_types(discovered_type_names, composite_types)
+    }
+}
+
+/// Collect all the scalar types that can occur in the metadata. This is a bit circumstantial. A better
 /// approach is likely to record scalar type names directly in the metadata via version2.sql.
 pub fn occurring_scalar_types(
     tables: &metadata::TablesInfo,

--- a/crates/configuration/src/version3/mod.rs
+++ b/crates/configuration/src/version3/mod.rs
@@ -235,24 +235,19 @@ pub fn transitively_occurring_types(
                     match &f.r#type {
                         metadata::Type::CompositeType(ct2) => {
                             discovered_type_names.insert(ct2.to_string());
-                            ()
                         }
                         metadata::Type::ScalarType(t) => {
                             occurring_scalar_types.insert(t.clone());
-                            ()
                         }
                         metadata::Type::ArrayType(arr_ty) => match **arr_ty {
                             metadata::Type::CompositeType(ref ct2) => {
                                 discovered_type_names.insert(ct2.to_string());
-                                ()
                             }
                             metadata::Type::ScalarType(ref t) => {
                                 occurring_scalar_types.insert(t.clone());
-                                ()
                             }
                             metadata::Type::ArrayType(_) => {
                                 // This case is impossible, because we do not support nested arrays
-                                ()
                             }
                         },
                     }

--- a/crates/configuration/src/version3/version3.sql
+++ b/crates/configuration/src/version3/version3.sql
@@ -7,8 +7,8 @@
 -- When debugging in 'psql', uncomment the lines below to be able to run the
 -- query with arguments set.
 
--- DEALLOCATE ALL; -- Or use 'DEALLOCATE configuration' between reloads
--- PREPARE configuration(varchar[], varchar[], varchar[], jsonb, varchar[]) AS
+DEALLOCATE ALL; -- Or use 'DEALLOCATE configuration' between reloads
+PREPARE configuration(varchar[], varchar[], varchar[], jsonb, varchar[], varchar[]) AS
 
 WITH
   -- The overall structure of this query is a CTE (i.e. 'WITH .. SELECT')
@@ -230,8 +230,7 @@ WITH
       (
         SELECT relation_id FROM composite_types
         WHERE
-          NOT (type_name = ANY (
-  '{woop,replication_slot_info,split_copy_info,split_shard_info,geometry_dump,valid_detail,norm_addy}'::varchar[]))
+          NOT (type_name = ANY ($6))
         EXCEPT
         SELECT relation_id FROM relations
       )
@@ -1175,10 +1174,10 @@ WITH
       c.constraint_type = 'f' -- For foreign-key constraints
   )
 SELECT
-  coalesce(tables.result, '{}'::jsonb) AS "Tables",
-  coalesce(aggregate_functions.result, '{}'::jsonb) AS "AggregateFunctions",
-  coalesce(comparison_functions.result, '{}'::jsonb) AS "ComparisonFunctions",
-  coalesce(composite_types_json.result, '{}'::jsonb) AS "CompositeTypes"
+  jsonb_pretty(coalesce(tables.result, '{}'::jsonb)) AS "Tables",
+  jsonb_pretty(coalesce(aggregate_functions.result, '{}'::jsonb)) AS "AggregateFunctions",
+  jsonb_pretty(coalesce(comparison_functions.result, '{}'::jsonb)) AS "ComparisonFunctions",
+  jsonb_pretty(coalesce(composite_types_json.result, '{}'::jsonb)) AS "CompositeTypes"
 FROM
   (
     SELECT
@@ -1493,26 +1492,27 @@ FROM
 
 -- Uncomment the following lines to just run the configuration query with reasonable default arguments
 --
--- EXECUTE configuration(
---   '{"information_schema", "tiger", "pg_catalog", "topology"}'::varchar[],
---   '{"public"}'::varchar[],
---   '{"public", "pg_catalog", "tiger"}'::varchar[],
---   '[
---     {"operatorName": "=", "exposedName": "_eq", "operatorKind": "equal"},
---     {"operatorName": "!=", "exposedName": "_neq", "operatorKind": "custom"},
---     {"operatorName": "<>", "exposedName": "_neq", "operatorKind": "custom"},
---     {"operatorName": "<=", "exposedName": "_lte", "operatorKind": "custom"},
---     {"operatorName": ">", "exposedName": "_gt", "operatorKind": "custom"},
---     {"operatorName": ">=", "exposedName": "_gte", "operatorKind": "custom"},
---     {"operatorName": "<", "exposedName": "_lt", "operatorKind": "custom"},
---     {"operatorName": "~~", "exposedName": "_like", "operatorKind": "custom"},
---     {"operatorName": "!~~", "exposedName": "_nlike", "operatorKind": "custom"},
---     {"operatorName": "~~*", "exposedName": "_ilike", "operatorKind": "custom"},
---     {"operatorName": "!~~*", "exposedName": "_nilike", "operatorKind": "custom"},
---     {"operatorName": "~", "exposedName": "_regex", "operatorKind": "custom"},
---     {"operatorName": "!~", "exposedName": "_nregex", "operatorKind": "custom"},
---     {"operatorName": "~*", "exposedName": "_iregex", "operatorKind": "custom"},
---     {"operatorName": "!~*", "exposedName": "_niregex", "operatorKind": "custom"}
---    ]'::jsonb,
---   '{box_above,box_below}'::varchar[]
--- );
+EXECUTE configuration(
+  '{"information_schema", "tiger", "pg_catalog", "topology"}'::varchar[],
+  '{"public"}'::varchar[],
+  '{"public", "pg_catalog", "tiger"}'::varchar[],
+  '[
+    {"operatorName": "=", "exposedName": "_eq", "operatorKind": "equal"},
+    {"operatorName": "!=", "exposedName": "_neq", "operatorKind": "custom"},
+    {"operatorName": "<>", "exposedName": "_neq", "operatorKind": "custom"},
+    {"operatorName": "<=", "exposedName": "_lte", "operatorKind": "custom"},
+    {"operatorName": ">", "exposedName": "_gt", "operatorKind": "custom"},
+    {"operatorName": ">=", "exposedName": "_gte", "operatorKind": "custom"},
+    {"operatorName": "<", "exposedName": "_lt", "operatorKind": "custom"},
+    {"operatorName": "~~", "exposedName": "_like", "operatorKind": "custom"},
+    {"operatorName": "!~~", "exposedName": "_nlike", "operatorKind": "custom"},
+    {"operatorName": "~~*", "exposedName": "_ilike", "operatorKind": "custom"},
+    {"operatorName": "!~~*", "exposedName": "_nilike", "operatorKind": "custom"},
+    {"operatorName": "~", "exposedName": "_regex", "operatorKind": "custom"},
+    {"operatorName": "!~", "exposedName": "_nregex", "operatorKind": "custom"},
+    {"operatorName": "~*", "exposedName": "_iregex", "operatorKind": "custom"},
+    {"operatorName": "!~*", "exposedName": "_niregex", "operatorKind": "custom"}
+   ]'::jsonb,
+  '{box_above,box_below}'::varchar[],
+  '{woop,replication_slot_info,split_copy_info,split_shard_info,geometry_dump,valid_detail,norm_addy}'::varchar[]
+);

--- a/crates/configuration/src/version3/version3.sql
+++ b/crates/configuration/src/version3/version3.sql
@@ -7,8 +7,8 @@
 -- When debugging in 'psql', uncomment the lines below to be able to run the
 -- query with arguments set.
 
--- DEALLOCATE ALL; -- Or use 'DEALLOCATE configuration' between reloads
--- PREPARE configuration(varchar[], varchar[], varchar[], jsonb, varchar[]) AS
+DEALLOCATE ALL; -- Or use 'DEALLOCATE configuration' between reloads
+PREPARE configuration(varchar[], varchar[], varchar[], jsonb, varchar[], varchar[]) AS
 
 WITH
   -- The overall structure of this query is a CTE (i.e. 'WITH .. SELECT')
@@ -229,6 +229,8 @@ WITH
       exclusively_composite_type_ids AS
       (
         SELECT relation_id FROM composite_types
+        WHERE
+          NOT (type_name = ANY ($6))
         EXCEPT
         SELECT relation_id FROM relations
       )
@@ -1172,10 +1174,10 @@ WITH
       c.constraint_type = 'f' -- For foreign-key constraints
   )
 SELECT
-  coalesce(tables.result, '{}'::jsonb) AS "Tables",
-  coalesce(aggregate_functions.result, '{}'::jsonb) AS "AggregateFunctions",
-  coalesce(comparison_functions.result, '{}'::jsonb) AS "ComparisonFunctions",
-  coalesce(composite_types_json.result, '{}'::jsonb) AS "CompositeTypes"
+  jsonb_pretty(coalesce(tables.result, '{}'::jsonb)) AS "Tables",
+  jsonb_pretty(coalesce(aggregate_functions.result, '{}'::jsonb)) AS "AggregateFunctions",
+  jsonb_pretty(coalesce(comparison_functions.result, '{}'::jsonb)) AS "ComparisonFunctions",
+  jsonb_pretty(coalesce(composite_types_json.result, '{}'::jsonb)) AS "CompositeTypes"
 FROM
   (
     SELECT
@@ -1490,26 +1492,27 @@ FROM
 
 -- Uncomment the following lines to just run the configuration query with reasonable default arguments
 --
--- EXECUTE configuration(
---   '{"information_schema", "tiger", "pg_catalog", "topology"}'::varchar[],
---   '{"public"}'::varchar[],
---   '{"public", "pg_catalog", "tiger"}'::varchar[],
---   '[
---     {"operatorName": "=", "exposedName": "_eq", "operatorKind": "equal"},
---     {"operatorName": "!=", "exposedName": "_neq", "operatorKind": "custom"},
---     {"operatorName": "<>", "exposedName": "_neq", "operatorKind": "custom"},
---     {"operatorName": "<=", "exposedName": "_lte", "operatorKind": "custom"},
---     {"operatorName": ">", "exposedName": "_gt", "operatorKind": "custom"},
---     {"operatorName": ">=", "exposedName": "_gte", "operatorKind": "custom"},
---     {"operatorName": "<", "exposedName": "_lt", "operatorKind": "custom"},
---     {"operatorName": "~~", "exposedName": "_like", "operatorKind": "custom"},
---     {"operatorName": "!~~", "exposedName": "_nlike", "operatorKind": "custom"},
---     {"operatorName": "~~*", "exposedName": "_ilike", "operatorKind": "custom"},
---     {"operatorName": "!~~*", "exposedName": "_nilike", "operatorKind": "custom"},
---     {"operatorName": "~", "exposedName": "_regex", "operatorKind": "custom"},
---     {"operatorName": "!~", "exposedName": "_nregex", "operatorKind": "custom"},
---     {"operatorName": "~*", "exposedName": "_iregex", "operatorKind": "custom"},
---     {"operatorName": "!~*", "exposedName": "_niregex", "operatorKind": "custom"}
---    ]'::jsonb,
---   '{box_above,box_below}'::varchar[]
--- );
+EXECUTE configuration(
+  '{"information_schema", "tiger", "pg_catalog", "topology"}'::varchar[],
+  '{"public"}'::varchar[],
+  '{"public", "pg_catalog", "tiger"}'::varchar[],
+  '[
+    {"operatorName": "=", "exposedName": "_eq", "operatorKind": "equal"},
+    {"operatorName": "!=", "exposedName": "_neq", "operatorKind": "custom"},
+    {"operatorName": "<>", "exposedName": "_neq", "operatorKind": "custom"},
+    {"operatorName": "<=", "exposedName": "_lte", "operatorKind": "custom"},
+    {"operatorName": ">", "exposedName": "_gt", "operatorKind": "custom"},
+    {"operatorName": ">=", "exposedName": "_gte", "operatorKind": "custom"},
+    {"operatorName": "<", "exposedName": "_lt", "operatorKind": "custom"},
+    {"operatorName": "~~", "exposedName": "_like", "operatorKind": "custom"},
+    {"operatorName": "!~~", "exposedName": "_nlike", "operatorKind": "custom"},
+    {"operatorName": "~~*", "exposedName": "_ilike", "operatorKind": "custom"},
+    {"operatorName": "!~~*", "exposedName": "_nilike", "operatorKind": "custom"},
+    {"operatorName": "~", "exposedName": "_regex", "operatorKind": "custom"},
+    {"operatorName": "!~", "exposedName": "_nregex", "operatorKind": "custom"},
+    {"operatorName": "~*", "exposedName": "_iregex", "operatorKind": "custom"},
+    {"operatorName": "!~*", "exposedName": "_niregex", "operatorKind": "custom"}
+   ]'::jsonb,
+  '{box_above,box_below}'::varchar[],
+  '{woop,replication_slot_info,split_copy_info,split_shard_info,geometry_dump,valid_detail,norm_addy}'::varchar[]
+);

--- a/crates/configuration/src/version3/version3.sql
+++ b/crates/configuration/src/version3/version3.sql
@@ -7,8 +7,8 @@
 -- When debugging in 'psql', uncomment the lines below to be able to run the
 -- query with arguments set.
 
-DEALLOCATE ALL; -- Or use 'DEALLOCATE configuration' between reloads
-PREPARE configuration(varchar[], varchar[], varchar[], jsonb, varchar[], varchar[]) AS
+-- DEALLOCATE ALL; -- Or use 'DEALLOCATE configuration' between reloads
+-- PREPARE configuration(varchar[], varchar[], varchar[], jsonb, varchar[]) AS
 
 WITH
   -- The overall structure of this query is a CTE (i.e. 'WITH .. SELECT')
@@ -229,8 +229,6 @@ WITH
       exclusively_composite_type_ids AS
       (
         SELECT relation_id FROM composite_types
-        WHERE
-          NOT (type_name = ANY ($6))
         EXCEPT
         SELECT relation_id FROM relations
       )
@@ -1174,10 +1172,10 @@ WITH
       c.constraint_type = 'f' -- For foreign-key constraints
   )
 SELECT
-  jsonb_pretty(coalesce(tables.result, '{}'::jsonb)) AS "Tables",
-  jsonb_pretty(coalesce(aggregate_functions.result, '{}'::jsonb)) AS "AggregateFunctions",
-  jsonb_pretty(coalesce(comparison_functions.result, '{}'::jsonb)) AS "ComparisonFunctions",
-  jsonb_pretty(coalesce(composite_types_json.result, '{}'::jsonb)) AS "CompositeTypes"
+  coalesce(tables.result, '{}'::jsonb) AS "Tables",
+  coalesce(aggregate_functions.result, '{}'::jsonb) AS "AggregateFunctions",
+  coalesce(comparison_functions.result, '{}'::jsonb) AS "ComparisonFunctions",
+  coalesce(composite_types_json.result, '{}'::jsonb) AS "CompositeTypes"
 FROM
   (
     SELECT
@@ -1492,27 +1490,26 @@ FROM
 
 -- Uncomment the following lines to just run the configuration query with reasonable default arguments
 --
-EXECUTE configuration(
-  '{"information_schema", "tiger", "pg_catalog", "topology"}'::varchar[],
-  '{"public"}'::varchar[],
-  '{"public", "pg_catalog", "tiger"}'::varchar[],
-  '[
-    {"operatorName": "=", "exposedName": "_eq", "operatorKind": "equal"},
-    {"operatorName": "!=", "exposedName": "_neq", "operatorKind": "custom"},
-    {"operatorName": "<>", "exposedName": "_neq", "operatorKind": "custom"},
-    {"operatorName": "<=", "exposedName": "_lte", "operatorKind": "custom"},
-    {"operatorName": ">", "exposedName": "_gt", "operatorKind": "custom"},
-    {"operatorName": ">=", "exposedName": "_gte", "operatorKind": "custom"},
-    {"operatorName": "<", "exposedName": "_lt", "operatorKind": "custom"},
-    {"operatorName": "~~", "exposedName": "_like", "operatorKind": "custom"},
-    {"operatorName": "!~~", "exposedName": "_nlike", "operatorKind": "custom"},
-    {"operatorName": "~~*", "exposedName": "_ilike", "operatorKind": "custom"},
-    {"operatorName": "!~~*", "exposedName": "_nilike", "operatorKind": "custom"},
-    {"operatorName": "~", "exposedName": "_regex", "operatorKind": "custom"},
-    {"operatorName": "!~", "exposedName": "_nregex", "operatorKind": "custom"},
-    {"operatorName": "~*", "exposedName": "_iregex", "operatorKind": "custom"},
-    {"operatorName": "!~*", "exposedName": "_niregex", "operatorKind": "custom"}
-   ]'::jsonb,
-  '{box_above,box_below}'::varchar[],
-  '{woop,replication_slot_info,split_copy_info,split_shard_info,geometry_dump,valid_detail,norm_addy}'::varchar[]
-);
+-- EXECUTE configuration(
+--   '{"information_schema", "tiger", "pg_catalog", "topology"}'::varchar[],
+--   '{"public"}'::varchar[],
+--   '{"public", "pg_catalog", "tiger"}'::varchar[],
+--   '[
+--     {"operatorName": "=", "exposedName": "_eq", "operatorKind": "equal"},
+--     {"operatorName": "!=", "exposedName": "_neq", "operatorKind": "custom"},
+--     {"operatorName": "<>", "exposedName": "_neq", "operatorKind": "custom"},
+--     {"operatorName": "<=", "exposedName": "_lte", "operatorKind": "custom"},
+--     {"operatorName": ">", "exposedName": "_gt", "operatorKind": "custom"},
+--     {"operatorName": ">=", "exposedName": "_gte", "operatorKind": "custom"},
+--     {"operatorName": "<", "exposedName": "_lt", "operatorKind": "custom"},
+--     {"operatorName": "~~", "exposedName": "_like", "operatorKind": "custom"},
+--     {"operatorName": "!~~", "exposedName": "_nlike", "operatorKind": "custom"},
+--     {"operatorName": "~~*", "exposedName": "_ilike", "operatorKind": "custom"},
+--     {"operatorName": "!~~*", "exposedName": "_nilike", "operatorKind": "custom"},
+--     {"operatorName": "~", "exposedName": "_regex", "operatorKind": "custom"},
+--     {"operatorName": "!~", "exposedName": "_nregex", "operatorKind": "custom"},
+--     {"operatorName": "~*", "exposedName": "_iregex", "operatorKind": "custom"},
+--     {"operatorName": "!~*", "exposedName": "_niregex", "operatorKind": "custom"}
+--    ]'::jsonb,
+--   '{box_above,box_below}'::varchar[]
+-- );

--- a/crates/configuration/src/version3/version3.sql
+++ b/crates/configuration/src/version3/version3.sql
@@ -7,8 +7,8 @@
 -- When debugging in 'psql', uncomment the lines below to be able to run the
 -- query with arguments set.
 
-DEALLOCATE ALL; -- Or use 'DEALLOCATE configuration' between reloads
-PREPARE configuration(varchar[], varchar[], varchar[], jsonb, varchar[], varchar[]) AS
+-- DEALLOCATE ALL; -- Or use 'DEALLOCATE configuration' between reloads
+-- PREPARE configuration(varchar[], varchar[], varchar[], jsonb, varchar[]) AS
 
 WITH
   -- The overall structure of this query is a CTE (i.e. 'WITH .. SELECT')
@@ -230,7 +230,8 @@ WITH
       (
         SELECT relation_id FROM composite_types
         WHERE
-          NOT (type_name = ANY ($6))
+          NOT (type_name = ANY (
+  '{woop,replication_slot_info,split_copy_info,split_shard_info,geometry_dump,valid_detail,norm_addy}'::varchar[]))
         EXCEPT
         SELECT relation_id FROM relations
       )
@@ -1174,10 +1175,10 @@ WITH
       c.constraint_type = 'f' -- For foreign-key constraints
   )
 SELECT
-  jsonb_pretty(coalesce(tables.result, '{}'::jsonb)) AS "Tables",
-  jsonb_pretty(coalesce(aggregate_functions.result, '{}'::jsonb)) AS "AggregateFunctions",
-  jsonb_pretty(coalesce(comparison_functions.result, '{}'::jsonb)) AS "ComparisonFunctions",
-  jsonb_pretty(coalesce(composite_types_json.result, '{}'::jsonb)) AS "CompositeTypes"
+  coalesce(tables.result, '{}'::jsonb) AS "Tables",
+  coalesce(aggregate_functions.result, '{}'::jsonb) AS "AggregateFunctions",
+  coalesce(comparison_functions.result, '{}'::jsonb) AS "ComparisonFunctions",
+  coalesce(composite_types_json.result, '{}'::jsonb) AS "CompositeTypes"
 FROM
   (
     SELECT
@@ -1492,27 +1493,26 @@ FROM
 
 -- Uncomment the following lines to just run the configuration query with reasonable default arguments
 --
-EXECUTE configuration(
-  '{"information_schema", "tiger", "pg_catalog", "topology"}'::varchar[],
-  '{"public"}'::varchar[],
-  '{"public", "pg_catalog", "tiger"}'::varchar[],
-  '[
-    {"operatorName": "=", "exposedName": "_eq", "operatorKind": "equal"},
-    {"operatorName": "!=", "exposedName": "_neq", "operatorKind": "custom"},
-    {"operatorName": "<>", "exposedName": "_neq", "operatorKind": "custom"},
-    {"operatorName": "<=", "exposedName": "_lte", "operatorKind": "custom"},
-    {"operatorName": ">", "exposedName": "_gt", "operatorKind": "custom"},
-    {"operatorName": ">=", "exposedName": "_gte", "operatorKind": "custom"},
-    {"operatorName": "<", "exposedName": "_lt", "operatorKind": "custom"},
-    {"operatorName": "~~", "exposedName": "_like", "operatorKind": "custom"},
-    {"operatorName": "!~~", "exposedName": "_nlike", "operatorKind": "custom"},
-    {"operatorName": "~~*", "exposedName": "_ilike", "operatorKind": "custom"},
-    {"operatorName": "!~~*", "exposedName": "_nilike", "operatorKind": "custom"},
-    {"operatorName": "~", "exposedName": "_regex", "operatorKind": "custom"},
-    {"operatorName": "!~", "exposedName": "_nregex", "operatorKind": "custom"},
-    {"operatorName": "~*", "exposedName": "_iregex", "operatorKind": "custom"},
-    {"operatorName": "!~*", "exposedName": "_niregex", "operatorKind": "custom"}
-   ]'::jsonb,
-  '{box_above,box_below}'::varchar[],
-  '{woop,replication_slot_info,split_copy_info,split_shard_info,geometry_dump,valid_detail,norm_addy}'::varchar[]
-);
+-- EXECUTE configuration(
+--   '{"information_schema", "tiger", "pg_catalog", "topology"}'::varchar[],
+--   '{"public"}'::varchar[],
+--   '{"public", "pg_catalog", "tiger"}'::varchar[],
+--   '[
+--     {"operatorName": "=", "exposedName": "_eq", "operatorKind": "equal"},
+--     {"operatorName": "!=", "exposedName": "_neq", "operatorKind": "custom"},
+--     {"operatorName": "<>", "exposedName": "_neq", "operatorKind": "custom"},
+--     {"operatorName": "<=", "exposedName": "_lte", "operatorKind": "custom"},
+--     {"operatorName": ">", "exposedName": "_gt", "operatorKind": "custom"},
+--     {"operatorName": ">=", "exposedName": "_gte", "operatorKind": "custom"},
+--     {"operatorName": "<", "exposedName": "_lt", "operatorKind": "custom"},
+--     {"operatorName": "~~", "exposedName": "_like", "operatorKind": "custom"},
+--     {"operatorName": "!~~", "exposedName": "_nlike", "operatorKind": "custom"},
+--     {"operatorName": "~~*", "exposedName": "_ilike", "operatorKind": "custom"},
+--     {"operatorName": "!~~*", "exposedName": "_nilike", "operatorKind": "custom"},
+--     {"operatorName": "~", "exposedName": "_regex", "operatorKind": "custom"},
+--     {"operatorName": "!~", "exposedName": "_nregex", "operatorKind": "custom"},
+--     {"operatorName": "~*", "exposedName": "_iregex", "operatorKind": "custom"},
+--     {"operatorName": "!~*", "exposedName": "_niregex", "operatorKind": "custom"}
+--    ]'::jsonb,
+--   '{box_above,box_below}'::varchar[]
+-- );

--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__schema_tests__schema_test__get_schema.snap
@@ -4,6 +4,71 @@ expression: result
 ---
 {
   "scalar_types": {
+    "bit": {
+      "aggregate_functions": {
+        "bit_and": {
+          "result_type": {
+            "type": "named",
+            "name": "bit"
+          }
+        },
+        "bit_or": {
+          "result_type": {
+            "type": "named",
+            "name": "bit"
+          }
+        },
+        "bit_xor": {
+          "result_type": {
+            "type": "named",
+            "name": "bit"
+          }
+        }
+      },
+      "comparison_operators": {
+        "_eq": {
+          "type": "equal"
+        },
+        "_gt": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "bit"
+          }
+        },
+        "_gte": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "bit"
+          }
+        },
+        "_in": {
+          "type": "in"
+        },
+        "_lt": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "bit"
+          }
+        },
+        "_lte": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "bit"
+          }
+        },
+        "_neq": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "bit"
+          }
+        }
+      }
+    },
     "bool": {
       "aggregate_functions": {
         "bool_and": {
@@ -2572,7 +2637,7 @@ expression: result
             "type": "array",
             "element_type": {
               "type": "named",
-              "name": "text"
+              "name": "person_name"
             }
           }
         },
@@ -2631,6 +2696,29 @@ expression: result
             "underlying_type": {
               "type": "named",
               "name": "int4"
+            }
+          }
+        }
+      }
+    },
+    "discoverable_types": {
+      "fields": {
+        "only_occurring_here1": {
+          "type": {
+            "type": "named",
+            "name": "bit"
+          }
+        }
+      }
+    },
+    "discoverable_types_root_occurrence": {
+      "fields": {
+        "col": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "discoverable_types"
             }
           }
         }
@@ -2715,7 +2803,7 @@ expression: result
     },
     "organization": {
       "fields": {
-        "members": {
+        "committees": {
           "type": {
             "type": "array",
             "element_type": {
@@ -2749,14 +2837,17 @@ expression: result
       }
     },
     "person_address": {
+      "description": "The address of a person, obviously",
       "fields": {
         "address_line_1": {
+          "description": "Address line No 1",
           "type": {
             "type": "named",
             "name": "text"
           }
         },
         "address_line_2": {
+          "description": "Address line No 2",
           "type": {
             "type": "named",
             "name": "text"
@@ -2765,14 +2856,17 @@ expression: result
       }
     },
     "person_name": {
+      "description": "The name of a person, obviously",
       "fields": {
         "first_name": {
+          "description": "The first name of a person",
           "type": {
             "type": "named",
             "name": "text"
           }
         },
         "last_name": {
+          "description": "The last name of a person",
           "type": {
             "type": "named",
             "name": "text"
@@ -3824,6 +3918,41 @@ expression: result
         }
       }
     },
+    "v1_insert_discoverable_types_root_occurrence_object": {
+      "fields": {
+        "col": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "discoverable_types"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_discoverable_types_root_occurrence_response": {
+      "description": "Responses from the 'v1_insert_discoverable_types_root_occurrence' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "discoverable_types_root_occurrence"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_even_numbers_object": {
       "fields": {
         "the_number": {
@@ -4230,6 +4359,13 @@ expression: result
       "name": "deck_of_cards",
       "arguments": {},
       "type": "deck_of_cards",
+      "uniqueness_constraints": {},
+      "foreign_keys": {}
+    },
+    {
+      "name": "discoverable_types_root_occurrence",
+      "arguments": {},
+      "type": "discoverable_types_root_occurrence",
       "uniqueness_constraints": {},
       "foreign_keys": {}
     },
@@ -5012,6 +5148,22 @@ expression: result
       "result_type": {
         "type": "named",
         "name": "v1_insert_deck_of_cards_response"
+      }
+    },
+    {
+      "name": "v1_insert_discoverable_types_root_occurrence",
+      "description": "Insert into the discoverable_types_root_occurrence table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_discoverable_types_root_occurrence_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "v1_insert_discoverable_types_root_occurrence_response"
       }
     },
     {

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__schema_tests__schema_test__get_schema.snap
@@ -2341,6 +2341,25 @@ expression: result
         }
       }
     },
+    "discoverable_types_root_occurrence": {
+      "fields": {
+        "col": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "discoverable_types"
+            }
+          }
+        },
+        "rowid": {
+          "type": {
+            "type": "named",
+            "name": "int8"
+          }
+        }
+      }
+    },
     "insert_album": {
       "fields": {
         "AlbumId": {
@@ -2390,38 +2409,6 @@ expression: result
               "type": "named",
               "name": "varchar"
             }
-          }
-        }
-      }
-    },
-    "person_address": {
-      "fields": {
-        "address_line_1": {
-          "type": {
-            "type": "named",
-            "name": "text"
-          }
-        },
-        "address_line_2": {
-          "type": {
-            "type": "named",
-            "name": "text"
-          }
-        }
-      }
-    },
-    "person_name": {
-      "fields": {
-        "first_name": {
-          "type": {
-            "type": "named",
-            "name": "text"
-          }
-        },
-        "last_name": {
-          "type": {
-            "type": "named",
-            "name": "text"
           }
         }
       }
@@ -2713,6 +2700,28 @@ expression: result
             "element_type": {
               "type": "named",
               "name": "deck_of_cards"
+            }
+          }
+        }
+      }
+    },
+    "v1_delete_discoverable_types_root_occurrence_by_rowid_response": {
+      "description": "Responses from the 'v1_delete_discoverable_types_root_occurrence_by_rowid' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "discoverable_types_root_occurrence"
             }
           }
         }
@@ -3534,6 +3543,47 @@ expression: result
         }
       }
     },
+    "v1_insert_discoverable_types_root_occurrence_object": {
+      "fields": {
+        "col": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "discoverable_types"
+            }
+          }
+        },
+        "rowid": {
+          "type": {
+            "type": "named",
+            "name": "int8"
+          }
+        }
+      }
+    },
+    "v1_insert_discoverable_types_root_occurrence_response": {
+      "description": "Responses from the 'v1_insert_discoverable_types_root_occurrence' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "discoverable_types_root_occurrence"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_pg_extension_spatial_ref_sys_object": {
       "fields": {
         "auth_name": {
@@ -3981,6 +4031,19 @@ expression: result
       "type": "deck_of_cards",
       "uniqueness_constraints": {
         "deck_of_cards_pkey": {
+          "unique_columns": [
+            "rowid"
+          ]
+        }
+      },
+      "foreign_keys": {}
+    },
+    {
+      "name": "discoverable_types_root_occurrence",
+      "arguments": {},
+      "type": "discoverable_types_root_occurrence",
+      "uniqueness_constraints": {
+        "discoverable_types_root_occurrence_pkey": {
           "unique_columns": [
             "rowid"
           ]
@@ -4547,6 +4610,22 @@ expression: result
       }
     },
     {
+      "name": "v1_delete_discoverable_types_root_occurrence_by_rowid",
+      "description": "Delete any value on the discoverable_types_root_occurrence table using the rowid key",
+      "arguments": {
+        "rowid": {
+          "type": {
+            "type": "named",
+            "name": "int8"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "v1_delete_discoverable_types_root_occurrence_by_rowid_response"
+      }
+    },
+    {
       "name": "v1_insert_Album",
       "description": "Insert into the Album table",
       "arguments": {
@@ -4736,6 +4815,22 @@ expression: result
       "result_type": {
         "type": "named",
         "name": "v1_insert_deck_of_cards_response"
+      }
+    },
+    {
+      "name": "v1_insert_discoverable_types_root_occurrence",
+      "description": "Insert into the discoverable_types_root_occurrence table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_discoverable_types_root_occurrence_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "v1_insert_discoverable_types_root_occurrence_response"
       }
     },
     {

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__postgres_current_only_configure_v3_initial_configuration_is_unchanged.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__postgres_current_only_configure_v3_initial_configuration_is_unchanged.snap
@@ -848,6 +848,23 @@ expression: default_configuration
         "foreignRelations": {},
         "description": null
       },
+      "discoverable_types_root_occurrence": {
+        "schemaName": "public",
+        "tableName": "discoverable_types_root_occurrence",
+        "columns": {
+          "col": {
+            "name": "col",
+            "type": {
+              "compositeType": "discoverable_types"
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "uniquenessConstraints": {},
+        "foreignRelations": {},
+        "description": null
+      },
       "even_numbers": {
         "schemaName": "public",
         "tableName": "even_numbers",
@@ -1069,9 +1086,34 @@ expression: default_configuration
         "description": null
       }
     },
-    "compositeTypes": {},
+    "compositeTypes": {
+      "discoverable_types": {
+        "name": "discoverable_types",
+        "fields": {
+          "only_occurring_here1": {
+            "name": "only_occurring_here1",
+            "type": {
+              "scalarType": "bit"
+            },
+            "description": null
+          }
+        },
+        "description": null
+      }
+    },
     "nativeQueries": {},
     "aggregateFunctions": {
+      "bit": {
+        "bit_and": {
+          "returnType": "bit"
+        },
+        "bit_or": {
+          "returnType": "bit"
+        },
+        "bit_xor": {
+          "returnType": "bit"
+        }
+      },
       "bool": {
         "bool_and": {
           "returnType": "bool"
@@ -1353,6 +1395,50 @@ expression: default_configuration
       }
     },
     "comparisonOperators": {
+      "bit": {
+        "_eq": {
+          "operatorName": "=",
+          "operatorKind": "equal",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_gt": {
+          "operatorName": ">",
+          "operatorKind": "custom",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_gte": {
+          "operatorName": ">=",
+          "operatorKind": "custom",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_in": {
+          "operatorName": "IN",
+          "operatorKind": "in",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_lt": {
+          "operatorName": "<",
+          "operatorKind": "custom",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_lte": {
+          "operatorName": "<=",
+          "operatorKind": "custom",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_neq": {
+          "operatorName": "<>",
+          "operatorKind": "custom",
+          "argumentType": "bit",
+          "isInfix": true
+        }
+      },
       "bool": {
         "_eq": {
           "operatorName": "=",

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
@@ -4,6 +4,71 @@ expression: result
 ---
 {
   "scalar_types": {
+    "bit": {
+      "aggregate_functions": {
+        "bit_and": {
+          "result_type": {
+            "type": "named",
+            "name": "bit"
+          }
+        },
+        "bit_or": {
+          "result_type": {
+            "type": "named",
+            "name": "bit"
+          }
+        },
+        "bit_xor": {
+          "result_type": {
+            "type": "named",
+            "name": "bit"
+          }
+        }
+      },
+      "comparison_operators": {
+        "_eq": {
+          "type": "equal"
+        },
+        "_gt": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "bit"
+          }
+        },
+        "_gte": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "bit"
+          }
+        },
+        "_in": {
+          "type": "in"
+        },
+        "_lt": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "bit"
+          }
+        },
+        "_lte": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "bit"
+          }
+        },
+        "_neq": {
+          "type": "custom",
+          "argument_type": {
+            "type": "named",
+            "name": "bit"
+          }
+        }
+      }
+    },
     "bool": {
       "aggregate_functions": {
         "bool_and": {
@@ -2684,7 +2749,7 @@ expression: result
             "type": "array",
             "element_type": {
               "type": "named",
-              "name": "text"
+              "name": "person_name"
             }
           }
         },
@@ -2794,6 +2859,29 @@ expression: result
         }
       }
     },
+    "discoverable_types": {
+      "fields": {
+        "only_occurring_here1": {
+          "type": {
+            "type": "named",
+            "name": "bit"
+          }
+        }
+      }
+    },
+    "discoverable_types_root_occurrence": {
+      "fields": {
+        "col": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "discoverable_types"
+            }
+          }
+        }
+      }
+    },
     "even_numbers": {
       "fields": {
         "the_number": {
@@ -2873,7 +2961,7 @@ expression: result
     },
     "organization": {
       "fields": {
-        "members": {
+        "committees": {
           "type": {
             "type": "array",
             "element_type": {
@@ -2907,14 +2995,17 @@ expression: result
       }
     },
     "person_address": {
+      "description": "The address of a person, obviously",
       "fields": {
         "address_line_1": {
+          "description": "Address line No 1",
           "type": {
             "type": "named",
             "name": "text"
           }
         },
         "address_line_2": {
+          "description": "Address line No 2",
           "type": {
             "type": "named",
             "name": "text"
@@ -2923,14 +3014,17 @@ expression: result
       }
     },
     "person_name": {
+      "description": "The name of a person, obviously",
       "fields": {
         "first_name": {
+          "description": "The first name of a person",
           "type": {
             "type": "named",
             "name": "text"
           }
         },
         "last_name": {
+          "description": "The last name of a person",
           "type": {
             "type": "named",
             "name": "text"
@@ -4258,6 +4352,41 @@ expression: result
         }
       }
     },
+    "v1_insert_discoverable_types_root_occurrence_object": {
+      "fields": {
+        "col": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "discoverable_types"
+            }
+          }
+        }
+      }
+    },
+    "v1_insert_discoverable_types_root_occurrence_response": {
+      "description": "Responses from the 'v1_insert_discoverable_types_root_occurrence' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "discoverable_types_root_occurrence"
+            }
+          }
+        }
+      }
+    },
     "v1_insert_even_numbers_object": {
       "fields": {
         "the_number": {
@@ -4878,6 +5007,13 @@ expression: result
       "name": "deck_of_cards",
       "arguments": {},
       "type": "deck_of_cards",
+      "uniqueness_constraints": {},
+      "foreign_keys": {}
+    },
+    {
+      "name": "discoverable_types_root_occurrence",
+      "arguments": {},
+      "type": "discoverable_types_root_occurrence",
       "uniqueness_constraints": {},
       "foreign_keys": {}
     },
@@ -5799,6 +5935,22 @@ expression: result
       "result_type": {
         "type": "named",
         "name": "v1_insert_deck_of_cards_response"
+      }
+    },
+    {
+      "name": "v1_insert_discoverable_types_root_occurrence",
+      "description": "Insert into the discoverable_types_root_occurrence table",
+      "arguments": {
+        "_object": {
+          "type": {
+            "type": "named",
+            "name": "v1_insert_discoverable_types_root_occurrence_object"
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "v1_insert_discoverable_types_root_occurrence_response"
       }
     },
     {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,26 +27,30 @@ services:
         target: /docker-entrypoint-initdb.d/03-composite-simple.sql
         read_only: true
       - type: bind
+        source: ./static/composite-types-comments.sql
+        target: /docker-entrypoint-initdb.d/04-composite-types-comments.sql
+        read_only: true
+      - type: bind
         source: ./static/composite-types-complex.sql
-        target: /docker-entrypoint-initdb.d/04-composite-complex.sql
+        target: /docker-entrypoint-initdb.d/05-composite-complex.sql
         read_only: true
       - type: bind
         source: ./static/custom-tables.sql
-        target: /docker-entrypoint-initdb.d/05-custom-tables.sql
+        target: /docker-entrypoint-initdb.d/06-custom-tables.sql
         read_only: true
       - type: bind
         source: ./static/domain-types.sql
-        target: /docker-entrypoint-initdb.d/06-domain-types.sql
+        target: /docker-entrypoint-initdb.d/07-domain-types.sql
         read_only: true
       - type: bind
         source: ./static/enum-types.sql
-        target: /docker-entrypoint-initdb.d/07-enum-types.sql
+        target: /docker-entrypoint-initdb.d/08-enum-types.sql
         read_only: true
       # The script to copy the database template for mutations tests should
       # come in last in order to capture all aspects.
       - type: bind
         source: ./static/copy-chinook.sql
-        target: /docker-entrypoint-initdb.d/08-copy-chinook.sql
+        target: /docker-entrypoint-initdb.d/09-copy-chinook.sql
         read_only: true
     healthcheck:
       test:
@@ -115,16 +119,20 @@ services:
         target: /docker-entrypoint-initdb.d/01-composite-types-simple.sql
         read_only: true
       - type: bind
+        source: ./static/composite-types-comments.sql
+        target: /docker-entrypoint-initdb.d/02-composite-types-comments.sql
+        read_only: true
+      - type: bind
         source: ./static/composite-types-complex.sql
-        target: /docker-entrypoint-initdb.d/02-composite-types-complex.sql
+        target: /docker-entrypoint-initdb.d/03-composite-types-complex.sql
         read_only: true
       - type: bind
         source: ./static/domain-types.sql
-        target: /docker-entrypoint-initdb.d/03-domain-types.sql
+        target: /docker-entrypoint-initdb.d/04-domain-types.sql
         read_only: true
       - type: bind
         source: ./static/enum-types.sql
-        target: /docker-entrypoint-initdb.d/04-enum-types.sql
+        target: /docker-entrypoint-initdb.d/05-enum-types.sql
         read_only: true
     healthcheck:
       test:
@@ -155,8 +163,12 @@ services:
         target: /home/yugabyte/01-composite-types-simple.sql
         read_only: true
       - type: bind
+        source: ./static/composite-types-comments.sql
+        target: /home/yugabyte/02-composite-types-comments.sql
+        read_only: true
+      - type: bind
         source: ./static/composite-types-complex.sql
-        target: /home/yugabyte/02-composite-types-complex.sql
+        target: /home/yugabyte/03-composite-types-complex.sql
         read_only: true
       - type: bind
         source: ./static/domain-types.sql

--- a/static/citus/v3-chinook-ndc-metadata/configuration.json
+++ b/static/citus/v3-chinook-ndc-metadata/configuration.json
@@ -783,7 +783,7 @@
             "name": "members",
             "type": {
               "arrayType": {
-                "scalarType": "text"
+                "compositeType": "person_name"
               }
             },
             "description": null
@@ -801,7 +801,7 @@
       "organization": {
         "name": "organization",
         "fields": {
-          "members": {
+          "committees": {
             "name": "committees",
             "type": {
               "arrayType": {
@@ -848,17 +848,17 @@
             "type": {
               "scalarType": "text"
             },
-            "description": null
+            "description": "Address line No 1"
           },
           "address_line_2": {
             "name": "address_line_2",
             "type": {
               "scalarType": "text"
             },
-            "description": null
+            "description": "Address line No 2"
           }
         },
-        "description": null
+        "description": "The address of a person, obviously"
       },
       "person_name": {
         "name": "person_name",
@@ -868,17 +868,17 @@
             "type": {
               "scalarType": "text"
             },
-            "description": null
+            "description": "The first name of a person"
           },
           "last_name": {
             "name": "last_name",
             "type": {
               "scalarType": "text"
             },
-            "description": null
+            "description": "The last name of a person"
           }
         },
-        "description": null
+        "description": "The name of a person, obviously"
       }
     },
     "nativeQueries": {

--- a/static/citus/v3-chinook-ndc-metadata/configuration.json
+++ b/static/citus/v3-chinook-ndc-metadata/configuration.json
@@ -757,6 +757,23 @@
         "foreignRelations": {},
         "description": null
       },
+      "discoverable_types_root_occurrence": {
+        "schemaName": "public",
+        "tableName": "discoverable_types_root_occurrence",
+        "columns": {
+          "col": {
+            "name": "col",
+            "type": {
+              "compositeType": "discoverable_types"
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "uniquenessConstraints": {},
+        "foreignRelations": {},
+        "description": null
+      },
       "even_numbers": {
         "schemaName": "public",
         "tableName": "even_numbers",
@@ -792,6 +809,19 @@
             "name": "name",
             "type": {
               "scalarType": "text"
+            },
+            "description": null
+          }
+        },
+        "description": null
+      },
+      "discoverable_types": {
+        "name": "discoverable_types",
+        "fields": {
+          "only_occurring_here1": {
+            "name": "only_occurring_here1",
+            "type": {
+              "scalarType": "bit"
             },
             "description": null
           }
@@ -1586,6 +1616,17 @@
       }
     },
     "aggregateFunctions": {
+      "bit": {
+        "bit_and": {
+          "returnType": "bit"
+        },
+        "bit_or": {
+          "returnType": "bit"
+        },
+        "bit_xor": {
+          "returnType": "bit"
+        }
+      },
       "bool": {
         "bool_and": {
           "returnType": "bool"
@@ -1959,6 +2000,50 @@
       }
     },
     "comparisonOperators": {
+      "bit": {
+        "_eq": {
+          "operatorName": "=",
+          "operatorKind": "equal",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_gt": {
+          "operatorName": ">",
+          "operatorKind": "custom",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_gte": {
+          "operatorName": ">=",
+          "operatorKind": "custom",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_in": {
+          "operatorName": "IN",
+          "operatorKind": "in",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_lt": {
+          "operatorName": "<",
+          "operatorKind": "custom",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_lte": {
+          "operatorName": "<=",
+          "operatorKind": "custom",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_neq": {
+          "operatorName": "<>",
+          "operatorKind": "custom",
+          "argumentType": "bit",
+          "isInfix": true
+        }
+      },
       "bool": {
         "_eq": {
           "operatorName": "=",

--- a/static/citus/v3-chinook-ndc-metadata/configuration.json
+++ b/static/citus/v3-chinook-ndc-metadata/configuration.json
@@ -783,7 +783,7 @@
             "name": "members",
             "type": {
               "arrayType": {
-                "compositeType": "person_name"
+                "scalarType": "text"
               }
             },
             "description": null
@@ -801,7 +801,7 @@
       "organization": {
         "name": "organization",
         "fields": {
-          "committees": {
+          "members": {
             "name": "committees",
             "type": {
               "arrayType": {
@@ -848,17 +848,17 @@
             "type": {
               "scalarType": "text"
             },
-            "description": "Address line No 1"
+            "description": null
           },
           "address_line_2": {
             "name": "address_line_2",
             "type": {
               "scalarType": "text"
             },
-            "description": "Address line No 2"
+            "description": null
           }
         },
-        "description": "The address of a person, obviously"
+        "description": null
       },
       "person_name": {
         "name": "person_name",
@@ -868,17 +868,17 @@
             "type": {
               "scalarType": "text"
             },
-            "description": "The first name of a person"
+            "description": null
           },
           "last_name": {
             "name": "last_name",
             "type": {
               "scalarType": "text"
             },
-            "description": "The last name of a person"
+            "description": null
           }
         },
-        "description": "The name of a person, obviously"
+        "description": null
       }
     },
     "nativeQueries": {

--- a/static/cockroach/v3-chinook-ndc-metadata/configuration.json
+++ b/static/cockroach/v3-chinook-ndc-metadata/configuration.json
@@ -768,6 +768,34 @@
         "foreignRelations": {},
         "description": null
       },
+      "discoverable_types_root_occurrence": {
+        "schemaName": "public",
+        "tableName": "discoverable_types_root_occurrence",
+        "columns": {
+          "col": {
+            "name": "col",
+            "type": {
+              "compositeType": "discoverable_types"
+            },
+            "nullable": "nullable",
+            "description": null
+          },
+          "rowid": {
+            "name": "rowid",
+            "type": {
+              "scalarType": "int8"
+            },
+            "nullable": "nonNullable",
+            "hasDefault": "hasDefault",
+            "description": null
+          }
+        },
+        "uniquenessConstraints": {
+          "discoverable_types_root_occurrence_pkey": ["rowid"]
+        },
+        "foreignRelations": {},
+        "description": null
+      },
       "pg_extension_spatial_ref_sys": {
         "schemaName": "pg_extension",
         "tableName": "spatial_ref_sys",

--- a/static/cockroach/v3-chinook-ndc-metadata/configuration.json
+++ b/static/cockroach/v3-chinook-ndc-metadata/configuration.json
@@ -818,7 +818,48 @@
         "description": "Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table."
       }
     },
-    "compositeTypes": {},
+    "compositeTypes": {
+      "person_address": {
+        "name": "person_address",
+        "fields": {
+          "address_line_1": {
+            "name": "address_line_1",
+            "type": {
+              "scalarType": "text"
+            },
+            "description": null
+          },
+          "address_line_2": {
+            "name": "address_line_2",
+            "type": {
+              "scalarType": "text"
+            },
+            "description": null
+          }
+        },
+        "description": null
+      },
+      "person_name": {
+        "name": "person_name",
+        "fields": {
+          "first_name": {
+            "name": "first_name",
+            "type": {
+              "scalarType": "text"
+            },
+            "description": null
+          },
+          "last_name": {
+            "name": "last_name",
+            "type": {
+              "scalarType": "text"
+            },
+            "description": null
+          }
+        },
+        "description": null
+      }
+    },
     "nativeQueries": {
       "address_identity_function": {
         "sql": {

--- a/static/cockroach/v3-chinook-ndc-metadata/configuration.json
+++ b/static/cockroach/v3-chinook-ndc-metadata/configuration.json
@@ -818,48 +818,7 @@
         "description": "Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table."
       }
     },
-    "compositeTypes": {
-      "person_address": {
-        "name": "person_address",
-        "fields": {
-          "address_line_1": {
-            "name": "address_line_1",
-            "type": {
-              "scalarType": "text"
-            },
-            "description": null
-          },
-          "address_line_2": {
-            "name": "address_line_2",
-            "type": {
-              "scalarType": "text"
-            },
-            "description": null
-          }
-        },
-        "description": null
-      },
-      "person_name": {
-        "name": "person_name",
-        "fields": {
-          "first_name": {
-            "name": "first_name",
-            "type": {
-              "scalarType": "text"
-            },
-            "description": null
-          },
-          "last_name": {
-            "name": "last_name",
-            "type": {
-              "scalarType": "text"
-            },
-            "description": null
-          }
-        },
-        "description": null
-      }
-    },
+    "compositeTypes": {},
     "nativeQueries": {
       "address_identity_function": {
         "sql": {

--- a/static/composite-types-comments.sql
+++ b/static/composite-types-comments.sql
@@ -1,0 +1,11 @@
+
+-- This file defines types which are used to test the support of composite
+-- types.
+
+COMMENT ON TYPE person_name IS 'The name of a person, obviously';
+COMMENT ON COLUMN person_name.first_name IS 'The first name of a person';
+COMMENT ON COLUMN person_name.last_name IS 'The last name of a person';
+
+COMMENT ON TYPE person_address IS 'The address of a person, obviously';
+COMMENT ON COLUMN person_address.address_line_1 IS 'Address line No 1';
+COMMENT ON COLUMN person_address.address_line_2 IS 'Address line No 2';

--- a/static/composite-types-simple.sql
+++ b/static/composite-types-simple.sql
@@ -25,3 +25,6 @@ CREATE TABLE discoverable_types_root_occurrence
   (
     col discoverable_types
   );
+
+-- We add this because ndc-test is going to check that this table it not empty.
+INSERT INTO discoverable_types_root_occurrence(col) VALUES (ROW(1)::discoverable_types);

--- a/static/composite-types-simple.sql
+++ b/static/composite-types-simple.sql
@@ -13,3 +13,15 @@ CREATE TYPE person_address AS
     address_line_1 text,
     address_line_2 text
   );
+
+-- The below types and tables serve to show that composite types inform which scalar types are relevant.
+
+CREATE TYPE discoverable_types AS
+  (
+    only_occurring_here1 bit
+  );
+
+CREATE TABLE discoverable_types_root_occurrence
+  (
+    col discoverable_types
+  );

--- a/static/postgres/v3-chinook-ndc-metadata/configuration.json
+++ b/static/postgres/v3-chinook-ndc-metadata/configuration.json
@@ -1040,7 +1040,7 @@
             "name": "members",
             "type": {
               "arrayType": {
-                "scalarType": "text"
+                "compositeType": "person_name"
               }
             },
             "description": null
@@ -1058,7 +1058,7 @@
       "organization": {
         "name": "organization",
         "fields": {
-          "members": {
+          "committees": {
             "name": "committees",
             "type": {
               "arrayType": {
@@ -1105,17 +1105,17 @@
             "type": {
               "scalarType": "text"
             },
-            "description": null
+            "description": "Address line No 1"
           },
           "address_line_2": {
             "name": "address_line_2",
             "type": {
               "scalarType": "text"
             },
-            "description": null
+            "description": "Address line No 2"
           }
         },
-        "description": null
+        "description": "The address of a person, obviously"
       },
       "person_name": {
         "name": "person_name",
@@ -1125,17 +1125,17 @@
             "type": {
               "scalarType": "text"
             },
-            "description": null
+            "description": "The first name of a person"
           },
           "last_name": {
             "name": "last_name",
             "type": {
               "scalarType": "text"
             },
-            "description": null
+            "description": "The last name of a person"
           }
         },
-        "description": null
+        "description": "The name of a person, obviously"
       }
     },
     "nativeQueries": {

--- a/static/postgres/v3-chinook-ndc-metadata/configuration.json
+++ b/static/postgres/v3-chinook-ndc-metadata/configuration.json
@@ -1040,7 +1040,7 @@
             "name": "members",
             "type": {
               "arrayType": {
-                "compositeType": "person_name"
+                "scalarType": "text"
               }
             },
             "description": null
@@ -1058,7 +1058,7 @@
       "organization": {
         "name": "organization",
         "fields": {
-          "committees": {
+          "members": {
             "name": "committees",
             "type": {
               "arrayType": {
@@ -1105,17 +1105,17 @@
             "type": {
               "scalarType": "text"
             },
-            "description": "Address line No 1"
+            "description": null
           },
           "address_line_2": {
             "name": "address_line_2",
             "type": {
               "scalarType": "text"
             },
-            "description": "Address line No 2"
+            "description": null
           }
         },
-        "description": "The address of a person, obviously"
+        "description": null
       },
       "person_name": {
         "name": "person_name",
@@ -1125,17 +1125,17 @@
             "type": {
               "scalarType": "text"
             },
-            "description": "The first name of a person"
+            "description": null
           },
           "last_name": {
             "name": "last_name",
             "type": {
               "scalarType": "text"
             },
-            "description": "The last name of a person"
+            "description": null
           }
         },
-        "description": "The name of a person, obviously"
+        "description": null
       }
     },
     "nativeQueries": {

--- a/static/postgres/v3-chinook-ndc-metadata/configuration.json
+++ b/static/postgres/v3-chinook-ndc-metadata/configuration.json
@@ -820,6 +820,23 @@
         "foreignRelations": {},
         "description": null
       },
+      "discoverable_types_root_occurrence": {
+        "schemaName": "public",
+        "tableName": "discoverable_types_root_occurrence",
+        "columns": {
+          "col": {
+            "name": "col",
+            "type": {
+              "compositeType": "discoverable_types"
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "uniquenessConstraints": {},
+        "foreignRelations": {},
+        "description": null
+      },
       "even_numbers": {
         "schemaName": "public",
         "tableName": "even_numbers",
@@ -1049,6 +1066,19 @@
             "name": "name",
             "type": {
               "scalarType": "text"
+            },
+            "description": null
+          }
+        },
+        "description": null
+      },
+      "discoverable_types": {
+        "name": "discoverable_types",
+        "fields": {
+          "only_occurring_here1": {
+            "name": "only_occurring_here1",
+            "type": {
+              "scalarType": "bit"
             },
             "description": null
           }
@@ -1843,6 +1873,17 @@
       }
     },
     "aggregateFunctions": {
+      "bit": {
+        "bit_and": {
+          "returnType": "bit"
+        },
+        "bit_or": {
+          "returnType": "bit"
+        },
+        "bit_xor": {
+          "returnType": "bit"
+        }
+      },
       "bool": {
         "bool_and": {
           "returnType": "bool"
@@ -2216,6 +2257,50 @@
       }
     },
     "comparisonOperators": {
+      "bit": {
+        "_eq": {
+          "operatorName": "=",
+          "operatorKind": "equal",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_gt": {
+          "operatorName": ">",
+          "operatorKind": "custom",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_gte": {
+          "operatorName": ">=",
+          "operatorKind": "custom",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_in": {
+          "operatorName": "IN",
+          "operatorKind": "in",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_lt": {
+          "operatorName": "<",
+          "operatorKind": "custom",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_lte": {
+          "operatorName": "<=",
+          "operatorKind": "custom",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_neq": {
+          "operatorName": "<>",
+          "operatorKind": "custom",
+          "argumentType": "bit",
+          "isInfix": true
+        }
+      },
       "bool": {
         "_eq": {
           "operatorName": "=",

--- a/static/yugabyte/v3-chinook-ndc-metadata/configuration.json
+++ b/static/yugabyte/v3-chinook-ndc-metadata/configuration.json
@@ -783,7 +783,7 @@
             "name": "members",
             "type": {
               "arrayType": {
-                "scalarType": "text"
+                "compositeType": "person_name"
               }
             },
             "description": null
@@ -801,7 +801,7 @@
       "organization": {
         "name": "organization",
         "fields": {
-          "members": {
+          "committees": {
             "name": "committees",
             "type": {
               "arrayType": {
@@ -848,17 +848,17 @@
             "type": {
               "scalarType": "text"
             },
-            "description": null
+            "description": "Address line No 1"
           },
           "address_line_2": {
             "name": "address_line_2",
             "type": {
               "scalarType": "text"
             },
-            "description": null
+            "description": "Address line No 2"
           }
         },
-        "description": null
+        "description": "The address of a person, obviously"
       },
       "person_name": {
         "name": "person_name",
@@ -868,17 +868,17 @@
             "type": {
               "scalarType": "text"
             },
-            "description": null
+            "description": "The first name of a person"
           },
           "last_name": {
             "name": "last_name",
             "type": {
               "scalarType": "text"
             },
-            "description": null
+            "description": "The last name of a person"
           }
         },
-        "description": null
+        "description": "The name of a person, obviously"
       }
     },
     "nativeQueries": {

--- a/static/yugabyte/v3-chinook-ndc-metadata/configuration.json
+++ b/static/yugabyte/v3-chinook-ndc-metadata/configuration.json
@@ -783,7 +783,7 @@
             "name": "members",
             "type": {
               "arrayType": {
-                "compositeType": "person_name"
+                "scalarType": "text"
               }
             },
             "description": null
@@ -801,7 +801,7 @@
       "organization": {
         "name": "organization",
         "fields": {
-          "committees": {
+          "members": {
             "name": "committees",
             "type": {
               "arrayType": {
@@ -848,17 +848,17 @@
             "type": {
               "scalarType": "text"
             },
-            "description": "Address line No 1"
+            "description": null
           },
           "address_line_2": {
             "name": "address_line_2",
             "type": {
               "scalarType": "text"
             },
-            "description": "Address line No 2"
+            "description": null
           }
         },
-        "description": "The address of a person, obviously"
+        "description": null
       },
       "person_name": {
         "name": "person_name",
@@ -868,17 +868,17 @@
             "type": {
               "scalarType": "text"
             },
-            "description": "The first name of a person"
+            "description": null
           },
           "last_name": {
             "name": "last_name",
             "type": {
               "scalarType": "text"
             },
-            "description": "The last name of a person"
+            "description": null
           }
         },
-        "description": "The name of a person, obviously"
+        "description": null
       }
     },
     "nativeQueries": {

--- a/static/yugabyte/v3-chinook-ndc-metadata/configuration.json
+++ b/static/yugabyte/v3-chinook-ndc-metadata/configuration.json
@@ -757,6 +757,23 @@
         "foreignRelations": {},
         "description": null
       },
+      "discoverable_types_root_occurrence": {
+        "schemaName": "public",
+        "tableName": "discoverable_types_root_occurrence",
+        "columns": {
+          "col": {
+            "name": "col",
+            "type": {
+              "compositeType": "discoverable_types"
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "uniquenessConstraints": {},
+        "foreignRelations": {},
+        "description": null
+      },
       "even_numbers": {
         "schemaName": "public",
         "tableName": "even_numbers",
@@ -792,6 +809,19 @@
             "name": "name",
             "type": {
               "scalarType": "text"
+            },
+            "description": null
+          }
+        },
+        "description": null
+      },
+      "discoverable_types": {
+        "name": "discoverable_types",
+        "fields": {
+          "only_occurring_here1": {
+            "name": "only_occurring_here1",
+            "type": {
+              "scalarType": "bit"
             },
             "description": null
           }
@@ -1560,6 +1590,14 @@
       }
     },
     "aggregateFunctions": {
+      "bit": {
+        "bit_and": {
+          "returnType": "bit"
+        },
+        "bit_or": {
+          "returnType": "bit"
+        }
+      },
       "bool": {
         "bool_and": {
           "returnType": "bool"
@@ -1921,6 +1959,50 @@
       }
     },
     "comparisonOperators": {
+      "bit": {
+        "_eq": {
+          "operatorName": "=",
+          "operatorKind": "equal",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_gt": {
+          "operatorName": ">",
+          "operatorKind": "custom",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_gte": {
+          "operatorName": ">=",
+          "operatorKind": "custom",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_in": {
+          "operatorName": "IN",
+          "operatorKind": "in",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_lt": {
+          "operatorName": "<",
+          "operatorKind": "custom",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_lte": {
+          "operatorName": "<=",
+          "operatorKind": "custom",
+          "argumentType": "bit",
+          "isInfix": true
+        },
+        "_neq": {
+          "operatorName": "<>",
+          "operatorKind": "custom",
+          "argumentType": "bit",
+          "isInfix": true
+        }
+      },
       "bool": {
         "_eq": {
           "operatorName": "=",


### PR DESCRIPTION
### What

This PR adds the ability of the introspection query to detect composite types, meaning user-defined record types that do not arise from a table but exist as standalone definitions.

This even discovered a typo in the previous, manually crafted composite type metadata.

Support for cockroachdb is limited here until https://github.com/cockroachdb/cockroach/issues/109675 is released.

### How

**Introspection Query** now captures composite types, filtering out the tables. Making metadata json out of these is quite similar to how we already did tables, so no huge surprises here.

**Occurring types logic** now becomes somewhat more complex because we can no longer simply look at which type names are used in the collections we track. A composite type occurring in say, a table column, may refer to scalar types that don't occur anywhere else, and even other composite types. Occurring type discovery thus becomes an iterative procedure rather than a single pass.