### PR TITLE
Build Windows binaries statically.

### DIFF
--- a/.github/workflows/ship.yaml
+++ b/.github/workflows/ship.yaml
@@ -131,6 +131,7 @@ jobs:
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
             extension: .exe
+            extra-rust-flags: "-C target-feature=+crt-static"
     runs-on: ${{ matrix.runner }}
     env:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
@@ -187,6 +188,12 @@ jobs:
             declare "CARGO_TARGET_${TARGET_SCREAMING}_LINKER"='${{ matrix.linker }}'
             export "CARGO_TARGET_${TARGET_SCREAMING}_LINKER"
           fi
+
+          if [[ -n '${{ matrix.extra-rust-flags }}' ]]; then
+            RUSTFLAGS="${RUSTFLAGS} ${{ matrix.extra-rust-flags }}"
+            export RUSTFLAGS
+          fi
+          echo "RUSTFLAGS = ${RUSTFLAGS}"
 
           echo "Building for target: ${CARGO_BUILD_TARGET}"
           cargo build --release --package=ndc-postgres-cli

--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,8 @@
 
 - Fix schema conflict result_type for native query mutations.
   ([#405](https://github.com/hasura/ndc-postgres/pull/405))
+- The CLI plugin no longer requires the Visual C++ Redistributable on Windows.
+  ([#417](https://github.com/hasura/ndc-postgres/pull/417))
 
 ## [v0.5.2] - 2024-03-29
 


### PR DESCRIPTION
### What

We don't want users to have to install the Visual C++ Redistributable to use the ndc-postgres CLI plugin.

### How

We can instruct `rustc` to link statically with the C runtime with the `-C target-feature=+crt-static` flag. See [RFC 1721](https://github.com/rust-lang/rfcs/blob/master/text/1721-crt-static.md) for details.