### PR TITLE
bugfix: allow aliasing returning and affected_rows fields

### DIFF
--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__delete_playlist_track.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__delete_playlist_track.snap
@@ -17,18 +17,18 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%3_returning")), '[]') AS "returning"
+          coalesce(json_agg(row_to_json("%3_returninG")), '[]') AS "returninG"
         FROM
           (
             SELECT
               "%1_delete_playlist_track"."PlaylistId" AS "playlist_id"
             FROM
               "%0_NATIVE_QUERY_delete_playlist_track" AS "%1_delete_playlist_track"
-          ) AS "%3_returning"
-      ) AS "%3_returning"
+          ) AS "%3_returninG"
+      ) AS "%3_returninG"
       CROSS JOIN (
         SELECT
-          COUNT(*) AS "affected_rows"
+          COUNT(*) AS "affectedRows"
         FROM
           "%0_NATIVE_QUERY_delete_playlist_track" AS "%1_delete_playlist_track"
       ) AS "%4_aggregates"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__delete_playlist_track.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__delete_playlist_track.snap
@@ -7,7 +7,7 @@ expression: result
     {
       "type": "procedure",
       "result": {
-        "returning": [
+        "returninG": [
           {
             "playlist_id": 1
           },
@@ -15,7 +15,7 @@ expression: result
             "playlist_id": 8
           }
         ],
-        "affected_rows": 2
+        "affectedRows": 2
       }
     }
   ]

--- a/crates/tests/tests-common/goldenfiles/mutations/delete_playlist_track.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/delete_playlist_track.json
@@ -9,12 +9,11 @@
       "fields": {
         "type": "object",
         "fields": {
-          "affected_rows": {
+          "affectedRows": {
             "column": "affected_rows",
             "type": "column"
           },
-
-          "returning": {
+          "returninG": {
             "type": "column",
             "column": "returning",
             "fields": {


### PR DESCRIPTION
### What

It should be possible to alias the returning and affected_rows fields when running a mutation.
This is doubly important because this is what the cli/lsp/engine do by default for `affected_rows` :)

### How

Instead of having the alias satisfy the field name, we ask the Field to do that.
We traverse the result fields, find the ones named "returning" and "affected_rows", and use that, instead of trying to fetch by the alias name in the fields map.
