### PR TITLE
Upgrade to Rust v1.77.2.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711407199,
-        "narHash": "sha256-A/nB4j3JHL51ztlMQdfKw6y8tUJJzai3bLsZUEEaBxY=",
+        "lastModified": 1712681629,
+        "narHash": "sha256-bMDXn4AkTXLCpoZbII6pDGoSeSe9gI87jxPsHRXgu/E=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "7e468a455506f2e65550e08dfd45092f0857a009",
+        "rev": "220387ac8e99cbee0ca4c95b621c4bc782b6a235",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711461781,
-        "narHash": "sha256-nI/IhcOS7r8EOe6wMojDptDL0VFVbl05gPd0EW1COts=",
+        "lastModified": 1712742472,
+        "narHash": "sha256-EVubu9UGPhayvDit0KYKysZiXUo2BRyd6v7bNoCfkrI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b776d8d98eaa689c6a4b23fe84eb8ea241bf4861",
+        "rev": "f9cee3306b1c7b94459e03cefc94f522f74d4f11",
         "type": "github"
       },
       "original": {
@@ -71,11 +71,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711419061,
-        "narHash": "sha256-+5M/czgYGqs/jKmi8bvYC+JUYboUKNTfkRiesXopeXQ=",
+        "lastModified": 1712715149,
+        "narHash": "sha256-uOx7GaLV+5hekAYtm/CBr627Pi7+d1Yh70hwKmVjYYo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4c11d2f698ff1149f76b69e72852d5d75f492d0c",
+        "rev": "9ef1eca23bee5fb8080863909af3802130b2ee57",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,8 @@
   description = "PostgreSQL data connector";
 
   inputs = {
-    nixpkgs.url = github:NixOS/nixpkgs;
-    flake-utils.url = github:numtide/flake-utils;
+    nixpkgs.url = "github:NixOS/nixpkgs?branch=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
 
     crane = {
       url = "github:ipetkov/crane";

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.77.0"
+channel = "1.77.2"
 profile = "default"  # see https://rust-lang.github.io/rustup/concepts/profiles.html
 components = ["rust-analyzer", "rust-src"]  # see https://rust-lang.github.io/rustup/concepts/components.html


### PR DESCRIPTION
### What

Rust v1.77.2 fixes a security flaw ([CVE-2024-24576]) in binaries built for Windows.

The ndc-postgres CLI is not vulnerable to this as it does not invoke other programs, but it seemed prudent to upgrade anyway.

### How

I edited `rust-toolchain.toml` and ran `nix flake update`.

[CVE-2024-24576]: https://nvd.nist.gov/vuln/detail/CVE-2024-24576