### PR TITLE
support OpenTelemetry zipkin b3 propagation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "ndc-sdk"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-sdk-rs.git?rev=7409334d2ec2ca1d05fb341e69c9f07af520d8e0#7409334d2ec2ca1d05fb341e69c9f07af520d8e0"
+source = "git+https://github.com/hasura/ndc-sdk-rs.git?rev=6158b1adbcc4ac7d8acb721c1626f6f715424a27#6158b1adbcc4ac7d8acb721c1626f6f715424a27"
 dependencies = [
  "async-trait",
  "axum",
@@ -1509,6 +1509,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
+ "opentelemetry-zipkin",
  "opentelemetry_sdk",
  "prometheus",
  "reqwest",
@@ -1812,6 +1813,27 @@ name = "opentelemetry-semantic-conventions"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+
+[[package]]
+name = "opentelemetry-zipkin"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6943c09b1b7c17b403ae842b00f23e6d5fc6f5ec06cccb3f39aca97094a899a"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "typed-builder",
+]
 
 [[package]]
 name = "opentelemetry_sdk"
@@ -3424,6 +3446,26 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typed-builder"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77739c880e00693faef3d65ea3aad725f196da38b22fdc7ea6ded6e1ce4d3add"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f718dfaf347dcb5b983bfc87608144b0bad87970aebcbea5ce44d2a30c08e63"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,5 +48,5 @@ unused_async = "allow"
 
 [workspace.dependencies]
 ndc-models = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.2" }
-ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs.git", rev = "7409334d2ec2ca1d05fb341e69c9f07af520d8e0" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs.git", rev = "6158b1adbcc4ac7d8acb721c1626f6f715424a27" }
 ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.2" }

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Support OpenTelemetry Zipkin B3 propagation.
+  ([#427](https://github.com/hasura/ndc-postgres/pull/427))
+
 ### Changed
 
 ### Fixed


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

Connectors should support both W3C and Zipkin B3 propagation. B3
propagation headers priority should be higher because W3C traceparent
header is intercepted by Cloud Run service.

### How

Upgrade Rust SDK commit [6158b1a](https://github.com/hasura/ndc-sdk-rs/commit/6158b1adbcc4ac7d8acb721c1626f6f715424a27)

