### PR TITLE
Use different PAT for running e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -31,14 +31,14 @@ jobs:
         with:
           repository: hasura/v3-engine
           path: v3-engine
-          token: ${{ secrets.E2E_WORKFLOW_PAT }}
+          token: ${{ secrets.HASURA_BOT_TOKEN }}
 
       - name: Check out v3-e2e-testing
         uses: actions/checkout@v4
         with:
           repository: hasura/v3-e2e-testing
           path: v3-e2e-testing
-          token: ${{ secrets.E2E_WORKFLOW_PAT }}
+          token: ${{ secrets.HASURA_BOT_TOKEN }}
 
       - name: Install ndc-postgres tools
         working-directory: ndc-postgres


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

Use a token that does not expire for running e2e tests.
