### PR TITLE
Don't tell people to use the CLI's `initialize` command.

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -187,11 +187,11 @@ async fn read_config_file_contents(configuration_file_path: &PathBuf) -> anyhow:
         .map_err(|err| {
             if err.kind() == std::io::ErrorKind::NotFound {
                 anyhow::anyhow!(
-                    "{}: No such file or directory. Perhaps you meant to 'initialize' first?",
+                    "{}: No such file or directory.",
                     configuration_file_path.display()
                 )
             } else {
-                anyhow::anyhow!(err)
+                err.into()
             }
         })
 }


### PR DESCRIPTION
### What

The CLI is typically intended to be used as a plugin to `ddn`, which only exposes `update`, not `initialize`. Telling people to use this doesn't really help them.

### How

I used my big `Delete` button.