### PR TITLE
Enable pedantic Clippy warnings, and disable anything that fails.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,37 @@ members = [
 ]
 
 [workspace.lints.clippy]
-all = "warn"
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+# disable certain pedantic warnings
+doc_markdown = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+module_name_repetitions = "allow"
+must_use_candidate = "allow"
+wildcard_imports = "allow"
+# disable these for now, but we should probably fix them
+default_trait_access = "allow"
+explicit_into_iter_loop = "allow"
+explicit_iter_loop = "allow"
+from_iter_instead_of_collect = "allow"
+if_not_else = "allow"
+inconsistent_struct_constructor = "allow"
+inefficient_to_string = "allow"
+manual_let_else = "allow"
+manual_string_new = "allow"
+match_same_arms = "allow"
+match_wildcard_for_single_variants = "allow"
+needless_pass_by_value = "allow"
+redundant_else = "allow"
+semicolon_if_nothing_returned = "allow"
+similar_names = "allow"
+single_match_else = "allow"
+too_many_lines = "allow"
+uninlined_format_args = "allow"
+unnecessary_wraps = "allow"
+unreadable_literal = "allow"
+unused_async = "allow"
 
 [workspace.dependencies]
 ndc-client = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.1" }


### PR DESCRIPTION
### What

Two reasons:

1. so we don't add more unknowingly, and
2. so we can eradicate them over time, if we feel like it.

### How

I added the lints to `Cargo.toml`.