### PR TITLE
Update broken metadata, and test that it is kept up to date

### DIFF
--- a/crates/tests/databases-tests/src/postgres/common.rs
+++ b/crates/tests/databases-tests/src/postgres/common.rs
@@ -6,6 +6,8 @@ pub const BROKEN_QUERIES_NDC_METADATA_PATH: &str = "static/postgres/broken-queri
 
 pub const CONNECTION_URI: &str = "postgresql://postgres:password@localhost:64002";
 
+pub const EMPTY_CONNECTION_URI: &str = "postgresql://postgres:password@localhost:64002/empty";
+
 /// Creates a router with a fresh state from the test ndc_metadata.
 pub async fn create_router() -> axum::Router {
     tests_common::router::create_router(CHINOOK_NDC_METADATA_PATH, CONNECTION_URI).await

--- a/crates/tests/databases-tests/src/postgres/configuration_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/configuration_tests.rs
@@ -22,7 +22,7 @@ async fn get_configuration_schema() {
 // version 3 tests
 
 #[tokio::test]
-async fn postgres_broken_metadata_is_up_to_date() {
+async fn postgres_current_only_broken_metadata_is_up_to_date() {
     common_tests::configuration_v3_tests::configure_is_idempotent(
         common::EMPTY_CONNECTION_URI,
         common::BROKEN_QUERIES_NDC_METADATA_PATH,

--- a/crates/tests/databases-tests/src/postgres/configuration_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/configuration_tests.rs
@@ -22,6 +22,16 @@ async fn get_configuration_schema() {
 // version 3 tests
 
 #[tokio::test]
+async fn postgres_broken_metadata_is_up_to_date() {
+    common_tests::configuration_v3_tests::configure_is_idempotent(
+        common::EMPTY_CONNECTION_URI,
+        common::BROKEN_QUERIES_NDC_METADATA_PATH,
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
 async fn postgres_current_only_configure_v3_is_idempotent() {
     common_tests::configuration_v3_tests::configure_is_idempotent(
         common::CONNECTION_URI,

--- a/static/postgres/broken-queries-ndc-metadata/configuration.json
+++ b/static/postgres/broken-queries-ndc-metadata/configuration.json
@@ -1,6 +1,6 @@
 {
-  "version": "3",
   "$schema": "../../schema.json",
+  "version": "3",
   "connectionSettings": {
     "connectionUri": {
       "variable": "CONNECTION_URI"
@@ -17,6 +17,31 @@
     "tables": {},
     "compositeTypes": {},
     "nativeQueries": {
+      "artist_in_disguise": {
+        "sql": {
+          "inline": "INSERT INTO public.\"Artist\" VALUES (5000, 'This is not a query') RETURNING *"
+        },
+        "columns": {
+          "ArtistId": {
+            "name": "ArtistId",
+            "type": {
+              "scalarType": "int4"
+            },
+            "nullable": "nullable",
+            "description": null
+          },
+          "Name": {
+            "name": "Name",
+            "type": {
+              "scalarType": "varchar"
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "arguments": {},
+        "description": "Used to test that a mutation statement cannot be run as part of a query"
+      },
       "broken": {
         "sql": "SELECT ) AS result",
         "columns": {
@@ -46,32 +71,6 @@
         },
         "arguments": {},
         "description": "A working native query that simply returns 1"
-      },
-      "artist_in_disguise": {
-        "sql": {
-          "inline": "INSERT INTO public.\"Artist\" VALUES (5000, 'This is not a query') RETURNING *"
-        },
-        "columns": {
-          "ArtistId": {
-            "name": "ArtistId",
-            "type": {
-              "scalarType": "int4"
-            },
-            "nullable": "nullable",
-            "description": null
-          },
-          "Name": {
-            "name": "Name",
-            "type": {
-              "scalarType": "varchar"
-            },
-            "nullable": "nullable",
-            "description": null
-          }
-        },
-        "arguments": {},
-        "description": "Used to test that a mutation statement cannot be run as part of a query",
-        "isProcedure": false
       }
     },
     "aggregateFunctions": {
@@ -187,6 +186,22 @@
         },
         "variance": {
           "returnType": "numeric"
+        }
+      },
+      "text": {
+        "max": {
+          "returnType": "text"
+        },
+        "min": {
+          "returnType": "text"
+        }
+      },
+      "varchar": {
+        "max": {
+          "returnType": "text"
+        },
+        "min": {
+          "returnType": "text"
         }
       }
     },
@@ -322,12 +337,222 @@
           "argumentType": "numeric",
           "isInfix": true
         }
+      },
+      "text": {
+        "_eq": {
+          "operatorName": "=",
+          "operatorKind": "equal",
+          "argumentType": "text",
+          "isInfix": true
+        },
+        "_gt": {
+          "operatorName": ">",
+          "operatorKind": "custom",
+          "argumentType": "text",
+          "isInfix": true
+        },
+        "_gte": {
+          "operatorName": ">=",
+          "operatorKind": "custom",
+          "argumentType": "text",
+          "isInfix": true
+        },
+        "_ilike": {
+          "operatorName": "~~*",
+          "operatorKind": "custom",
+          "argumentType": "text",
+          "isInfix": true
+        },
+        "_in": {
+          "operatorName": "IN",
+          "operatorKind": "in",
+          "argumentType": "text",
+          "isInfix": true
+        },
+        "_iregex": {
+          "operatorName": "~*",
+          "operatorKind": "custom",
+          "argumentType": "text",
+          "isInfix": true
+        },
+        "_like": {
+          "operatorName": "~~",
+          "operatorKind": "custom",
+          "argumentType": "text",
+          "isInfix": true
+        },
+        "_lt": {
+          "operatorName": "<",
+          "operatorKind": "custom",
+          "argumentType": "text",
+          "isInfix": true
+        },
+        "_lte": {
+          "operatorName": "<=",
+          "operatorKind": "custom",
+          "argumentType": "text",
+          "isInfix": true
+        },
+        "_neq": {
+          "operatorName": "<>",
+          "operatorKind": "custom",
+          "argumentType": "text",
+          "isInfix": true
+        },
+        "_nilike": {
+          "operatorName": "!~~*",
+          "operatorKind": "custom",
+          "argumentType": "text",
+          "isInfix": true
+        },
+        "_niregex": {
+          "operatorName": "!~*",
+          "operatorKind": "custom",
+          "argumentType": "text",
+          "isInfix": true
+        },
+        "_nlike": {
+          "operatorName": "!~~",
+          "operatorKind": "custom",
+          "argumentType": "text",
+          "isInfix": true
+        },
+        "_nregex": {
+          "operatorName": "!~",
+          "operatorKind": "custom",
+          "argumentType": "text",
+          "isInfix": true
+        },
+        "_regex": {
+          "operatorName": "~",
+          "operatorKind": "custom",
+          "argumentType": "text",
+          "isInfix": true
+        },
+        "starts_with": {
+          "operatorName": "starts_with",
+          "operatorKind": "custom",
+          "argumentType": "text",
+          "isInfix": false
+        },
+        "ts_match_tt": {
+          "operatorName": "ts_match_tt",
+          "operatorKind": "custom",
+          "argumentType": "text",
+          "isInfix": false
+        }
+      },
+      "varchar": {
+        "_eq": {
+          "operatorName": "=",
+          "operatorKind": "equal",
+          "argumentType": "varchar",
+          "isInfix": true
+        },
+        "_gt": {
+          "operatorName": ">",
+          "operatorKind": "custom",
+          "argumentType": "varchar",
+          "isInfix": true
+        },
+        "_gte": {
+          "operatorName": ">=",
+          "operatorKind": "custom",
+          "argumentType": "varchar",
+          "isInfix": true
+        },
+        "_ilike": {
+          "operatorName": "~~*",
+          "operatorKind": "custom",
+          "argumentType": "varchar",
+          "isInfix": true
+        },
+        "_in": {
+          "operatorName": "IN",
+          "operatorKind": "in",
+          "argumentType": "varchar",
+          "isInfix": true
+        },
+        "_iregex": {
+          "operatorName": "~*",
+          "operatorKind": "custom",
+          "argumentType": "varchar",
+          "isInfix": true
+        },
+        "_like": {
+          "operatorName": "~~",
+          "operatorKind": "custom",
+          "argumentType": "varchar",
+          "isInfix": true
+        },
+        "_lt": {
+          "operatorName": "<",
+          "operatorKind": "custom",
+          "argumentType": "varchar",
+          "isInfix": true
+        },
+        "_lte": {
+          "operatorName": "<=",
+          "operatorKind": "custom",
+          "argumentType": "varchar",
+          "isInfix": true
+        },
+        "_neq": {
+          "operatorName": "<>",
+          "operatorKind": "custom",
+          "argumentType": "varchar",
+          "isInfix": true
+        },
+        "_nilike": {
+          "operatorName": "!~~*",
+          "operatorKind": "custom",
+          "argumentType": "varchar",
+          "isInfix": true
+        },
+        "_niregex": {
+          "operatorName": "!~*",
+          "operatorKind": "custom",
+          "argumentType": "varchar",
+          "isInfix": true
+        },
+        "_nlike": {
+          "operatorName": "!~~",
+          "operatorKind": "custom",
+          "argumentType": "varchar",
+          "isInfix": true
+        },
+        "_nregex": {
+          "operatorName": "!~",
+          "operatorKind": "custom",
+          "argumentType": "varchar",
+          "isInfix": true
+        },
+        "_regex": {
+          "operatorName": "~",
+          "operatorKind": "custom",
+          "argumentType": "varchar",
+          "isInfix": true
+        },
+        "starts_with": {
+          "operatorName": "starts_with",
+          "operatorKind": "custom",
+          "argumentType": "varchar",
+          "isInfix": false
+        },
+        "ts_match_tt": {
+          "operatorName": "ts_match_tt",
+          "operatorKind": "custom",
+          "argumentType": "varchar",
+          "isInfix": false
+        }
       }
     },
     "typeRepresentations": {
       "int4": "int32",
       "int8": "int64",
-      "numeric": "bigDecimal"
+      "numeric": "bigDecimal",
+      "text": "string",
+      "varchar": "string"
     }
   },
   "introspectionOptions": {


### PR DESCRIPTION
### What

The `just generate-metadata` command updated the "broken" test metadata on `main`. This PR introduces a test that ensures this is kept up to date, such that updates to this metadata doesn't lag behind the changes that actually introduced them.