### PR TITLE
Use AURORA_CONNECTION_URI instead of inconsistent  variables

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -13,4 +13,4 @@ export CARGO_INCREMENTAL='true'
 export RUSTFLAGS='-C link-arg=-fuse-ld=mold'
 
 # set your AWS Aurora connection string for testing
-export AURORA_CONNECTION_STRING='postgresql://...'
+export AURORA_CONNECTION_URI='postgresql://...'

--- a/.github/workflows/cargo-test.yaml
+++ b/.github/workflows/cargo-test.yaml
@@ -140,7 +140,7 @@ jobs:
           cargo nextest run --no-fail-fast --release --features aurora --filter-expr='package(databases-tests)'
         env:
           RUST_LOG: INFO
-          AURORA_CONNECTION_STRING: ${{ secrets.AURORA_CONNECTION_STRING }}
+          AURORA_CONNECTION_URI: ${{ secrets.AURORA_CONNECTION_URI }}
 
       # scream into Slack if something goes wrong
       - name: report status

--- a/crates/tests/databases-tests/Cargo.toml
+++ b/crates/tests/databases-tests/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 [features]
 # We only run the AWS Aurora tests if this feature is enabled.
 # This is handled by the `just test` command, which enables the feature if the
-# `AURORA_CONNECTION_STRING` environment variable is set.
+# `AURORA_CONNECTION_URI` environment variable is set.
 aurora = []
 # We only run the Yugabyte tests if this feature is enabled.
 # Note that the Yugabyte Docker image seems not to work on aarch64.

--- a/crates/tests/databases-tests/src/aurora/common.rs
+++ b/crates/tests/databases-tests/src/aurora/common.rs
@@ -6,7 +6,7 @@ pub const CHINOOK_NDC_METADATA_PATH: &str = "static/aurora/v3-chinook-ndc-metada
 
 /// We get our connection string from an env var so that it can be stored in secrets in CI
 pub fn get_connection_string() -> String {
-    env::var("AURORA_CONNECTION_STRING").unwrap()
+    env::var("AURORA_CONNECTION_URI").unwrap()
 }
 
 /// Creates a router with a fresh state from the test NDC metadata.

--- a/docs/development.md
+++ b/docs/development.md
@@ -98,7 +98,7 @@ See [debugging.md](./debugging.md).
 
 You can also run `just dev-citus`, `just dev-cockroach` or `just dev-aurora`.
 
-Aurora runs against a static AWS instance, so you'll need to set the `AURORA_CONNECTION_STRING` environment variable
+Aurora runs against a static AWS instance, so you'll need to set the `AURORA_CONNECTION_URI` environment variable
 to a valid connection string.
 
 ## Profile

--- a/scripts/reinitialize-aurora.sh
+++ b/scripts/reinitialize-aurora.sh
@@ -2,14 +2,14 @@
 set -e -u -o pipefail
 
 # This shell script reinitializes the aurora test database.
-# The environment variable AURORA_CONNECTION_STRING (typically set in
+# The environment variable AURORA_CONNECTION_URI (typically set in
 # .envrc.local) is assumed to hold the authenticated connection string to the
 # writable aurora instance to act on.
 
 # In order to avoid accidental loss of data the database must be suitably empty before proceeding.
 
 number_of_existing_relations="$(
-  psql "$AURORA_CONNECTION_STRING" -t <<QUERY
+  psql "$AURORA_CONNECTION_URI" -t <<QUERY
 SELECT
   COUNT(*)
 FROM pg_class
@@ -25,7 +25,7 @@ then
   exit 1
 fi
 
-psql "$AURORA_CONNECTION_STRING" <<DOC
+psql "$AURORA_CONNECTION_URI" <<DOC
 
 -- Ingesting the Chinook dataset takes about 15 minutes on my machine. I put
 -- this down to the file using one INSERT statement per row of data rather than


### PR DESCRIPTION
### What

Internally we use two variable names for the same purpose: `AURORA_CONNECTION_URI` and `AURORA_CONNECTION_STRING`. This PR renames all uses of `AURORA_CONNECTION_STRING` to `AURORA_CONNECTION_URI`.

### How

Rename everything, and create a new action env variable in the repo.
