### PR TITLE
Separate business and exchange types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,11 +2082,6 @@ dependencies = [
 [[package]]
 name = "query-engine-metadata"
 version = "0.5.2"
-dependencies = [
- "schemars",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "query-engine-sql"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,6 +2104,7 @@ dependencies = [
  "indexmap 2.2.6",
  "insta",
  "multimap",
+ "ndc-postgres-configuration",
  "ndc-sdk",
  "query-engine-metadata",
  "query-engine-sql",

--- a/crates/configuration/src/configuration.rs
+++ b/crates/configuration/src/configuration.rs
@@ -4,13 +4,12 @@ use std::path::Path;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use tokio::fs;
 
 use query_engine_metadata::metadata;
 
 use crate::environment::Environment;
 use crate::error::Error;
-use crate::values::{ConnectionUri, IsolationLevel, PoolSettings, Secret};
+use crate::values::{IsolationLevel, PoolSettings};
 use crate::version3;
 
 pub const CONFIGURATION_FILENAME: &str = "configuration.json";
@@ -59,45 +58,6 @@ pub async fn parse_configuration(
     configuration_dir: impl AsRef<Path>,
     environment: impl Environment,
 ) -> Result<Configuration, Error> {
-    let configuration_file = configuration_dir.as_ref().join(CONFIGURATION_FILENAME);
-
-    let configuration_file_contents =
-        fs::read_to_string(&configuration_file)
-            .await
-            .map_err(|err| {
-                Error::IoErrorButStringified(format!("{}: {}", &configuration_file.display(), err))
-            })?;
-    let mut configuration: version3::RawConfiguration =
-        serde_json::from_str(&configuration_file_contents).map_err(|error| Error::ParseError {
-            file_path: configuration_file.clone(),
-            line: error.line(),
-            column: error.column(),
-            message: error.to_string(),
-        })?;
-    // look for native query sql file references and read from disk.
-    for native_query_sql in configuration.metadata.native_queries.0.values_mut() {
-        native_query_sql.sql = metadata::NativeQuerySqlEither::NativeQuerySql(
-            native_query_sql
-                .sql
-                .from_external(configuration_dir.as_ref())
-                .map_err(Error::IoErrorButStringified)?,
-        );
-    }
-    let connection_uri =
-        match configuration.connection_settings.connection_uri {
-            ConnectionUri(Secret::Plain(uri)) => Ok(uri),
-            ConnectionUri(Secret::FromEnvironment { variable }) => environment
-                .read(&variable)
-                .map_err(|error| Error::MissingEnvironmentVariable {
-                    file_path: configuration_file,
-                    message: error.to_string(),
-                }),
-        }?;
-    Ok(Configuration {
-        metadata: configuration.metadata,
-        pool_settings: configuration.connection_settings.pool_settings,
-        connection_uri,
-        isolation_level: configuration.connection_settings.isolation_level,
-        mutations_version: configuration.mutations_version,
-    })
+    // Try parsing each supported version in turn
+    version3::parse_configuration(configuration_dir, environment).await
 }

--- a/crates/configuration/src/version3/comparison.rs
+++ b/crates/configuration/src/version3/comparison.rs
@@ -1,6 +1,6 @@
 //! Helpers for the comparison operators configuration.
 
-use query_engine_metadata::metadata::database::OperatorKind;
+use super::database::OperatorKind;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/crates/configuration/src/version3/metadata/database.rs
+++ b/crates/configuration/src/version3/metadata/database.rs
@@ -1,5 +1,12 @@
 //! Metadata information regarding the database and tracked information.
 
+// This code was copied from a different place that predated the introduction of clippy to the
+// project. Therefore we disregard certain clippy lints:
+#![allow(
+    clippy::enum_variant_names,
+    clippy::upper_case_acronyms,
+    clippy::wrong_self_convention
+)]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};

--- a/crates/configuration/src/version3/metadata/database.rs
+++ b/crates/configuration/src/version3/metadata/database.rs
@@ -1,0 +1,288 @@
+//! Metadata information regarding the database and tracked information.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Map of all known composite types.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CompositeTypes(pub BTreeMap<String, CompositeType>);
+
+/// A Scalar Type.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ScalarType(pub String);
+
+/// The type of values that a column, field, or argument may take.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum Type {
+    ScalarType(ScalarType),
+    CompositeType(String),
+    ArrayType(Box<Type>),
+}
+
+/// Information about a composite type. These are very similar to tables, but with the crucial
+/// difference that composite types do not support constraints (such as NOT NULL).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CompositeType {
+    pub name: String,
+    pub fields: BTreeMap<String, FieldInfo>,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// Information about a composite type field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct FieldInfo {
+    pub name: String,
+    pub r#type: Type,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// The complete list of supported binary operators for scalar types.
+/// Not all of these are supported for every type.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ComparisonOperators(pub BTreeMap<ScalarType, BTreeMap<String, ComparisonOperator>>);
+
+/// Represents a postgres binary comparison operator
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ComparisonOperator {
+    pub operator_name: String,
+    pub operator_kind: OperatorKind,
+    pub argument_type: ScalarType,
+
+    #[serde(default = "default_true")]
+    pub is_infix: bool,
+}
+
+/// Is it a built-in operator, or a custom operator.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum OperatorKind {
+    Equal,
+    In,
+    Custom,
+}
+
+/// This is quite unfortunate: https://github.com/serde-rs/serde/issues/368
+/// TL;DR: we can't set default literals for serde, so if we want 'is_infix' to
+/// default to 'true', we have to set its default as a function that returns 'true'.
+fn default_true() -> bool {
+    true
+}
+
+/// Mapping from a "table" name to its information.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TablesInfo(pub BTreeMap<String, TableInfo>);
+
+/// Information about a database table (or any other kind of relation).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TableInfo {
+    pub schema_name: String,
+    pub table_name: String,
+    pub columns: BTreeMap<String, ColumnInfo>,
+    #[serde(default)]
+    pub uniqueness_constraints: UniquenessConstraints,
+    #[serde(default)]
+    pub foreign_relations: ForeignRelations,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// Can this column contain null values
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum Nullable {
+    #[default]
+    Nullable,
+    NonNullable,
+}
+
+/// Does this column have a default value.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum HasDefault {
+    #[default]
+    NoDefault,
+    HasDefault,
+}
+
+/// Is this column an identity column.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum IsIdentity {
+    #[default]
+    NotIdentity,
+    IdentityByDefault,
+    IdentityAlways,
+}
+
+/// Is this column a generated column.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum IsGenerated {
+    #[default]
+    NotGenerated,
+    Stored,
+}
+
+/// Information about a database column.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ColumnInfo {
+    pub name: String,
+    pub r#type: Type,
+    #[serde(default)]
+    pub nullable: Nullable,
+    #[serde(skip_serializing_if = "does_not_have_default")]
+    #[serde(default)]
+    pub has_default: HasDefault,
+    #[serde(skip_serializing_if = "is_not_identity")]
+    #[serde(default)]
+    pub is_identity: IsIdentity,
+    #[serde(skip_serializing_if = "is_not_generated")]
+    #[serde(default)]
+    pub is_generated: IsGenerated,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+fn does_not_have_default(has_default: &HasDefault) -> bool {
+    matches!(has_default, HasDefault::NoDefault)
+}
+
+fn is_not_identity(is_identity: &IsIdentity) -> bool {
+    matches!(is_identity, IsIdentity::NotIdentity)
+}
+
+fn is_not_generated(is_generated: &IsGenerated) -> bool {
+    matches!(is_generated, IsGenerated::NotGenerated)
+}
+
+/// A mapping from the name of a unique constraint to its value.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UniquenessConstraints(pub BTreeMap<String, UniquenessConstraint>);
+
+/// The set of columns that make up a uniqueness constraint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UniquenessConstraint(pub BTreeSet<String>);
+
+/// A mapping from the name of a foreign key constraint to its value.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ForeignRelations(pub BTreeMap<String, ForeignRelation>);
+
+/// A foreign key constraint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ForeignRelation {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub foreign_schema: Option<String>,
+    pub foreign_table: String,
+    pub column_mapping: BTreeMap<String, String>,
+}
+
+/// All supported aggregate functions, grouped by type.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AggregateFunctions(pub BTreeMap<ScalarType, BTreeMap<String, AggregateFunction>>);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AggregateFunction {
+    pub return_type: ScalarType,
+}
+
+/// Type representation of scalar types, grouped by type.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TypeRepresentations(pub BTreeMap<ScalarType, TypeRepresentation>);
+
+/// Type representation of a scalar type.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum TypeRepresentation {
+    /// JSON booleans
+    Boolean,
+    /// Any JSON string
+    String,
+    /// float4
+    Float32,
+    /// float8
+    Float64,
+    /// int2
+    Int16,
+    /// int4
+    Int32,
+    /// int8
+    Int64,
+    /// numeric
+    BigDecimal,
+    /// timestamp
+    Timestamp,
+    /// timestamp with timezone
+    Timestamptz,
+    /// time
+    Time,
+    /// time with timezone
+    Timetz,
+    /// date
+    Date,
+    /// uuid
+    UUID,
+    /// geography
+    Geography,
+    /// geometry
+    Geometry,
+    /// Any JSON number
+    Number,
+    /// Any JSON number, with no decimal part
+    Integer,
+    /// An arbitrary json.
+    Json,
+    /// One of the specified string values
+    Enum(Vec<String>),
+}
+
+// tests
+
+#[cfg(test)]
+mod tests {
+    use super::{ScalarType, TypeRepresentation, TypeRepresentations};
+
+    #[test]
+    fn parse_type_representations() {
+        assert_eq!(
+            serde_json::from_str::<TypeRepresentations>(
+                r#"{"int4": "integer", "card_suit": {"enum": ["hearts", "clubs", "diamonds", "spades"]}}"#
+            )
+            .unwrap(),
+            TypeRepresentations(
+                [(
+                    ScalarType("int4".to_string()),
+                    TypeRepresentation::Integer
+                ), (
+                    ScalarType("card_suit".to_string()),
+                    TypeRepresentation::Enum(vec![
+                        "hearts".into(),
+                        "clubs".into(),
+                        "diamonds".into(),
+                        "spades".into()
+                    ])
+                )]
+                .into()
+            )
+        );
+    }
+}

--- a/crates/configuration/src/version3/metadata/mod.rs
+++ b/crates/configuration/src/version3/metadata/mod.rs
@@ -4,8 +4,6 @@ pub mod database;
 pub mod mutations;
 pub mod native_queries;
 
-use std::collections::BTreeSet;
-
 // re-export without modules
 pub use database::*;
 pub use native_queries::*;
@@ -29,6 +27,4 @@ pub struct Metadata {
     pub comparison_operators: ComparisonOperators,
     #[serde(default)]
     pub type_representations: TypeRepresentations,
-    #[serde(skip)]
-    pub occurring_scalar_types: BTreeSet<ScalarType>,
 }

--- a/crates/configuration/src/version3/metadata/mod.rs
+++ b/crates/configuration/src/version3/metadata/mod.rs
@@ -1,0 +1,34 @@
+//! Metadata information regarding the database and tracked information.
+
+pub mod database;
+pub mod mutations;
+pub mod native_queries;
+
+use std::collections::BTreeSet;
+
+// re-export without modules
+pub use database::*;
+pub use native_queries::*;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Metadata information.
+#[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Metadata {
+    #[serde(default)]
+    pub tables: TablesInfo,
+    #[serde(default)]
+    pub composite_types: CompositeTypes,
+    #[serde(default)]
+    pub native_queries: NativeQueries,
+    #[serde(default)]
+    pub aggregate_functions: AggregateFunctions,
+    #[serde(default)]
+    pub comparison_operators: ComparisonOperators,
+    #[serde(default)]
+    pub type_representations: TypeRepresentations,
+    #[serde(skip)]
+    pub occurring_scalar_types: BTreeSet<ScalarType>,
+}

--- a/crates/configuration/src/version3/metadata/mutations.rs
+++ b/crates/configuration/src/version3/metadata/mutations.rs
@@ -1,0 +1,12 @@
+//! Generated mutations-related metadata information.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Which version of the generated mutations will be included in the schema
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum MutationsVersion {
+    V1,
+    VeryExperimentalWip,
+}

--- a/crates/configuration/src/version3/metadata/native_queries.rs
+++ b/crates/configuration/src/version3/metadata/native_queries.rs
@@ -1,0 +1,346 @@
+//! Metadata information regarding native queries.
+
+use super::database::*;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+
+// Types
+
+/// Metadata information of native queries.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeQueries(pub BTreeMap<String, NativeQueryInfo>);
+
+/// Information about a Native Query
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeQueryInfo {
+    /// SQL expression to use for the Native Query.
+    /// We can interpolate values using `{{variable_name}}` syntax,
+    /// such as `SELECT * FROM authors WHERE name = {{author_name}}`
+    pub sql: NativeQuerySqlEither,
+    /// Columns returned by the Native Query
+    pub columns: BTreeMap<String, ReadOnlyColumnInfo>,
+    #[serde(default)]
+    /// Names and types of arguments that can be passed to this Native Query
+    pub arguments: BTreeMap<String, ReadOnlyColumnInfo>,
+    #[serde(default)]
+    pub description: Option<String>,
+    /// True if this native query mutates the database
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default)]
+    pub is_procedure: bool,
+}
+
+/// Information about a native query column.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReadOnlyColumnInfo {
+    pub name: String,
+    pub r#type: Type,
+    #[serde(default)]
+    pub nullable: Nullable,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// This type contains information that still needs to be resolved.
+/// After deserializing, we expect the value to be "external",
+/// and after a subsequent step where we read from files,
+/// they should all be converted to NativeQuerySql.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(from = "NativeQuerySqlExternal")]
+#[serde(into = "NativeQuerySqlExternal")]
+pub enum NativeQuerySqlEither {
+    NativeQuerySql(NativeQuerySql),
+    NativeQuerySqlExternal(NativeQuerySqlExternal),
+}
+
+impl NativeQuerySqlEither {
+    /// Extract the actual native query sql from this type.
+    /// If this happens before reading a file, it will fail with an error.
+    pub fn sql(self) -> Result<NativeQueryParts, String> {
+        match self {
+            NativeQuerySqlEither::NativeQuerySql(NativeQuerySql::Inline { sql }) => Ok(sql),
+            NativeQuerySqlEither::NativeQuerySql(NativeQuerySql::FromFile { sql, .. }) => Ok(sql),
+            NativeQuerySqlEither::NativeQuerySqlExternal(NativeQuerySqlExternal::Inline {
+                inline,
+            }) => Ok(inline),
+            NativeQuerySqlEither::NativeQuerySqlExternal(
+                NativeQuerySqlExternal::InlineUntagged(inline),
+            ) => Ok(inline),
+            NativeQuerySqlEither::NativeQuerySqlExternal(NativeQuerySqlExternal::File {
+                ..
+            }) => Err("not all native query sql files were read during parsing".to_string()),
+        }
+    }
+}
+
+impl From<NativeQuerySqlExternal> for NativeQuerySqlEither {
+    /// We use this to deserialize.
+    fn from(value: NativeQuerySqlExternal) -> Self {
+        NativeQuerySqlEither::NativeQuerySqlExternal(value)
+    }
+}
+
+impl From<NativeQuerySqlEither> for NativeQuerySqlExternal {
+    /// We use this to serialize.
+    fn from(value: NativeQuerySqlEither) -> Self {
+        match value {
+            NativeQuerySqlEither::NativeQuerySqlExternal(value) => value,
+            NativeQuerySqlEither::NativeQuerySql(value) => value.into(),
+        }
+    }
+}
+
+/// A Native Query SQL after file resolution.
+/// This is the underlying type of the `NativeQuerySqlEither` variant with the same name
+/// that is expected in the metadata when translating requests. A subsequent phase after de-serializing
+/// Should convert NativeQuerySqlExternal values to values of this type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NativeQuerySql {
+    FromFile {
+        file: std::path::PathBuf,
+        sql: NativeQueryParts,
+    },
+    Inline {
+        sql: NativeQueryParts,
+    },
+}
+
+impl NativeQuerySql {
+    /// Extract the native query sql expression.
+    pub fn sql(self) -> NativeQueryParts {
+        match self {
+            NativeQuerySql::Inline { sql } => sql,
+            NativeQuerySql::FromFile { sql, .. } => sql,
+        }
+    }
+}
+
+// We use this type as an intermediate representation for serialization/deserialization
+// of native query sql location/expression.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[serde(untagged)]
+/// Native Query SQL location.
+pub enum NativeQuerySqlExternal {
+    /// Refer to an external Native Query SQL file.
+    File {
+        /// Relative path to a sql file.
+        file: std::path::PathBuf,
+    },
+    /// Inline Native Query SQL string.
+    Inline {
+        /// An inline Native Query SQL string.
+        inline: NativeQueryParts,
+    },
+    InlineUntagged(
+        /// An inline Native Query SQL string.
+        NativeQueryParts,
+    ),
+}
+
+impl NativeQuerySqlEither {
+    /// Convert an external native query sql type to NativeQuerySql,
+    /// including reading files from disk.
+    pub fn from_external(
+        &self,
+        absolute_configuration_directory: &std::path::Path,
+    ) -> Result<NativeQuerySql, String> {
+        match self {
+            // unexpected we get this, but ok.
+            NativeQuerySqlEither::NativeQuerySql(value) => Ok(value.clone()),
+            NativeQuerySqlEither::NativeQuerySqlExternal(external) => match external {
+                NativeQuerySqlExternal::File { file } => {
+                    parse_native_query_from_file(absolute_configuration_directory.join(file))
+                }
+                NativeQuerySqlExternal::Inline { inline } => Ok(NativeQuerySql::Inline {
+                    sql: inline.clone(),
+                }),
+                NativeQuerySqlExternal::InlineUntagged(inline) => Ok(NativeQuerySql::Inline {
+                    sql: inline.clone(),
+                }),
+            },
+        }
+    }
+}
+
+impl From<NativeQuerySql> for NativeQuerySqlExternal {
+    /// used for deserialization.
+    fn from(value: NativeQuerySql) -> Self {
+        match value {
+            NativeQuerySql::Inline { sql } => NativeQuerySqlExternal::Inline { inline: sql },
+            NativeQuerySql::FromFile { file, .. } => NativeQuerySqlExternal::File { file },
+        }
+    }
+}
+
+impl JsonSchema for NativeQuerySqlEither {
+    fn schema_name() -> String {
+        "NativeQuerySql".to_string()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        NativeQuerySqlExternal::json_schema(gen)
+    }
+}
+
+/// A part of a Native Query text, either raw text or a parameter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NativeQueryPart {
+    /// A raw text part
+    Text(String),
+    /// A parameter
+    Parameter(String),
+}
+
+/// A Native Query SQL parts after parsing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "String")]
+#[serde(into = "String")]
+pub struct NativeQueryParts(pub Vec<NativeQueryPart>);
+
+impl From<String> for NativeQueryParts {
+    /// Used for de-serialization.
+    fn from(value: String) -> Self {
+        parse_native_query(&value)
+    }
+}
+
+impl From<NativeQueryParts> for String {
+    /// Used for serialization.
+    fn from(value: NativeQueryParts) -> Self {
+        let mut sql: String = String::new();
+        for part in value.0.iter() {
+            match part {
+                NativeQueryPart::Text(text) => sql.push_str(text.as_str()),
+                NativeQueryPart::Parameter(param) => {
+                    sql.push_str(format!("{{{{{}}}}}", param).as_str())
+                }
+            }
+        }
+        sql
+    }
+}
+
+impl JsonSchema for NativeQueryParts {
+    fn schema_name() -> String {
+        "InlineNativeQuerySql".to_string()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(gen)
+    }
+}
+
+// Parsing
+
+/// Read a file a parse it into native query parts.
+pub fn parse_native_query_from_file(file: std::path::PathBuf) -> Result<NativeQuerySql, String> {
+    let contents: String = match fs::read_to_string(&file) {
+        Ok(ok) => Ok(ok),
+        Err(err) => Err(format!("{}: {}", &file.display(), err)),
+    }?;
+    let sql = parse_native_query(&contents);
+    Ok(NativeQuerySql::FromFile { file, sql })
+}
+
+/// Parse a native query into parts where variables have the syntax `{{<variable>}}`.
+fn parse_native_query(string: &str) -> NativeQueryParts {
+    let vec: Vec<Vec<NativeQueryPart>> = string
+        .split("{{")
+        .map(|part| match part.split_once("}}") {
+            None => vec![NativeQueryPart::Text(part.to_string())],
+            Some((var, text)) => {
+                if text.is_empty() {
+                    vec![NativeQueryPart::Parameter(var.to_string())]
+                } else {
+                    vec![
+                        NativeQueryPart::Parameter(var.to_string()),
+                        NativeQueryPart::Text(text.to_string()),
+                    ]
+                }
+            }
+        })
+        .collect();
+    NativeQueryParts(vec.concat())
+}
+
+// tests
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_native_query, NativeQueryPart, NativeQueryParts, NativeQuerySqlExternal};
+
+    #[test]
+    fn no_parameters() {
+        assert_eq!(
+            parse_native_query("select 1"),
+            NativeQueryParts(vec![NativeQueryPart::Text("select 1".to_string())])
+        );
+    }
+
+    #[test]
+    fn one_parameter() {
+        assert_eq!(
+            parse_native_query("select * from t where {{name}} = name"),
+            NativeQueryParts(vec![
+                NativeQueryPart::Text("select * from t where ".to_string()),
+                NativeQueryPart::Parameter("name".to_string()),
+                NativeQueryPart::Text(" = name".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn multiple_parameters() {
+        assert_eq!(
+            parse_native_query("select * from t where id = {{id}} and {{name}} = {{other_name}}"),
+            NativeQueryParts(vec![
+                NativeQueryPart::Text("select * from t where id = ".to_string()),
+                NativeQueryPart::Parameter("id".to_string()),
+                NativeQueryPart::Text(" and ".to_string()),
+                NativeQueryPart::Parameter("name".to_string()),
+                NativeQueryPart::Text(" = ".to_string()),
+                NativeQueryPart::Parameter("other_name".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn one_parameter_and_curly_text() {
+        assert_eq!(
+            parse_native_query("select * from t where {{name}} = '{name}'"),
+            NativeQueryParts(vec![
+                NativeQueryPart::Text("select * from t where ".to_string()),
+                NativeQueryPart::Parameter("name".to_string()),
+                NativeQueryPart::Text(" = '{name}'".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn parse_inline_untagged() {
+        assert_eq!(
+            serde_json::from_str::<NativeQuerySqlExternal>(r#""select 1""#).unwrap(),
+            NativeQuerySqlExternal::InlineUntagged(NativeQueryParts(vec![NativeQueryPart::Text(
+                "select 1".to_string()
+            )]))
+        );
+    }
+
+    #[test]
+    fn parse_inline_tagged() {
+        assert_eq!(
+            serde_json::from_str::<NativeQuerySqlExternal>(r#"{ "inline": "select 1" }"#).unwrap(),
+            NativeQuerySqlExternal::Inline {
+                inline: NativeQueryParts(vec![NativeQueryPart::Text("select 1".to_string())])
+            }
+        );
+    }
+}

--- a/crates/configuration/src/version3/metadata/native_queries.rs
+++ b/crates/configuration/src/version3/metadata/native_queries.rs
@@ -1,5 +1,8 @@
 //! Metadata information regarding native queries.
 
+// This code was copied from a different place that predated the introduction of clippy to the
+// project. Therefore we disregard certain clippy lints:
+#![allow(clippy::wrong_self_convention)]
 use super::database::*;
 
 use schemars::JsonSchema;

--- a/crates/configuration/src/version3/mod.rs
+++ b/crates/configuration/src/version3/mod.rs
@@ -2,6 +2,7 @@
 
 mod comparison;
 pub mod connection_settings;
+mod metadata;
 mod options;
 
 use std::borrow::Cow;
@@ -15,8 +16,7 @@ use sqlx::{Connection, Executor, Row};
 use tokio::fs;
 use tracing::{info_span, Instrument};
 
-use query_engine_metadata::metadata;
-use query_engine_metadata::metadata::database;
+use metadata::database;
 
 use crate::environment::Environment;
 use crate::error::Error;
@@ -528,10 +528,20 @@ pub async fn parse_configuration(
                 }),
         }?;
     Ok(crate::Configuration {
-        metadata: configuration.metadata,
+        metadata: interpret_metadata(configuration.metadata),
         pool_settings: configuration.connection_settings.pool_settings,
         connection_uri,
         isolation_level: configuration.connection_settings.isolation_level,
-        mutations_version: configuration.mutations_version,
+        mutations_version: interpret_mutations_version(configuration.mutations_version),
     })
+}
+
+fn interpret_metadata(_metadata: metadata::Metadata) -> query_engine_metadata::metadata::Metadata {
+    todo!()
+}
+
+fn interpret_mutations_version(
+    _metadata: Option<metadata::mutations::MutationsVersion>,
+) -> Option<query_engine_metadata::metadata::mutations::MutationsVersion> {
+    todo!()
 }

--- a/crates/configuration/src/version3/mod.rs
+++ b/crates/configuration/src/version3/mod.rs
@@ -619,12 +619,12 @@ fn convert_read_only_column_info(
     query_engine_metadata::metadata::ReadOnlyColumnInfo {
         name: read_only_column_info.name,
         r#type: convert_type(read_only_column_info.r#type),
-        nullable: convert_nullable(read_only_column_info.nullable),
+        nullable: convert_nullable(&read_only_column_info.nullable),
         description: read_only_column_info.description,
     }
 }
 
-fn convert_nullable(nullable: metadata::Nullable) -> query_engine_metadata::metadata::Nullable {
+fn convert_nullable(nullable: &metadata::Nullable) -> query_engine_metadata::metadata::Nullable {
     match nullable {
         metadata::Nullable::Nullable => query_engine_metadata::metadata::Nullable::Nullable,
         metadata::Nullable::NonNullable => query_engine_metadata::metadata::Nullable::NonNullable,
@@ -833,14 +833,14 @@ fn convert_comparison_operator(
 ) -> query_engine_metadata::metadata::ComparisonOperator {
     query_engine_metadata::metadata::ComparisonOperator {
         operator_name: comparison_operator.operator_name,
-        operator_kind: convert_operator_kind(comparison_operator.operator_kind),
+        operator_kind: convert_operator_kind(&comparison_operator.operator_kind),
         argument_type: convert_scalar_type(comparison_operator.argument_type),
         is_infix: comparison_operator.is_infix,
     }
 }
 
 fn convert_operator_kind(
-    operator_kind: metadata::OperatorKind,
+    operator_kind: &metadata::OperatorKind,
 ) -> query_engine_metadata::metadata::OperatorKind {
     match operator_kind {
         metadata::OperatorKind::Equal => query_engine_metadata::metadata::OperatorKind::Equal,
@@ -960,16 +960,16 @@ fn convert_column_info(
     query_engine_metadata::metadata::ColumnInfo {
         name: column_info.name,
         r#type: convert_type(column_info.r#type),
-        nullable: convert_nullable(column_info.nullable),
-        has_default: convert_has_default(column_info.has_default),
-        is_identity: convert_is_identity(column_info.is_identity),
-        is_generated: convert_is_generated(column_info.is_generated),
+        nullable: convert_nullable(&column_info.nullable),
+        has_default: convert_has_default(&column_info.has_default),
+        is_identity: convert_is_identity(&column_info.is_identity),
+        is_generated: convert_is_generated(&column_info.is_generated),
         description: column_info.description,
     }
 }
 
 fn convert_is_generated(
-    is_generated: metadata::IsGenerated,
+    is_generated: &metadata::IsGenerated,
 ) -> query_engine_metadata::metadata::IsGenerated {
     match is_generated {
         metadata::IsGenerated::NotGenerated => {
@@ -980,7 +980,7 @@ fn convert_is_generated(
 }
 
 fn convert_is_identity(
-    is_identity: metadata::IsIdentity,
+    is_identity: &metadata::IsIdentity,
 ) -> query_engine_metadata::metadata::IsIdentity {
     match is_identity {
         metadata::IsIdentity::NotIdentity => {
@@ -996,7 +996,7 @@ fn convert_is_identity(
 }
 
 fn convert_has_default(
-    has_default: metadata::HasDefault,
+    has_default: &metadata::HasDefault,
 ) -> query_engine_metadata::metadata::HasDefault {
     match has_default {
         metadata::HasDefault::NoDefault => query_engine_metadata::metadata::HasDefault::NoDefault,

--- a/crates/configuration/src/version3/mod.rs
+++ b/crates/configuration/src/version3/mod.rs
@@ -501,22 +501,6 @@ pub async fn parse_configuration(
         );
     }
 
-    let (scalar_types, composite_types) = transitively_occurring_types(
-        occurring_scalar_types(
-            &configuration.metadata.tables,
-            &configuration.metadata.native_queries,
-            &configuration.metadata.aggregate_functions,
-        ),
-        &occurring_composite_types(
-            &configuration.metadata.tables,
-            &configuration.metadata.native_queries,
-        ),
-        configuration.metadata.composite_types,
-    );
-
-    configuration.metadata.occurring_scalar_types = scalar_types;
-    configuration.metadata.composite_types = composite_types;
-
     let connection_uri =
         match configuration.connection_settings.connection_uri {
             ConnectionUri(Secret::Plain(uri)) => Ok(uri),
@@ -528,20 +512,507 @@ pub async fn parse_configuration(
                 }),
         }?;
     Ok(crate::Configuration {
-        metadata: interpret_metadata(configuration.metadata),
+        metadata: convert_metadata(configuration.metadata),
         pool_settings: configuration.connection_settings.pool_settings,
         connection_uri,
         isolation_level: configuration.connection_settings.isolation_level,
-        mutations_version: interpret_mutations_version(configuration.mutations_version),
+        mutations_version: convert_mutations_version(configuration.mutations_version),
     })
 }
 
-fn interpret_metadata(_metadata: metadata::Metadata) -> query_engine_metadata::metadata::Metadata {
-    todo!()
+fn convert_metadata(metadata: metadata::Metadata) -> query_engine_metadata::metadata::Metadata {
+    let (scalar_types, composite_types) = transitively_occurring_types(
+        occurring_scalar_types(
+            &metadata.tables,
+            &metadata.native_queries,
+            &metadata.aggregate_functions,
+        ),
+        &occurring_composite_types(&metadata.tables, &metadata.native_queries),
+        metadata.composite_types,
+    );
+
+    query_engine_metadata::metadata::Metadata {
+        tables: convert_tables(metadata.tables),
+        composite_types: convert_composite_types(composite_types),
+        native_queries: convert_native_queries(metadata.native_queries),
+        aggregate_functions: convert_aggregate_functions(metadata.aggregate_functions),
+        comparison_operators: convert_comparison_operators(metadata.comparison_operators),
+        type_representations: convert_type_representations(metadata.type_representations),
+        occurring_scalar_types: convert_scalar_types(scalar_types),
+    }
 }
 
-fn interpret_mutations_version(
-    _metadata: Option<metadata::mutations::MutationsVersion>,
+fn convert_scalar_types(
+    scalar_types: BTreeSet<metadata::ScalarType>,
+) -> BTreeSet<query_engine_metadata::metadata::ScalarType> {
+    scalar_types.into_iter().map(convert_scalar_type).collect()
+}
+
+fn convert_scalar_type(
+    scalar_type: metadata::ScalarType,
+) -> query_engine_metadata::metadata::ScalarType {
+    query_engine_metadata::metadata::ScalarType(scalar_type.0)
+}
+
+fn convert_aggregate_functions(
+    aggregate_functions: metadata::AggregateFunctions,
+) -> query_engine_metadata::metadata::AggregateFunctions {
+    let res = aggregate_functions
+        .0
+        .into_iter()
+        .map(|(k, v)| {
+            (
+                convert_scalar_type(k),
+                v.into_iter()
+                    .map(|(k, v)| (k, convert_aggregate_function(v)))
+                    .collect(),
+            )
+        })
+        .collect();
+
+    query_engine_metadata::metadata::AggregateFunctions(res)
+}
+
+fn convert_aggregate_function(
+    aggregate_function: metadata::AggregateFunction,
+) -> query_engine_metadata::metadata::AggregateFunction {
+    query_engine_metadata::metadata::AggregateFunction {
+        return_type: convert_scalar_type(aggregate_function.return_type),
+    }
+}
+
+fn convert_native_queries(
+    native_queries: metadata::NativeQueries,
+) -> query_engine_metadata::metadata::NativeQueries {
+    query_engine_metadata::metadata::NativeQueries(
+        native_queries
+            .0
+            .into_iter()
+            .map(|(k, v)| (k, convert_native_query_info(v)))
+            .collect(),
+    )
+}
+
+fn convert_native_query_info(
+    native_query_info: metadata::NativeQueryInfo,
+) -> query_engine_metadata::metadata::NativeQueryInfo {
+    query_engine_metadata::metadata::NativeQueryInfo {
+        sql: convert_native_query_sql_either(native_query_info.sql),
+        columns: native_query_info
+            .columns
+            .into_iter()
+            .map(|(k, v)| (k, convert_read_only_column_info(v)))
+            .collect(),
+        arguments: native_query_info
+            .arguments
+            .into_iter()
+            .map(|(k, v)| (k, convert_read_only_column_info(v)))
+            .collect(),
+        description: native_query_info.description,
+        is_procedure: native_query_info.is_procedure,
+    }
+}
+
+fn convert_read_only_column_info(
+    read_only_column_info: metadata::ReadOnlyColumnInfo,
+) -> query_engine_metadata::metadata::ReadOnlyColumnInfo {
+    query_engine_metadata::metadata::ReadOnlyColumnInfo {
+        name: read_only_column_info.name,
+        r#type: convert_type(read_only_column_info.r#type),
+        nullable: convert_nullable(read_only_column_info.nullable),
+        description: read_only_column_info.description,
+    }
+}
+
+fn convert_nullable(nullable: metadata::Nullable) -> query_engine_metadata::metadata::Nullable {
+    match nullable {
+        metadata::Nullable::Nullable => query_engine_metadata::metadata::Nullable::Nullable,
+        metadata::Nullable::NonNullable => query_engine_metadata::metadata::Nullable::NonNullable,
+    }
+}
+
+fn convert_type(r#type: metadata::Type) -> query_engine_metadata::metadata::Type {
+    match r#type {
+        metadata::Type::ScalarType(t) => {
+            query_engine_metadata::metadata::Type::ScalarType(convert_scalar_type(t))
+        }
+        metadata::Type::CompositeType(t) => query_engine_metadata::metadata::Type::CompositeType(t),
+        metadata::Type::ArrayType(t) => {
+            query_engine_metadata::metadata::Type::ArrayType(Box::new(convert_type(*t)))
+        }
+    }
+}
+
+fn convert_native_query_sql_either(
+    sql: metadata::NativeQuerySqlEither,
+) -> query_engine_metadata::metadata::NativeQuerySqlEither {
+    match sql {
+        metadata::NativeQuerySqlEither::NativeQuerySql(internal_sql) => {
+            query_engine_metadata::metadata::NativeQuerySqlEither::NativeQuerySql(
+                convert_native_query_sql_internal(internal_sql),
+            )
+        }
+        metadata::NativeQuerySqlEither::NativeQuerySqlExternal(external_sql) => {
+            query_engine_metadata::metadata::NativeQuerySqlEither::NativeQuerySqlExternal(
+                convert_native_query_sql_external(external_sql),
+            )
+        }
+    }
+}
+
+fn convert_native_query_sql_internal(
+    internal_sql: metadata::NativeQuerySql,
+) -> query_engine_metadata::metadata::NativeQuerySql {
+    match internal_sql {
+        metadata::NativeQuerySql::FromFile { file, sql } => {
+            query_engine_metadata::metadata::NativeQuerySql::FromFile {
+                file,
+                sql: convert_native_query_parts(sql),
+            }
+        }
+        metadata::NativeQuerySql::Inline { sql } => {
+            query_engine_metadata::metadata::NativeQuerySql::Inline {
+                sql: convert_native_query_parts(sql),
+            }
+        }
+    }
+}
+
+fn convert_native_query_sql_external(
+    external_sql: metadata::NativeQuerySqlExternal,
+) -> query_engine_metadata::metadata::NativeQuerySqlExternal {
+    match external_sql {
+        metadata::NativeQuerySqlExternal::File { file } => {
+            query_engine_metadata::metadata::NativeQuerySqlExternal::File { file }
+        }
+        metadata::NativeQuerySqlExternal::Inline { inline } => {
+            query_engine_metadata::metadata::NativeQuerySqlExternal::Inline {
+                inline: convert_native_query_parts(inline),
+            }
+        }
+        metadata::NativeQuerySqlExternal::InlineUntagged(parts) => {
+            query_engine_metadata::metadata::NativeQuerySqlExternal::InlineUntagged(
+                convert_native_query_parts(parts),
+            )
+        }
+    }
+}
+
+fn convert_native_query_parts(
+    inline: metadata::NativeQueryParts,
+) -> query_engine_metadata::metadata::NativeQueryParts {
+    query_engine_metadata::metadata::NativeQueryParts(
+        inline
+            .0
+            .into_iter()
+            .map(convert_native_query_part)
+            .collect(),
+    )
+}
+
+fn convert_native_query_part(
+    native_query_part: metadata::NativeQueryPart,
+) -> query_engine_metadata::metadata::NativeQueryPart {
+    match native_query_part {
+        metadata::NativeQueryPart::Text(t) => {
+            query_engine_metadata::metadata::NativeQueryPart::Text(t)
+        }
+        metadata::NativeQueryPart::Parameter(p) => {
+            query_engine_metadata::metadata::NativeQueryPart::Parameter(p)
+        }
+    }
+}
+
+fn convert_type_representations(
+    type_representations: metadata::TypeRepresentations,
+) -> query_engine_metadata::metadata::TypeRepresentations {
+    query_engine_metadata::metadata::TypeRepresentations(
+        type_representations
+            .0
+            .into_iter()
+            .map(|(k, type_representation)| {
+                (
+                    convert_scalar_type(k),
+                    convert_type_representation(type_representation),
+                )
+            })
+            .collect(),
+    )
+}
+
+fn convert_type_representation(
+    type_representation: metadata::TypeRepresentation,
+) -> query_engine_metadata::metadata::TypeRepresentation {
+    match type_representation {
+        metadata::TypeRepresentation::Boolean => {
+            query_engine_metadata::metadata::TypeRepresentation::Boolean
+        }
+        metadata::TypeRepresentation::String => {
+            query_engine_metadata::metadata::TypeRepresentation::String
+        }
+        metadata::TypeRepresentation::Float32 => {
+            query_engine_metadata::metadata::TypeRepresentation::Float32
+        }
+        metadata::TypeRepresentation::Float64 => {
+            query_engine_metadata::metadata::TypeRepresentation::Float64
+        }
+        metadata::TypeRepresentation::Int16 => {
+            query_engine_metadata::metadata::TypeRepresentation::Int16
+        }
+        metadata::TypeRepresentation::Int32 => {
+            query_engine_metadata::metadata::TypeRepresentation::Int32
+        }
+        metadata::TypeRepresentation::Int64 => {
+            query_engine_metadata::metadata::TypeRepresentation::Int64
+        }
+        metadata::TypeRepresentation::BigDecimal => {
+            query_engine_metadata::metadata::TypeRepresentation::BigDecimal
+        }
+        metadata::TypeRepresentation::Timestamp => {
+            query_engine_metadata::metadata::TypeRepresentation::Timestamp
+        }
+        metadata::TypeRepresentation::Timestamptz => {
+            query_engine_metadata::metadata::TypeRepresentation::Timestamptz
+        }
+        metadata::TypeRepresentation::Time => {
+            query_engine_metadata::metadata::TypeRepresentation::Time
+        }
+        metadata::TypeRepresentation::Timetz => {
+            query_engine_metadata::metadata::TypeRepresentation::Timetz
+        }
+        metadata::TypeRepresentation::Date => {
+            query_engine_metadata::metadata::TypeRepresentation::Date
+        }
+        metadata::TypeRepresentation::UUID => {
+            query_engine_metadata::metadata::TypeRepresentation::UUID
+        }
+        metadata::TypeRepresentation::Geography => {
+            query_engine_metadata::metadata::TypeRepresentation::Geography
+        }
+        metadata::TypeRepresentation::Geometry => {
+            query_engine_metadata::metadata::TypeRepresentation::Geometry
+        }
+        metadata::TypeRepresentation::Number => {
+            query_engine_metadata::metadata::TypeRepresentation::Number
+        }
+        metadata::TypeRepresentation::Integer => {
+            query_engine_metadata::metadata::TypeRepresentation::Integer
+        }
+        metadata::TypeRepresentation::Json => {
+            query_engine_metadata::metadata::TypeRepresentation::Json
+        }
+        metadata::TypeRepresentation::Enum(v) => {
+            query_engine_metadata::metadata::TypeRepresentation::Enum(v)
+        }
+    }
+}
+
+fn convert_comparison_operators(
+    comparison_operators: metadata::ComparisonOperators,
+) -> query_engine_metadata::metadata::ComparisonOperators {
+    query_engine_metadata::metadata::ComparisonOperators(
+        comparison_operators
+            .0
+            .into_iter()
+            .map(|(k, v)| {
+                (
+                    convert_scalar_type(k),
+                    v.into_iter()
+                        .map(|(k, comparison_operator)| {
+                            (k, convert_comparison_operator(comparison_operator))
+                        })
+                        .collect(),
+                )
+            })
+            .collect(),
+    )
+}
+
+fn convert_comparison_operator(
+    comparison_operator: metadata::ComparisonOperator,
+) -> query_engine_metadata::metadata::ComparisonOperator {
+    query_engine_metadata::metadata::ComparisonOperator {
+        operator_name: comparison_operator.operator_name,
+        operator_kind: convert_operator_kind(comparison_operator.operator_kind),
+        argument_type: convert_scalar_type(comparison_operator.argument_type),
+        is_infix: comparison_operator.is_infix,
+    }
+}
+
+fn convert_operator_kind(
+    operator_kind: metadata::OperatorKind,
+) -> query_engine_metadata::metadata::OperatorKind {
+    match operator_kind {
+        metadata::OperatorKind::Equal => query_engine_metadata::metadata::OperatorKind::Equal,
+        metadata::OperatorKind::In => query_engine_metadata::metadata::OperatorKind::In,
+        metadata::OperatorKind::Custom => query_engine_metadata::metadata::OperatorKind::Custom,
+    }
+}
+
+fn convert_composite_types(
+    composite_types: metadata::CompositeTypes,
+) -> query_engine_metadata::metadata::CompositeTypes {
+    query_engine_metadata::metadata::CompositeTypes(
+        composite_types
+            .0
+            .into_iter()
+            .map(|(k, composite_type)| (k, convert_composite_type(composite_type)))
+            .collect(),
+    )
+}
+
+fn convert_composite_type(
+    composite_type: metadata::CompositeType,
+) -> query_engine_metadata::metadata::CompositeType {
+    query_engine_metadata::metadata::CompositeType {
+        name: composite_type.name,
+        fields: composite_type
+            .fields
+            .into_iter()
+            .map(|(k, field)| (k, convert_composite_type_field_info(field)))
+            .collect(),
+        description: composite_type.description,
+    }
+}
+
+fn convert_composite_type_field_info(
+    field: metadata::FieldInfo,
+) -> query_engine_metadata::metadata::FieldInfo {
+    query_engine_metadata::metadata::FieldInfo {
+        name: field.name,
+        r#type: convert_type(field.r#type),
+        description: field.description,
+    }
+}
+
+fn convert_tables(tables: metadata::TablesInfo) -> query_engine_metadata::metadata::TablesInfo {
+    query_engine_metadata::metadata::TablesInfo(
+        tables
+            .0
+            .into_iter()
+            .map(|(k, table_info)| (k, convert_table_info(table_info)))
+            .collect(),
+    )
+}
+
+fn convert_table_info(
+    table_info: metadata::TableInfo,
+) -> query_engine_metadata::metadata::TableInfo {
+    query_engine_metadata::metadata::TableInfo {
+        schema_name: table_info.schema_name,
+        table_name: table_info.table_name,
+        columns: table_info
+            .columns
+            .into_iter()
+            .map(|(k, column_info)| (k, convert_column_info(column_info)))
+            .collect(),
+        uniqueness_constraints: convert_uniqueness_constraints(table_info.uniqueness_constraints),
+        foreign_relations: convert_foreign_relations(table_info.foreign_relations),
+        description: table_info.description,
+    }
+}
+
+fn convert_foreign_relations(
+    foreign_relations: metadata::ForeignRelations,
+) -> query_engine_metadata::metadata::ForeignRelations {
+    query_engine_metadata::metadata::ForeignRelations(
+        foreign_relations
+            .0
+            .into_iter()
+            .map(|(k, foreign_relation)| (k, convert_foreign_relation(foreign_relation)))
+            .collect(),
+    )
+}
+
+fn convert_foreign_relation(
+    foreign_relation: metadata::ForeignRelation,
+) -> query_engine_metadata::metadata::ForeignRelation {
+    query_engine_metadata::metadata::ForeignRelation {
+        foreign_schema: foreign_relation.foreign_schema,
+        foreign_table: foreign_relation.foreign_table,
+        column_mapping: foreign_relation.column_mapping,
+    }
+}
+
+fn convert_uniqueness_constraints(
+    uniqueness_constraints: metadata::UniquenessConstraints,
+) -> query_engine_metadata::metadata::UniquenessConstraints {
+    query_engine_metadata::metadata::UniquenessConstraints(
+        uniqueness_constraints
+            .0
+            .into_iter()
+            .map(|(k, uniqueness_constraint)| {
+                (k, convert_uniqueness_constraint(uniqueness_constraint))
+            })
+            .collect(),
+    )
+}
+
+fn convert_uniqueness_constraint(
+    uniqueness_constraint: metadata::UniquenessConstraint,
+) -> query_engine_metadata::metadata::UniquenessConstraint {
+    query_engine_metadata::metadata::UniquenessConstraint(uniqueness_constraint.0)
+}
+
+fn convert_column_info(
+    column_info: metadata::ColumnInfo,
+) -> query_engine_metadata::metadata::ColumnInfo {
+    query_engine_metadata::metadata::ColumnInfo {
+        name: column_info.name,
+        r#type: convert_type(column_info.r#type),
+        nullable: convert_nullable(column_info.nullable),
+        has_default: convert_has_default(column_info.has_default),
+        is_identity: convert_is_identity(column_info.is_identity),
+        is_generated: convert_is_generated(column_info.is_generated),
+        description: column_info.description,
+    }
+}
+
+fn convert_is_generated(
+    is_generated: metadata::IsGenerated,
+) -> query_engine_metadata::metadata::IsGenerated {
+    match is_generated {
+        metadata::IsGenerated::NotGenerated => {
+            query_engine_metadata::metadata::IsGenerated::NotGenerated
+        }
+        metadata::IsGenerated::Stored => query_engine_metadata::metadata::IsGenerated::Stored,
+    }
+}
+
+fn convert_is_identity(
+    is_identity: metadata::IsIdentity,
+) -> query_engine_metadata::metadata::IsIdentity {
+    match is_identity {
+        metadata::IsIdentity::NotIdentity => {
+            query_engine_metadata::metadata::IsIdentity::NotIdentity
+        }
+        metadata::IsIdentity::IdentityByDefault => {
+            query_engine_metadata::metadata::IsIdentity::IdentityByDefault
+        }
+        metadata::IsIdentity::IdentityAlways => {
+            query_engine_metadata::metadata::IsIdentity::IdentityAlways
+        }
+    }
+}
+
+fn convert_has_default(
+    has_default: metadata::HasDefault,
+) -> query_engine_metadata::metadata::HasDefault {
+    match has_default {
+        metadata::HasDefault::NoDefault => query_engine_metadata::metadata::HasDefault::NoDefault,
+        metadata::HasDefault::HasDefault => query_engine_metadata::metadata::HasDefault::HasDefault,
+    }
+}
+
+fn convert_mutations_version(
+    mutations_version_opt: Option<metadata::mutations::MutationsVersion>,
 ) -> Option<query_engine_metadata::metadata::mutations::MutationsVersion> {
-    todo!()
+    mutations_version_opt.map(|mutations_version| match mutations_version {
+        metadata::mutations::MutationsVersion::V1 => {
+            query_engine_metadata::metadata::mutations::MutationsVersion::V1
+        }
+        metadata::mutations::MutationsVersion::VeryExperimentalWip => {
+            query_engine_metadata::metadata::mutations::MutationsVersion::VeryExperimentalWip
+        }
+    })
 }

--- a/crates/configuration/src/version3/mod.rs
+++ b/crates/configuration/src/version3/mod.rs
@@ -190,7 +190,6 @@ pub async fn introspect(
             comparison_operators: relevant_comparison_operators,
             composite_types,
             type_representations: relevant_type_representations,
-            occurring_scalar_types: scalar_types,
         },
         introspection_options: args.introspection_options,
         mutations_version: args.mutations_version,

--- a/crates/configuration/src/version3/mod.rs
+++ b/crates/configuration/src/version3/mod.rs
@@ -189,6 +189,7 @@ pub async fn introspect(
             comparison_operators: relevant_comparison_operators,
             composite_types,
             type_representations: relevant_type_representations,
+            occurring_scalar_types: scalar_types,
         },
         introspection_options: args.introspection_options,
         mutations_version: args.mutations_version,

--- a/crates/configuration/src/version3/mod.rs
+++ b/crates/configuration/src/version3/mod.rs
@@ -519,7 +519,8 @@ pub async fn parse_configuration(
     })
 }
 
-fn convert_metadata(metadata: metadata::Metadata) -> query_engine_metadata::metadata::Metadata {
+// This function is used by tests as well
+pub fn convert_metadata(metadata: metadata::Metadata) -> query_engine_metadata::metadata::Metadata {
     let (scalar_types, composite_types) = transitively_occurring_types(
         occurring_scalar_types(
             &metadata.tables,
@@ -884,7 +885,7 @@ fn convert_composite_type_field_info(
     }
 }
 
-fn convert_tables(tables: metadata::TablesInfo) -> query_engine_metadata::metadata::TablesInfo {
+pub fn convert_tables(tables: metadata::TablesInfo) -> query_engine_metadata::metadata::TablesInfo {
     query_engine_metadata::metadata::TablesInfo(
         tables
             .0

--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -20,13 +20,9 @@ pub async fn get_schema(
     config: &configuration::Configuration,
 ) -> Result<models::SchemaResponse, connector::SchemaError> {
     let metadata = &config.metadata;
-    let mut scalar_types: BTreeMap<String, models::ScalarType> =
-        configuration::occurring_scalar_types(
-            &metadata.tables,
-            &metadata.native_queries,
-            &metadata.aggregate_functions,
-        )
-        .into_iter()
+    let mut scalar_types: BTreeMap<String, models::ScalarType> = metadata
+        .occurring_scalar_types
+        .iter()
         .map(|scalar_type| {
             let result = models::ScalarType {
                 representation: metadata
@@ -79,7 +75,7 @@ pub async fn get_schema(
                     })
                     .collect(),
             };
-            (scalar_type.0, result)
+            (scalar_type.0.clone(), result)
         })
         .collect();
 

--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -28,12 +28,12 @@ pub async fn get_schema(
                 representation: metadata
                     .type_representations
                     .0
-                    .get(&scalar_type)
+                    .get(scalar_type)
                     .map(map_type_representation),
                 aggregate_functions: metadata
                     .aggregate_functions
                     .0
-                    .get(&scalar_type)
+                    .get(scalar_type)
                     .unwrap_or(&BTreeMap::new())
                     .iter()
                     .map(|(function_name, function_definition)| {
@@ -50,7 +50,7 @@ pub async fn get_schema(
                 comparison_operators: metadata
                     .comparison_operators
                     .0
-                    .get(&scalar_type)
+                    .get(scalar_type)
                     .unwrap_or(&BTreeMap::new())
                     .iter()
                     .map(|(op_name, op_def)| {

--- a/crates/query-engine/metadata/Cargo.toml
+++ b/crates/query-engine/metadata/Cargo.toml
@@ -6,10 +6,3 @@ license.workspace = true
 
 [lints]
 workspace = true
-
-[dependencies]
-schemars = { version = "0.8.16", features = ["smol_str"] }
-serde = { version = "1.0.197", features = ["derive"] }
-
-[dev-dependencies]
-serde_json = "1.0.115"

--- a/crates/query-engine/metadata/src/metadata/database.rs
+++ b/crates/query-engine/metadata/src/metadata/database.rs
@@ -1,22 +1,20 @@
 //! Metadata information regarding the database and tracked information.
 
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
 /// Map of all known composite types.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+
 pub struct CompositeTypes(pub BTreeMap<String, CompositeType>);
 
 /// A Scalar Type.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+
 pub struct ScalarType(pub String);
 
 /// The type of values that a column, field, or argument may take.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+
 pub enum Type {
     ScalarType(ScalarType),
     CompositeType(String),
@@ -25,82 +23,74 @@ pub enum Type {
 
 /// Information about a composite type. These are very similar to tables, but with the crucial
 /// difference that composite types do not support constraints (such as NOT NULL).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+
 pub struct CompositeType {
     pub name: String,
     pub fields: BTreeMap<String, FieldInfo>,
-    #[serde(default)]
+
     pub description: Option<String>,
 }
 
 /// Information about a composite type field.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+
 pub struct FieldInfo {
     pub name: String,
     pub r#type: Type,
-    #[serde(default)]
+
     pub description: Option<String>,
 }
 
 /// The complete list of supported binary operators for scalar types.
 /// Not all of these are supported for every type.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+
 pub struct ComparisonOperators(pub BTreeMap<ScalarType, BTreeMap<String, ComparisonOperator>>);
 
 /// Represents a postgres binary comparison operator
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+
 pub struct ComparisonOperator {
     pub operator_name: String,
     pub operator_kind: OperatorKind,
     pub argument_type: ScalarType,
 
-    #[serde(default = "default_true")]
     pub is_infix: bool,
 }
 
 /// Is it a built-in operator, or a custom operator.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+
 pub enum OperatorKind {
     Equal,
     In,
     Custom,
 }
 
-/// This is quite unfortunate: https://github.com/serde-rs/serde/issues/368
-/// TL;DR: we can't set default literals for serde, so if we want 'is_infix' to
-/// default to 'true', we have to set its default as a function that returns 'true'.
-fn default_true() -> bool {
-    true
-}
-
 /// Mapping from a "table" name to its information.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+
 pub struct TablesInfo(pub BTreeMap<String, TableInfo>);
 
 /// Information about a database table (or any other kind of relation).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+
 pub struct TableInfo {
     pub schema_name: String,
     pub table_name: String,
     pub columns: BTreeMap<String, ColumnInfo>,
-    #[serde(default)]
+
     pub uniqueness_constraints: UniquenessConstraints,
-    #[serde(default)]
+
     pub foreign_relations: ForeignRelations,
-    #[serde(default)]
+
     pub description: Option<String>,
 }
 
 /// Can this column contain null values
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+
 pub enum Nullable {
     #[default]
     Nullable,
@@ -108,8 +98,8 @@ pub enum Nullable {
 }
 
 /// Does this column have a default value.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+
 pub enum HasDefault {
     #[default]
     NoDefault,
@@ -117,8 +107,8 @@ pub enum HasDefault {
 }
 
 /// Is this column an identity column.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+
 pub enum IsIdentity {
     #[default]
     NotIdentity,
@@ -127,8 +117,8 @@ pub enum IsIdentity {
 }
 
 /// Is this column a generated column.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+
 pub enum IsGenerated {
     #[default]
     NotGenerated,
@@ -136,82 +126,66 @@ pub enum IsGenerated {
 }
 
 /// Information about a database column.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+
 pub struct ColumnInfo {
     pub name: String,
     pub r#type: Type,
-    #[serde(default)]
+
     pub nullable: Nullable,
-    #[serde(skip_serializing_if = "does_not_have_default")]
-    #[serde(default)]
+
     pub has_default: HasDefault,
-    #[serde(skip_serializing_if = "is_not_identity")]
-    #[serde(default)]
+
     pub is_identity: IsIdentity,
-    #[serde(skip_serializing_if = "is_not_generated")]
-    #[serde(default)]
+
     pub is_generated: IsGenerated,
-    #[serde(default)]
+
     pub description: Option<String>,
 }
 
-fn does_not_have_default(has_default: &HasDefault) -> bool {
-    matches!(has_default, HasDefault::NoDefault)
-}
-
-fn is_not_identity(is_identity: &IsIdentity) -> bool {
-    matches!(is_identity, IsIdentity::NotIdentity)
-}
-
-fn is_not_generated(is_generated: &IsGenerated) -> bool {
-    matches!(is_generated, IsGenerated::NotGenerated)
-}
-
 /// A mapping from the name of a unique constraint to its value.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+
 pub struct UniquenessConstraints(pub BTreeMap<String, UniquenessConstraint>);
 
 /// The set of columns that make up a uniqueness constraint.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+
 pub struct UniquenessConstraint(pub BTreeSet<String>);
 
 /// A mapping from the name of a foreign key constraint to its value.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+
 pub struct ForeignRelations(pub BTreeMap<String, ForeignRelation>);
 
 /// A foreign key constraint.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+
 pub struct ForeignRelation {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub foreign_schema: Option<String>,
     pub foreign_table: String,
     pub column_mapping: BTreeMap<String, String>,
 }
 
 /// All supported aggregate functions, grouped by type.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+
 pub struct AggregateFunctions(pub BTreeMap<ScalarType, BTreeMap<String, AggregateFunction>>);
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+
 pub struct AggregateFunction {
     pub return_type: ScalarType,
 }
 
 /// Type representation of scalar types, grouped by type.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+
 pub struct TypeRepresentations(pub BTreeMap<ScalarType, TypeRepresentation>);
 
 /// Type representation of a scalar type.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+
 pub enum TypeRepresentation {
     /// JSON booleans
     Boolean,
@@ -253,36 +227,4 @@ pub enum TypeRepresentation {
     Json,
     /// One of the specified string values
     Enum(Vec<String>),
-}
-
-// tests
-
-#[cfg(test)]
-mod tests {
-    use super::{ScalarType, TypeRepresentation, TypeRepresentations};
-
-    #[test]
-    fn parse_type_representations() {
-        assert_eq!(
-            serde_json::from_str::<TypeRepresentations>(
-                r#"{"int4": "integer", "card_suit": {"enum": ["hearts", "clubs", "diamonds", "spades"]}}"#
-            )
-            .unwrap(),
-            TypeRepresentations(
-                [(
-                    ScalarType("int4".to_string()),
-                    TypeRepresentation::Integer
-                ), (
-                    ScalarType("card_suit".to_string()),
-                    TypeRepresentation::Enum(vec![
-                        "hearts".into(),
-                        "clubs".into(),
-                        "diamonds".into(),
-                        "spades".into()
-                    ])
-                )]
-                .into()
-            )
-        );
-    }
 }

--- a/crates/query-engine/metadata/src/metadata/mod.rs
+++ b/crates/query-engine/metadata/src/metadata/mod.rs
@@ -10,25 +10,14 @@ use std::collections::BTreeSet;
 pub use database::*;
 pub use native_queries::*;
 
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
 /// Metadata information.
-#[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub struct Metadata {
-    #[serde(default)]
     pub tables: TablesInfo,
-    #[serde(default)]
     pub composite_types: CompositeTypes,
-    #[serde(default)]
     pub native_queries: NativeQueries,
-    #[serde(default)]
     pub aggregate_functions: AggregateFunctions,
-    #[serde(default)]
     pub comparison_operators: ComparisonOperators,
-    #[serde(default)]
     pub type_representations: TypeRepresentations,
-    #[serde(skip)]
     pub occurring_scalar_types: BTreeSet<ScalarType>,
 }

--- a/crates/query-engine/metadata/src/metadata/mod.rs
+++ b/crates/query-engine/metadata/src/metadata/mod.rs
@@ -4,6 +4,8 @@ pub mod database;
 pub mod mutations;
 pub mod native_queries;
 
+use std::collections::BTreeSet;
+
 // re-export without modules
 pub use database::*;
 pub use native_queries::*;
@@ -27,4 +29,6 @@ pub struct Metadata {
     pub comparison_operators: ComparisonOperators,
     #[serde(default)]
     pub type_representations: TypeRepresentations,
+    #[serde(skip)]
+    pub occurring_scalar_types: BTreeSet<ScalarType>,
 }

--- a/crates/query-engine/metadata/src/metadata/mutations.rs
+++ b/crates/query-engine/metadata/src/metadata/mutations.rs
@@ -1,11 +1,7 @@
 //! Generated mutations-related metadata information.
 
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
 /// Which version of the generated mutations will be included in the schema
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum MutationsVersion {
     V1,
     VeryExperimentalWip,

--- a/crates/query-engine/translation/Cargo.toml
+++ b/crates/query-engine/translation/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 [dependencies]
 query-engine-metadata = { path = "../metadata" }
 query-engine-sql = { path = "../sql" }
+ndc-postgres-configuration = { path = "../../../crates/configuration/" }
 
 ndc-sdk = { workspace = true }
 


### PR DESCRIPTION
### What

We want to be able to confidently evolve the configuration format without risk of accidentally changing the behavior of previous versions.

This PR has no user-observable change in behavior.

Introducing a new major version of the configuration format is now a much more well-defined task, which should consist most of just duplicating the entire `version3` module hierarchy and then introducing the new changes in the duplicated copy.

### How

In order to achieve this we duplicate the complete metadata type hierarchy into configuration crate and introduce functions that convert between the now separate exchange types and business types, and ensure that all logic that has to do with serialization only lives with the exchange types (the version types)