### PR TITLE
prepare v0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "databases-tests"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "axum",
  "insta",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-postgres"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "ndc-postgres-configuration",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-postgres-cli"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "build-data",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-postgres-configuration"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "query-engine-metadata",
@@ -1699,7 +1699,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openapi-generator"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ndc-postgres-configuration",
  "schemars",
@@ -2071,7 +2071,7 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "query-engine-execution"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bytes",
  "prometheus",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "query-engine-metadata"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "schemars",
  "serde",
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "query-engine-sql"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "schemars",
  "serde",
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "query-engine-translation"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "indexmap 2.2.6",
  "insta",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "tests-common"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 
-package.version = "0.5.1"
+package.version = "0.5.2"
 package.edition = "2021"
 package.license = "Apache-2.0"
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,12 +4,29 @@
 
 ### Added
 
-- Make aggregation functions available through implicit casts.
-  ([#381](https://github.com/hasura/ndc-postgres/pull/380))
+### Changed
+
+### Fixed
+
+## [v0.5.2] - 2024-03-29
+
+### Added
+
+- Make operators of domain types available via implicit casts.
+  ([#392](https://github.com/hasura/ndc-postgres/pull/392))
+- Support introspection composite types.
+  ([#391](https://github.com/hasura/ndc-postgres/pull/391))
+- Support enum types in the configuration.
+  ([#387](https://github.com/hasura/ndc-postgres/pull/387))
+- Make aggregation functions available through implicit casts in the configuration.
+  ([#381](https://github.com/hasura/ndc-postgres/pull/381))
 - Support for introspecting domain types.
   ([#380](https://github.com/hasura/ndc-postgres/pull/380))
 
 ### Changed
+
+- Support ndc-spec 0.1.1.
+  ([#390](https://github.com/hasura/ndc-postgres/pull/390))
 
 ### Fixed
 
@@ -166,7 +183,8 @@ Initial release.
 
 <!-- end -->
 
-[Unreleased]: https://github.com/hasura/ndc-postgres/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/hasura/ndc-postgres/compare/v0.5.2...HEAD
+[v0.5.2]: https://github.com/hasura/ndc-postgres/releases/tag/v0.5.2
 [v0.5.1]: https://github.com/hasura/ndc-postgres/releases/tag/v0.5.1
 [v0.5.0]: https://github.com/hasura/ndc-postgres/releases/tag/v0.5.0
 [v0.4.1]: https://github.com/hasura/ndc-postgres/releases/tag/v0.4.1


### PR DESCRIPTION
### What

Prepare for v0.5.2 release.

### How

Update the changelog and bump the version.