### PR TITLE
Add enum type representations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Expose the type representation of enums via the ndc schema.
+  ([#397](https://github.com/hasura/ndc-postgres/pull/397))
+
 ### Changed
 
 ### Fixed

--- a/crates/configuration/src/version3/version3.sql
+++ b/crates/configuration/src/version3/version3.sql
@@ -1235,7 +1235,8 @@ SELECT
   coalesce(tables.result, '{}'::jsonb) AS "Tables",
   coalesce(aggregate_functions.result, '{}'::jsonb) AS "AggregateFunctions",
   coalesce(comparison_functions.result, '{}'::jsonb) AS "ComparisonFunctions",
-  coalesce(composite_types_json.result, '{}'::jsonb) AS "CompositeTypes"
+  coalesce(composite_types_json.result, '{}'::jsonb) AS "CompositeTypes",
+  coalesce(type_representations.result, '{}'::jsonb) AS "TypeRepresentations"
 FROM
   (
     SELECT
@@ -1569,6 +1570,22 @@ FROM
       comparison_operators_by_first_arg
       AS op
   ) AS comparison_functions
+
+  CROSS JOIN
+  (
+    -- Type representations.
+    -- At the moment, we only hint at the type representation of enums.
+    SELECT
+      jsonb_object_agg(
+        enum_type.type_name,
+        jsonb_build_object(
+          'enum', enum_type.enum_labels
+        )
+      ) as result
+    FROM
+      enum_types
+      AS enum_type
+  ) AS type_representations
   ;
 
 -- Uncomment the following lines to just run the configuration query with reasonable default arguments

--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -31,7 +31,27 @@ pub async fn get_schema(
             (
                 scalar_type.0.clone(),
                 models::ScalarType {
-                    representation: None,
+                    representation: metadata.type_representations.0.get(scalar_type).map(
+                        |type_representation| match type_representation {
+                            metadata::TypeRepresentation::Boolean => {
+                                models::TypeRepresentation::Boolean
+                            }
+                            metadata::TypeRepresentation::Integer => {
+                                models::TypeRepresentation::Integer
+                            }
+                            metadata::TypeRepresentation::Number => {
+                                models::TypeRepresentation::Number
+                            }
+                            metadata::TypeRepresentation::String => {
+                                models::TypeRepresentation::String
+                            }
+                            metadata::TypeRepresentation::Enum(variants) => {
+                                models::TypeRepresentation::Enum {
+                                    one_of: variants.to_vec(),
+                                }
+                            }
+                        },
+                    ),
                     aggregate_functions: metadata
                         .aggregate_functions
                         .0
@@ -479,7 +499,7 @@ fn make_procedure_type(
     scalar_types
         .entry("int4".to_string())
         .or_insert(models::ScalarType {
-            representation: None,
+            representation: Some(models::TypeRepresentation::Integer),
             aggregate_functions: BTreeMap::new(),
             comparison_operators: BTreeMap::new(),
         });

--- a/crates/query-engine/metadata/src/metadata/database.rs
+++ b/crates/query-engine/metadata/src/metadata/database.rs
@@ -203,3 +203,53 @@ pub struct AggregateFunctions(pub BTreeMap<ScalarType, BTreeMap<String, Aggregat
 pub struct AggregateFunction {
     pub return_type: ScalarType,
 }
+
+/// Type representation of scalar types, grouped by type.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TypeRepresentations(pub BTreeMap<ScalarType, TypeRepresentation>);
+
+/// Type representation of a scalar type.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum TypeRepresentation {
+    /// JSON booleans
+    Boolean,
+    /// Any JSON string
+    String,
+    /// Any JSON number
+    Number,
+    /// Any JSON number, with no decimal part
+    Integer,
+    /// One of the specified string values
+    Enum(Vec<String>),
+}
+
+// tests
+
+#[cfg(test)]
+mod tests {
+    use super::{ScalarType, TypeRepresentation, TypeRepresentations};
+
+    #[test]
+    fn parse_type_representations() {
+        assert_eq!(
+            serde_json::from_str::<TypeRepresentations>(
+                r#"{"card_suit": {"enum": ["hearts", "clubs", "diamonds", "spades"]}}"#
+            )
+            .unwrap(),
+            TypeRepresentations(
+                [(
+                    ScalarType("card_suit".to_string()),
+                    TypeRepresentation::Enum(vec![
+                        "hearts".into(),
+                        "clubs".into(),
+                        "diamonds".into(),
+                        "spades".into()
+                    ])
+                )]
+                .into()
+            )
+        );
+    }
+}

--- a/crates/query-engine/metadata/src/metadata/mod.rs
+++ b/crates/query-engine/metadata/src/metadata/mod.rs
@@ -25,4 +25,6 @@ pub struct Metadata {
     pub aggregate_functions: AggregateFunctions,
     #[serde(default)]
     pub comparison_operators: ComparisonOperators,
+    #[serde(default)]
+    pub type_representations: TypeRepresentations,
 }

--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__schema_tests__schema_test__get_schema.snap
@@ -393,6 +393,15 @@ expression: result
       }
     },
     "card_suit": {
+      "representation": {
+        "type": "enum",
+        "one_of": [
+          "hearts",
+          "clubs",
+          "diamonds",
+          "spades"
+        ]
+      },
       "aggregate_functions": {
         "max": {
           "result_type": {

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__schema_tests__schema_test__get_schema.snap
@@ -70,6 +70,15 @@ expression: result
       }
     },
     "card_suit": {
+      "representation": {
+        "type": "enum",
+        "one_of": [
+          "hearts",
+          "clubs",
+          "diamonds",
+          "spades"
+        ]
+      },
       "aggregate_functions": {
         "max": {
           "result_type": {

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__get_configuration_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__get_configuration_schema.snap
@@ -44,7 +44,8 @@ expression: schema
             "compositeTypes": {},
             "nativeQueries": {},
             "aggregateFunctions": {},
-            "comparisonOperators": {}
+            "comparisonOperators": {},
+            "typeRepresentations": {}
           },
           "allOf": [
             {
@@ -501,6 +502,14 @@ expression: schema
           "allOf": [
             {
               "$ref": "#/definitions/ComparisonOperators"
+            }
+          ]
+        },
+        "typeRepresentations": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/TypeRepresentations"
             }
           ]
         }
@@ -965,6 +974,62 @@ expression: schema
         "equal",
         "in",
         "custom"
+      ]
+    },
+    "TypeRepresentations": {
+      "description": "Type representation of scalar types, grouped by type.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/TypeRepresentation"
+      }
+    },
+    "TypeRepresentation": {
+      "description": "Type representation of a scalar type.",
+      "oneOf": [
+        {
+          "description": "JSON booleans",
+          "type": "string",
+          "enum": [
+            "boolean"
+          ]
+        },
+        {
+          "description": "Any JSON string",
+          "type": "string",
+          "enum": [
+            "string"
+          ]
+        },
+        {
+          "description": "Any JSON number",
+          "type": "string",
+          "enum": [
+            "number"
+          ]
+        },
+        {
+          "description": "Any JSON number, with no decimal part",
+          "type": "string",
+          "enum": [
+            "integer"
+          ]
+        },
+        {
+          "description": "One of the specified string values",
+          "type": "object",
+          "required": [
+            "enum"
+          ],
+          "properties": {
+            "enum": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
       ]
     },
     "IntrospectionOptions": {

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__get_rawconfiguration_v3_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__get_rawconfiguration_v3_schema.snap
@@ -34,7 +34,8 @@ expression: schema
         "compositeTypes": {},
         "nativeQueries": {},
         "aggregateFunctions": {},
-        "comparisonOperators": {}
+        "comparisonOperators": {},
+        "typeRepresentations": {}
       },
       "allOf": [
         {
@@ -489,6 +490,14 @@ expression: schema
           "allOf": [
             {
               "$ref": "#/definitions/ComparisonOperators"
+            }
+          ]
+        },
+        "typeRepresentations": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/TypeRepresentations"
             }
           ]
         }
@@ -953,6 +962,62 @@ expression: schema
         "equal",
         "in",
         "custom"
+      ]
+    },
+    "TypeRepresentations": {
+      "description": "Type representation of scalar types, grouped by type.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/TypeRepresentation"
+      }
+    },
+    "TypeRepresentation": {
+      "description": "Type representation of a scalar type.",
+      "oneOf": [
+        {
+          "description": "JSON booleans",
+          "type": "string",
+          "enum": [
+            "boolean"
+          ]
+        },
+        {
+          "description": "Any JSON string",
+          "type": "string",
+          "enum": [
+            "string"
+          ]
+        },
+        {
+          "description": "Any JSON number",
+          "type": "string",
+          "enum": [
+            "number"
+          ]
+        },
+        {
+          "description": "Any JSON number, with no decimal part",
+          "type": "string",
+          "enum": [
+            "integer"
+          ]
+        },
+        {
+          "description": "One of the specified string values",
+          "type": "object",
+          "required": [
+            "enum"
+          ],
+          "properties": {
+            "enum": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
       ]
     },
     "IntrospectionOptions": {

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__postgres_current_only_configure_v3_initial_configuration_is_unchanged.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__postgres_current_only_configure_v3_initial_configuration_is_unchanged.snap
@@ -2288,6 +2288,16 @@ expression: default_configuration
           "isInfix": false
         }
       }
+    },
+    "typeRepresentations": {
+      "card_suit": {
+        "enum": [
+          "hearts",
+          "clubs",
+          "diamonds",
+          "spades"
+        ]
+      }
     }
   },
   "introspectionOptions": {

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__openapi_tests__openapi__up_to_date_generated_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__openapi_tests__openapi__up_to_date_generated_schema.snap
@@ -42,7 +42,8 @@ expression: generated_schema_json
             "compositeTypes": {},
             "nativeQueries": {},
             "aggregateFunctions": {},
-            "comparisonOperators": {}
+            "comparisonOperators": {},
+            "typeRepresentations": {}
           },
           "allOf": [
             {
@@ -495,6 +496,14 @@ expression: generated_schema_json
               "$ref": "#/components/schemas/ComparisonOperators"
             }
           ]
+        },
+        "typeRepresentations": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/TypeRepresentations"
+            }
+          ]
         }
       }
     },
@@ -943,6 +952,62 @@ expression: generated_schema_json
         "equal",
         "in",
         "custom"
+      ]
+    },
+    "TypeRepresentations": {
+      "description": "Type representation of scalar types, grouped by type.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/components/schemas/TypeRepresentation"
+      }
+    },
+    "TypeRepresentation": {
+      "description": "Type representation of a scalar type.",
+      "oneOf": [
+        {
+          "description": "JSON booleans",
+          "type": "string",
+          "enum": [
+            "boolean"
+          ]
+        },
+        {
+          "description": "Any JSON string",
+          "type": "string",
+          "enum": [
+            "string"
+          ]
+        },
+        {
+          "description": "Any JSON number",
+          "type": "string",
+          "enum": [
+            "number"
+          ]
+        },
+        {
+          "description": "Any JSON number, with no decimal part",
+          "type": "string",
+          "enum": [
+            "integer"
+          ]
+        },
+        {
+          "description": "One of the specified string values",
+          "type": "object",
+          "required": [
+            "enum"
+          ],
+          "properties": {
+            "enum": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
       ]
     },
     "IntrospectionOptions": {

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
@@ -449,6 +449,15 @@ expression: result
       }
     },
     "card_suit": {
+      "representation": {
+        "type": "enum",
+        "one_of": [
+          "hearts",
+          "clubs",
+          "diamonds",
+          "spades"
+        ]
+      },
       "aggregate_functions": {
         "max": {
           "result_type": {

--- a/static/aurora/v3-chinook-ndc-metadata/configuration.json
+++ b/static/aurora/v3-chinook-ndc-metadata/configuration.json
@@ -751,7 +751,7 @@
             "name": "members",
             "type": {
               "arrayType": {
-                "scalarType": "text"
+                "compositeType": "person_name"
               }
             },
             "description": null
@@ -769,7 +769,7 @@
       "organization": {
         "name": "organization",
         "fields": {
-          "members": {
+          "committees": {
             "name": "committees",
             "type": {
               "arrayType": {
@@ -1539,6 +1539,14 @@
           "returnType": "bool"
         }
       },
+      "char": {
+        "max": {
+          "returnType": "text"
+        },
+        "min": {
+          "returnType": "text"
+        }
+      },
       "date": {
         "max": {
           "returnType": "date"
@@ -1775,11 +1783,17 @@
         }
       },
       "time": {
+        "avg": {
+          "returnType": "interval"
+        },
         "max": {
           "returnType": "time"
         },
         "min": {
           "returnType": "time"
+        },
+        "sum": {
+          "returnType": "interval"
         }
       },
       "timestamp": {
@@ -1804,6 +1818,14 @@
         },
         "min": {
           "returnType": "timetz"
+        }
+      },
+      "varchar": {
+        "max": {
+          "returnType": "text"
+        },
+        "min": {
+          "returnType": "text"
         }
       }
     },
@@ -2692,9 +2714,10 @@
           "isInfix": false
         }
       }
-    }
+    },
+    "typeRepresentations": {}
   },
-  "configureOptions": {
+  "introspectionOptions": {
     "excludedSchemas": [
       "information_schema",
       "pg_catalog",
@@ -2816,7 +2839,6 @@
         "operatorKind": "custom"
       }
     ],
-    "mutationsVersion": null,
     "introspectPrefixFunctionComparisonOperators": [
       "box_above",
       "box_below",
@@ -2945,5 +2967,6 @@
       "xmlvalidate",
       "xpath_exists"
     ]
-  }
+  },
+  "mutationsVersion": null
 }

--- a/static/citus/v3-chinook-ndc-metadata/configuration.json
+++ b/static/citus/v3-chinook-ndc-metadata/configuration.json
@@ -3293,6 +3293,11 @@
           "isInfix": false
         }
       }
+    },
+    "typeRepresentations": {
+      "card_suit": {
+        "enum": ["hearts", "clubs", "diamonds", "spades"]
+      }
     }
   },
   "introspectionOptions": {

--- a/static/cockroach/v3-chinook-ndc-metadata/configuration.json
+++ b/static/cockroach/v3-chinook-ndc-metadata/configuration.json
@@ -2796,6 +2796,11 @@
           "isInfix": false
         }
       }
+    },
+    "typeRepresentations": {
+      "card_suit": {
+        "enum": ["hearts", "clubs", "diamonds", "spades"]
+      }
     }
   },
   "introspectionOptions": {

--- a/static/postgres/v3-chinook-ndc-metadata/configuration.json
+++ b/static/postgres/v3-chinook-ndc-metadata/configuration.json
@@ -3670,6 +3670,11 @@
           "isInfix": false
         }
       }
+    },
+    "typeRepresentations": {
+      "card_suit": {
+        "enum": ["hearts", "clubs", "diamonds", "spades"]
+      }
     }
   },
   "introspectionOptions": {

--- a/static/schema.json
+++ b/static/schema.json
@@ -32,7 +32,8 @@
             "compositeTypes": {},
             "nativeQueries": {},
             "aggregateFunctions": {},
-            "comparisonOperators": {}
+            "comparisonOperators": {},
+            "typeRepresentations": {}
           },
           "allOf": [
             {
@@ -473,6 +474,14 @@
               "$ref": "#/definitions/ComparisonOperators"
             }
           ]
+        },
+        "typeRepresentations": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/TypeRepresentations"
+            }
+          ]
         }
       }
     },
@@ -860,6 +869,52 @@
       "description": "Is it a built-in operator, or a custom operator.",
       "type": "string",
       "enum": ["equal", "in", "custom"]
+    },
+    "TypeRepresentations": {
+      "description": "Type representation of scalar types, grouped by type.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/TypeRepresentation"
+      }
+    },
+    "TypeRepresentation": {
+      "description": "Type representation of a scalar type.",
+      "oneOf": [
+        {
+          "description": "JSON booleans",
+          "type": "string",
+          "enum": ["boolean"]
+        },
+        {
+          "description": "Any JSON string",
+          "type": "string",
+          "enum": ["string"]
+        },
+        {
+          "description": "Any JSON number",
+          "type": "string",
+          "enum": ["number"]
+        },
+        {
+          "description": "Any JSON number, with no decimal part",
+          "type": "string",
+          "enum": ["integer"]
+        },
+        {
+          "description": "One of the specified string values",
+          "type": "object",
+          "required": ["enum"],
+          "properties": {
+            "enum": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "IntrospectionOptions": {
       "description": "Options which only influence how the configuration is updated.",

--- a/static/yugabyte/v3-chinook-ndc-metadata/configuration.json
+++ b/static/yugabyte/v3-chinook-ndc-metadata/configuration.json
@@ -3252,6 +3252,11 @@
           "isInfix": false
         }
       }
+    },
+    "typeRepresentations": {
+      "card_suit": {
+        "enum": ["hearts", "clubs", "diamonds", "spades"]
+      }
     }
   },
   "introspectionOptions": {


### PR DESCRIPTION
### What

ndc-spec 0.1.1 introduce an [optional type representation hint](https://hasura.github.io/ndc-spec/specification/schema/scalar-types.html#type-representations). In this PR we provide type representation for enum values.

### How

1. We add a new `TypeRepresentations` field to our metadata, similar to aggregate functions and comparison operators
2. We already query for the enum types and variants, now we also return those from sql to rust and into the metadata.
3. For each scalar type, we try to look for their name in type reps, and return it if we find it.