### PR TITLE
Add Schema support for Scalar types in SQL AST

### DIFF
--- a/crates/configuration/src/version3/mod.rs
+++ b/crates/configuration/src/version3/mod.rs
@@ -564,14 +564,14 @@ pub fn convert_metadata(metadata: metadata::Metadata) -> query_engine_metadata::
 
 fn convert_scalar_types(
     scalar_types: BTreeSet<metadata::ScalarType>,
-) -> BTreeSet<query_engine_metadata::metadata::ScalarType> {
+) -> BTreeSet<query_engine_metadata::metadata::ScalarTypeName> {
     scalar_types.into_iter().map(convert_scalar_type).collect()
 }
 
 fn convert_scalar_type(
     scalar_type: metadata::ScalarType,
-) -> query_engine_metadata::metadata::ScalarType {
-    query_engine_metadata::metadata::ScalarType(scalar_type.0)
+) -> query_engine_metadata::metadata::ScalarTypeName {
+    query_engine_metadata::metadata::ScalarTypeName(scalar_type.0)
 }
 
 fn convert_aggregate_functions(

--- a/crates/query-engine/metadata/src/metadata/database.rs
+++ b/crates/query-engine/metadata/src/metadata/database.rs
@@ -9,14 +9,13 @@ pub struct CompositeTypes(pub BTreeMap<String, CompositeType>);
 
 /// A Scalar Type.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-
-pub struct ScalarType(pub String);
+pub struct ScalarTypeName(pub String);
 
 /// The type of values that a column, field, or argument may take.
 #[derive(Debug, Clone, PartialEq, Eq)]
 
 pub enum Type {
-    ScalarType(ScalarType),
+    ScalarType(ScalarTypeName),
     CompositeType(String),
     ArrayType(Box<Type>),
 }
@@ -46,7 +45,7 @@ pub struct FieldInfo {
 /// Not all of these are supported for every type.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 
-pub struct ComparisonOperators(pub BTreeMap<ScalarType, BTreeMap<String, ComparisonOperator>>);
+pub struct ComparisonOperators(pub BTreeMap<ScalarTypeName, BTreeMap<String, ComparisonOperator>>);
 
 /// Represents a postgres binary comparison operator
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -54,7 +53,7 @@ pub struct ComparisonOperators(pub BTreeMap<ScalarType, BTreeMap<String, Compari
 pub struct ComparisonOperator {
     pub operator_name: String,
     pub operator_kind: OperatorKind,
-    pub argument_type: ScalarType,
+    pub argument_type: ScalarTypeName,
 
     pub is_infix: bool,
 }
@@ -170,18 +169,18 @@ pub struct ForeignRelation {
 /// All supported aggregate functions, grouped by type.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 
-pub struct AggregateFunctions(pub BTreeMap<ScalarType, BTreeMap<String, AggregateFunction>>);
+pub struct AggregateFunctions(pub BTreeMap<ScalarTypeName, BTreeMap<String, AggregateFunction>>);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 
 pub struct AggregateFunction {
-    pub return_type: ScalarType,
+    pub return_type: ScalarTypeName,
 }
 
 /// Type representation of scalar types, grouped by type.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 
-pub struct TypeRepresentations(pub BTreeMap<ScalarType, TypeRepresentation>);
+pub struct TypeRepresentations(pub BTreeMap<ScalarTypeName, TypeRepresentation>);
 
 /// Type representation of a scalar type.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/query-engine/metadata/src/metadata/mod.rs
+++ b/crates/query-engine/metadata/src/metadata/mod.rs
@@ -19,5 +19,5 @@ pub struct Metadata {
     pub aggregate_functions: AggregateFunctions,
     pub comparison_operators: ComparisonOperators,
     pub type_representations: TypeRepresentations,
-    pub occurring_scalar_types: BTreeSet<ScalarType>,
+    pub occurring_scalar_types: BTreeSet<ScalarTypeName>,
 }

--- a/crates/query-engine/sql/src/sql/ast.rs
+++ b/crates/query-engine/sql/src/sql/ast.rs
@@ -299,9 +299,35 @@ pub enum Value {
     Variable(String),
 }
 
-/// Scalar type
+/// Scalar type. This include composite types.
+/// This will always be output as a quoted identifier.
+///
+/// This has a few quirks:
+///
+/// * Array types need to be quoted as `"type name"[]` and _not_ `"type name[]"`. Therefore we
+/// track whether a scalar type is supposed to be an array with the separate field `is_array`.
+///
+/// * Quoting of type name identifiers is only supported for the actual type names recorded in
+/// `pg_type`, and _not_ the SQL standard type names. This means that `character varying` is an
+/// acceptable type name, but `"character varying"` is _not_ (Unless of course you do `CREATE TYPE
+/// "character varying" AS (..)`. Spicy).
+///
 #[derive(Debug, Clone, PartialEq)]
-pub struct ScalarTypeName(pub String);
+pub struct ScalarTypeName {
+    pub type_name: String,
+    pub schema_name: Option<SchemaName>,
+    pub is_array: bool,
+}
+
+impl ScalarTypeName {
+    pub fn new_unqualified(type_name: &str) -> Self {
+        ScalarTypeName {
+            schema_name: None,
+            type_name: type_name.to_string(),
+            is_array: false,
+        }
+    }
+}
 
 /// A database schema name
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/query-engine/sql/src/sql/ast.rs
+++ b/crates/query-engine/sql/src/sql/ast.rs
@@ -103,7 +103,7 @@ pub enum From {
     JsonbToRecordset {
         expression: Expression,
         alias: TableAlias,
-        columns: Vec<(ColumnAlias, ScalarType)>,
+        columns: Vec<(ColumnAlias, ScalarTypeName)>,
     },
     JsonbArrayElements {
         expression: Expression,
@@ -241,7 +241,7 @@ pub enum Expression {
     Value(Value),
     Cast {
         expression: Box<Expression>,
-        r#type: ScalarType,
+        r#type: ScalarTypeName,
     },
     /// A COUNT clause
     Count(CountType),
@@ -301,7 +301,7 @@ pub enum Value {
 
 /// Scalar type
 #[derive(Debug, Clone, PartialEq)]
-pub struct ScalarType(pub String);
+pub struct ScalarTypeName(pub String);
 
 /// A database schema name
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/query-engine/sql/src/sql/convert.rs
+++ b/crates/query-engine/sql/src/sql/convert.rs
@@ -533,7 +533,17 @@ impl Value {
 
 impl ScalarTypeName {
     pub fn to_sql(&self, sql: &mut SQL) {
-        sql.append_syntax(self.0.as_str())
+        match &self.schema_name {
+            Some(schema_name) => {
+                sql.append_identifier(&schema_name.0);
+                sql.append_syntax(".");
+            }
+            None => (),
+        };
+        sql.append_identifier(&self.type_name);
+        if self.is_array {
+            sql.append_syntax("[]")
+        }
     }
 }
 

--- a/crates/query-engine/sql/src/sql/convert.rs
+++ b/crates/query-engine/sql/src/sql/convert.rs
@@ -531,7 +531,7 @@ impl Value {
     }
 }
 
-impl ScalarType {
+impl ScalarTypeName {
     pub fn to_sql(&self, sql: &mut SQL) {
         sql.append_syntax(self.0.as_str())
     }

--- a/crates/query-engine/sql/src/sql/helpers.rs
+++ b/crates/query-engine/sql/src/sql/helpers.rs
@@ -624,14 +624,14 @@ pub fn select_row_as_json_with_default(
 /// ```
 pub fn from_variables(alias: TableAlias) -> From {
     let expression = Expression::Value(Value::Variable(VARIABLES_OBJECT_PLACEHOLDER.to_string()));
-    let columns: Vec<(ColumnAlias, ScalarType)> = vec![
+    let columns: Vec<(ColumnAlias, ScalarTypeName)> = vec![
         (
             make_column_alias(VARIABLE_ORDER_FIELD.to_string()),
-            ScalarType("int".to_string()),
+            ScalarTypeName("int".to_string()),
         ),
         (
             make_column_alias(VARIABLES_FIELD.to_string()),
-            ScalarType("jsonb".to_string()),
+            ScalarTypeName("jsonb".to_string()),
         ),
     ];
 

--- a/crates/query-engine/sql/src/sql/helpers.rs
+++ b/crates/query-engine/sql/src/sql/helpers.rs
@@ -627,11 +627,11 @@ pub fn from_variables(alias: TableAlias) -> From {
     let columns: Vec<(ColumnAlias, ScalarTypeName)> = vec![
         (
             make_column_alias(VARIABLE_ORDER_FIELD.to_string()),
-            ScalarTypeName("int".to_string()),
+            ScalarTypeName::new_unqualified("int4"),
         ),
         (
             make_column_alias(VARIABLES_FIELD.to_string()),
-            ScalarTypeName("jsonb".to_string()),
+            ScalarTypeName::new_unqualified("jsonb"),
         ),
     ];
 

--- a/crates/query-engine/translation/src/translation/error.rs
+++ b/crates/query-engine/translation/src/translation/error.rs
@@ -12,7 +12,7 @@ pub enum Error {
     ArgumentNotFound(String),
     OperatorNotFound {
         operator_name: String,
-        type_name: database::ScalarType,
+        type_name: database::ScalarTypeName,
     },
     NonScalarTypeUsedInOperator {
         r#type: database::Type,
@@ -20,7 +20,7 @@ pub enum Error {
     RelationshipArgumentWasOverriden(String),
     EmptyPathForOrderByAggregate,
     MissingAggregateForArrayRelationOrdering,
-    TypeMismatch(serde_json::Value, database::ScalarType),
+    TypeMismatch(serde_json::Value, database::ScalarTypeName),
     UnexpectedVariable,
     CapabilityNotSupported(UnsupportedCapabilities),
     UnableToDeserializeNumberAsF64(serde_json::Number),

--- a/crates/query-engine/translation/src/translation/helpers.rs
+++ b/crates/query-engine/translation/src/translation/helpers.rs
@@ -189,7 +189,7 @@ impl<'request> Env<'request> {
     /// Looks up the binary comparison operator's PostgreSQL name and arguments' type in the metadata.
     pub fn lookup_comparison_operator(
         &self,
-        scalar_type: &metadata::ScalarType,
+        scalar_type: &metadata::ScalarTypeName,
         name: &str,
     ) -> Result<&'request metadata::ComparisonOperator, Error> {
         self.metadata
@@ -206,7 +206,7 @@ impl<'request> Env<'request> {
     /// Lookup type representation of a type.
     pub fn lookup_type_representation(
         &self,
-        scalar_type: &metadata::ScalarType,
+        scalar_type: &metadata::ScalarTypeName,
     ) -> Option<&metadata::TypeRepresentation> {
         self.metadata.type_representations.0.get(scalar_type)
     }

--- a/crates/query-engine/translation/src/translation/mutation/v1/delete.rs
+++ b/crates/query-engine/translation/src/translation/mutation/v1/delete.rs
@@ -138,7 +138,7 @@ mod tests {
             by_column: metadata::ColumnInfo {
                 name: "user_id".to_string(),
                 description: None,
-                r#type: metadata::Type::ScalarType(metadata::ScalarTypeName("int".to_string())),
+                r#type: metadata::Type::ScalarType(metadata::ScalarTypeName("int4".to_string())),
                 nullable: metadata::Nullable::NonNullable,
                 has_default: metadata::HasDefault::NoDefault,
                 is_identity: metadata::IsIdentity::NotIdentity,

--- a/crates/query-engine/translation/src/translation/mutation/v1/delete.rs
+++ b/crates/query-engine/translation/src/translation/mutation/v1/delete.rs
@@ -138,7 +138,7 @@ mod tests {
             by_column: metadata::ColumnInfo {
                 name: "user_id".to_string(),
                 description: None,
-                r#type: metadata::Type::ScalarType(metadata::ScalarType("int".to_string())),
+                r#type: metadata::Type::ScalarType(metadata::ScalarTypeName("int".to_string())),
                 nullable: metadata::Nullable::NonNullable,
                 has_default: metadata::HasDefault::NoDefault,
                 is_identity: metadata::IsIdentity::NotIdentity,

--- a/crates/query-engine/translation/src/translation/query/fields.rs
+++ b/crates/query-engine/translation/src/translation/query/fields.rs
@@ -433,13 +433,13 @@ fn wrap_array_in_type_representation(
     match column_type_representation {
         None => expression,
         Some(type_rep) => {
-            if let Some(sql::ast::ScalarType(cast_type)) =
+            if let Some(sql::ast::ScalarTypeName(cast_type)) =
                 get_type_representation_cast_type(type_rep)
             {
                 sql::ast::Expression::Cast {
                     expression: Box::new(expression),
                     // make it an array of cast type
-                    r#type: sql::ast::ScalarType(format!("{cast_type}[]")),
+                    r#type: sql::ast::ScalarTypeName(format!("{cast_type}[]")),
                 }
             } else {
                 expression
@@ -473,12 +473,14 @@ fn wrap_in_type_representation(
 /// If a type representation requires a cast, return the scalar type name.
 fn get_type_representation_cast_type(
     type_representation: &TypeRepresentation,
-) -> Option<sql::ast::ScalarType> {
+) -> Option<sql::ast::ScalarTypeName> {
     match type_representation {
         // In these situations, we expect to cast the expression according
         // to the type representation.
-        TypeRepresentation::Int64AsString => Some(sql::ast::ScalarType("text".to_string())),
-        TypeRepresentation::BigDecimalAsString => Some(sql::ast::ScalarType("text".to_string())),
+        TypeRepresentation::Int64AsString => Some(sql::ast::ScalarTypeName("text".to_string())),
+        TypeRepresentation::BigDecimalAsString => {
+            Some(sql::ast::ScalarTypeName("text".to_string()))
+        }
 
         // In these situations the type representation should be the same as
         // the expression, so we don't cast it.

--- a/crates/query-engine/translation/src/translation/query/filtering.rs
+++ b/crates/query-engine/translation/src/translation/query/filtering.rs
@@ -556,7 +556,7 @@ fn get_comparison_target_type(
     env: &Env,
     root_and_current_tables: &RootAndCurrentTables,
     column: &models::ComparisonTarget,
-) -> Result<database::ScalarType, Error> {
+) -> Result<database::ScalarTypeName, Error> {
     match column {
         models::ComparisonTarget::RootCollectionColumn { name } => {
             let column = env

--- a/crates/query-engine/translation/src/translation/query/values.rs
+++ b/crates/query-engine/translation/src/translation/query/values.rs
@@ -51,7 +51,7 @@ pub fn translate_json_value(
         _ => Ok(sql::ast::Expression::Cast {
             expression: Box::new(sql::ast::Expression::Cast {
                 expression: Box::new(Expression::Value(Value::JsonValue(value.clone()))),
-                r#type: sql::ast::ScalarType("jsonb".to_string()),
+                r#type: sql::ast::ScalarTypeName("jsonb".to_string()),
             }),
             r#type: type_to_ast_scalar_type(r#type),
         }),
@@ -59,7 +59,7 @@ pub fn translate_json_value(
 }
 
 /// Translate a NDC 'Type' to an SQL type name.
-fn type_to_ast_scalar_type(typ: &database::Type) -> sql::ast::ScalarType {
+fn type_to_ast_scalar_type(typ: &database::Type) -> sql::ast::ScalarTypeName {
     match typ {
         query_engine_metadata::metadata::Type::ArrayType(t) => {
             // This will add multiple '[]'-suffixes when the input type represents a nested array.
@@ -68,10 +68,14 @@ fn type_to_ast_scalar_type(typ: &database::Type) -> sql::ast::ScalarType {
             // were only a single pair of square brackets (e.g., 'int[][][]' simply becomes
             // 'int[]'), which is what we want.
             let scalar_type = type_to_ast_scalar_type(t).0;
-            sql::ast::ScalarType(scalar_type + "[]")
+            sql::ast::ScalarTypeName(scalar_type + "[]")
         }
-        query_engine_metadata::metadata::Type::ScalarType(t) => sql::ast::ScalarType(t.0.clone()),
-        query_engine_metadata::metadata::Type::CompositeType(t) => sql::ast::ScalarType(t.clone()),
+        query_engine_metadata::metadata::Type::ScalarType(t) => {
+            sql::ast::ScalarTypeName(t.0.clone())
+        }
+        query_engine_metadata::metadata::Type::CompositeType(t) => {
+            sql::ast::ScalarTypeName(t.clone())
+        }
     }
 }
 
@@ -175,7 +179,7 @@ pub fn translate_projected_variable(
                     expression: Box::new(sql::ast::Expression::Value(sql::ast::Value::Array(
                         vec![],
                     ))),
-                    r#type: sql::ast::ScalarType("text[]".to_string()),
+                    r#type: sql::ast::ScalarTypeName("text[]".to_string()),
                 }),
             }),
             r#type: type_to_ast_scalar_type(r#type),

--- a/crates/query-engine/translation/tests/snapshots/tests__it_select_where_in_variable.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__it_select_where_in_variable.snap
@@ -9,7 +9,7 @@ FROM
     SELECT
       row_to_json("%5_universe") AS "universe"
     FROM
-      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" int, "%variables" jsonb)
+      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" "int4", "%variables" "jsonb")
       CROSS JOIN LATERAL (
         WITH "%2_NATIVE_QUERY_array_series" AS (
           WITH "%9_NATIVE_QUERY_array_series" AS (
@@ -22,7 +22,7 @@ FROM
                   generate_series(
                     cast(
                       (
-                        ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as text[])) as int4),cast((("%0_%variables_table"."%variables" -> $3) #>> cast(ARRAY [] as text[])) as int4)) AS series) AS arr
+                        ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "int4"),cast((("%0_%variables_table"."%variables" -> $3) #>> cast(ARRAY [] as "text"[])) as "int4")) AS series) AS arr
                       )
                       SELECT
                         *
@@ -53,7 +53,7 @@ FROM
                                           array_agg(
                                             cast(
                                               (
-                                                "%3_array"."element" #>> cast(ARRAY [] as text[])) as int4)) AS "element" FROM jsonb_array_elements(("%0_%variables_table"."%variables" -> $4)) AS "%3_array"("element"))) AS "%4_in_subquery"("value")))) AS "%6_rows") AS "%6_rows") AS "%5_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%8_universe_agg";
+                                                "%3_array"."element" #>> cast(ARRAY [] as "text"[])) as "int4")) AS "element" FROM jsonb_array_elements(("%0_%variables_table"."%variables" -> $4)) AS "%3_array"("element"))) AS "%4_in_subquery"("value")))) AS "%6_rows") AS "%6_rows") AS "%5_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%8_universe_agg";
 
 {
     1: Variable(

--- a/crates/query-engine/translation/tests/snapshots/tests__it_select_where_related_exists.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__it_select_where_related_exists.snap
@@ -50,7 +50,7 @@ FROM
                   "public"."Album" AS "%2_album"
                 WHERE
                   (
-                    ("%2_album"."Title" LIKE cast($1 as varchar))
+                    ("%2_album"."Title" LIKE cast($1 as "varchar"))
                     AND ("%0_artist"."ArtistId" = "%2_album"."ArtistId")
                   )
               )

--- a/crates/query-engine/translation/tests/snapshots/tests__it_select_where_string.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__it_select_where_string.snap
@@ -20,7 +20,7 @@ FROM
               "public"."Album" AS "%0_Album"
             WHERE
               (
-                "%0_Album"."Title" IN (cast($1 as varchar), cast($2 as varchar))
+                "%0_Album"."Title" IN (cast($1 as "varchar"), cast($2 as "varchar"))
               )
           ) AS "%2_rows"
       ) AS "%2_rows"

--- a/crates/query-engine/translation/tests/snapshots/tests__it_select_where_unrelated_exists.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__it_select_where_unrelated_exists.snap
@@ -26,7 +26,7 @@ FROM
                   "public"."Artist" AS "%1_artist"
                 WHERE
                   (
-                    ("%1_artist"."Name" = cast($1 as varchar))
+                    ("%1_artist"."Name" = cast($1 as "varchar"))
                     AND ("%0_album"."ArtistId" = "%1_artist"."ArtistId")
                   )
               )

--- a/crates/query-engine/translation/tests/snapshots/tests__mutations__v1_insert.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__mutations__v1_insert.snap
@@ -9,7 +9,7 @@ WITH "%0_generated_mutation" AS (
   INSERT INTO
     "public"."Artist"("ArtistId", "Name")
   VALUES
-    (276, cast($1 as varchar)) RETURNING *
+    (276, cast($1 as "varchar")) RETURNING *
 )
 SELECT
   json_build_object('result', row_to_json("%2_universe"), 'type', $2) AS "universe"

--- a/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_by_name.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_by_name.snap
@@ -9,7 +9,7 @@ WITH "%1_NATIVE_QUERY_artist_by_name" AS (
     FROM
       public."Artist"
     WHERE
-      "Name" = cast($1 as varchar)
+      "Name" = cast($1 as "varchar")
   )
   SELECT
     *

--- a/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_with_album_by_title.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_with_album_by_title.snap
@@ -21,7 +21,7 @@ WITH "%1_NATIVE_QUERY_artist" AS (
     FROM
       public."Album"
     WHERE
-      "Title" LIKE cast($1 as varchar)
+      "Title" LIKE cast($1 as "varchar")
   )
   SELECT
     *

--- a/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_with_album_by_title_relationship_arguments.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_with_album_by_title_relationship_arguments.snap
@@ -21,7 +21,7 @@ WITH "%1_NATIVE_QUERY_artist" AS (
     FROM
       public."Album"
     WHERE
-      "Title" LIKE cast($1 as varchar)
+      "Title" LIKE cast($1 as "varchar")
       AND "AlbumId" < 300
   )
   SELECT

--- a/crates/query-engine/translation/tests/snapshots/tests__no_fields.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__no_fields.snap
@@ -19,7 +19,7 @@ FROM
               "public"."Album" AS "%0_Album"
             WHERE
               (
-                "%0_Album"."Title" IN (cast($1 as varchar), cast($2 as varchar))
+                "%0_Album"."Title" IN (cast($1 as "varchar"), cast($2 as "varchar"))
               )
             LIMIT
               10

--- a/crates/query-engine/translation/tests/snapshots/tests__select_array_column_nested_types.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_array_column_nested_types.snap
@@ -15,7 +15,10 @@ WITH "%1_NATIVE_QUERY_summarize_organizations" AS (
             (
               SELECT
                 array_agg(
-                  jsonb_populate_record(cast(null as organization), "%0_array"."element")
+                  jsonb_populate_record(
+                    cast(null as "organization"),
+                    "%0_array"."element"
+                  )
                 ) AS "element"
               FROM
                 jsonb_array_elements($1) AS "%0_array"("element")

--- a/crates/query-engine/translation/tests/snapshots/tests__select_array_column_reverse.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_array_column_reverse.snap
@@ -17,7 +17,7 @@ WITH "%1_NATIVE_QUERY_array_reverse" AS (
                 array_agg(
                   cast(
                     (
-                      "%0_array"."element" #>> cast(ARRAY [] as text[])) as varchar)) AS "element" FROM jsonb_array_elements($1) AS "%0_array"("element"))) WITH ORDINALITY AS t(x,ix) ORDER BY t.ix DESC)
+                      "%0_array"."element" #>> cast(ARRAY [] as "text"[])) as "varchar")) AS "element" FROM jsonb_array_elements($1) AS "%0_array"("element"))) WITH ORDINALITY AS t(x,ix) ORDER BY t.ix DESC)
                     )
                     SELECT
                       *

--- a/crates/query-engine/translation/tests/snapshots/tests__select_array_variable.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_array_variable.snap
@@ -9,7 +9,7 @@ FROM
     SELECT
       row_to_json("%3_universe") AS "universe"
     FROM
-      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" int, "%variables" jsonb)
+      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" "int4", "%variables" "jsonb")
       CROSS JOIN LATERAL (
         WITH "%2_NATIVE_QUERY_count_elements" AS (
           WITH "%7_NATIVE_QUERY_count_elements" AS (
@@ -20,7 +20,7 @@ FROM
                     array_agg(
                       cast(
                         (
-                          "%0_array"."element" #>> cast(ARRAY [] as text[])) as text)) AS "element" FROM jsonb_array_elements(("%0_%variables_table"."%variables" -> $2)) AS "%0_array"("element")), 1) as result
+                          "%0_array"."element" #>> cast(ARRAY [] as "text"[])) as "text")) AS "element" FROM jsonb_array_elements(("%0_%variables_table"."%variables" -> $2)) AS "%0_array"("element")), 1) as result
                         )
                         SELECT
                           *

--- a/crates/query-engine/translation/tests/snapshots/tests__select_array_variable_nested_types.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_array_variable_nested_types.snap
@@ -9,7 +9,7 @@ FROM
     SELECT
       row_to_json("%3_universe") AS "universe"
     FROM
-      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" int, "%variables" jsonb)
+      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" "int4", "%variables" "jsonb")
       CROSS JOIN LATERAL (
         WITH "%2_NATIVE_QUERY_summarize_organizations" AS (
           WITH "%7_NATIVE_QUERY_summarize_organizations" AS (
@@ -24,7 +24,10 @@ FROM
                     (
                       SELECT
                         array_agg(
-                          jsonb_populate_record(cast(null as organization), "%0_array"."element")
+                          jsonb_populate_record(
+                            cast(null as "organization"),
+                            "%0_array"."element"
+                          )
                         ) AS "element"
                       FROM
                         jsonb_array_elements(("%0_%variables_table"."%variables" -> $2)) AS "%0_array"("element")

--- a/crates/query-engine/translation/tests/snapshots/tests__select_composite_column_complex.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_composite_column_complex.snap
@@ -6,8 +6,8 @@ WITH "%1_NATIVE_QUERY_make_person" AS (
   WITH "%15_NATIVE_QUERY_make_person" AS (
     SELECT
       ROW(
-        jsonb_populate_record(cast(null as person_name), $1),
-        jsonb_populate_record(cast(null as person_address), $2)
+        jsonb_populate_record(cast(null as "person_name"), $1),
+        jsonb_populate_record(cast(null as "person_address"), $2)
       ) :: person as result
   )
   SELECT

--- a/crates/query-engine/translation/tests/snapshots/tests__select_composite_column_simple.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_composite_column_simple.snap
@@ -5,7 +5,7 @@ expression: result
 WITH "%1_NATIVE_QUERY_address_identity_function" AS (
   WITH "%9_NATIVE_QUERY_address_identity_function" AS (
     SELECT
-      jsonb_populate_record(cast(null as person_address), $1) as result
+      jsonb_populate_record(cast(null as "person_address"), $1) as result
   )
   SELECT
     *

--- a/crates/query-engine/translation/tests/snapshots/tests__select_composite_variable_complex.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_composite_variable_complex.snap
@@ -9,18 +9,18 @@ FROM
     SELECT
       row_to_json("%12_universe") AS "universe"
     FROM
-      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" int, "%variables" jsonb)
+      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" "int4", "%variables" "jsonb")
       CROSS JOIN LATERAL (
         WITH "%2_NATIVE_QUERY_make_person" AS (
           WITH "%16_NATIVE_QUERY_make_person" AS (
             SELECT
               ROW(
                 jsonb_populate_record(
-                  cast(null as person_name),
+                  cast(null as "person_name"),
                   ("%0_%variables_table"."%variables" -> $2)
                 ),
                 jsonb_populate_record(
-                  cast(null as person_address),
+                  cast(null as "person_address"),
                   ("%0_%variables_table"."%variables" -> $3)
                 )
               ) :: person as result

--- a/crates/query-engine/translation/tests/snapshots/tests__select_composite_variable_simple.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_composite_variable_simple.snap
@@ -9,13 +9,13 @@ FROM
     SELECT
       row_to_json("%6_universe") AS "universe"
     FROM
-      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" int, "%variables" jsonb)
+      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" "int4", "%variables" "jsonb")
       CROSS JOIN LATERAL (
         WITH "%2_NATIVE_QUERY_address_identity_function" AS (
           WITH "%10_NATIVE_QUERY_address_identity_function" AS (
             SELECT
               jsonb_populate_record(
-                cast(null as person_address),
+                cast(null as "person_address"),
                 ("%0_%variables_table"."%variables" -> $2)
               ) as result
           )

--- a/crates/query-engine/translation/tests/snapshots/tests__select_nested_column_complex.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_nested_column_complex.snap
@@ -5,7 +5,7 @@ expression: result
 WITH "%1_NATIVE_QUERY_organization_identity_function" AS (
   WITH "%18_NATIVE_QUERY_organization_identity_function" AS (
     SELECT
-      jsonb_populate_record(cast(null as organization), $1) as result_the_column
+      jsonb_populate_record(cast(null as "organization"), $1) as result_the_column
   )
   SELECT
     *

--- a/crates/query-engine/translation/tests/snapshots/tests__select_nested_column_simple.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_nested_column_simple.snap
@@ -5,7 +5,7 @@ expression: result
 WITH "%1_NATIVE_QUERY_address_identity_function" AS (
   WITH "%9_NATIVE_QUERY_address_identity_function" AS (
     SELECT
-      jsonb_populate_record(cast(null as person_address), $1) as result
+      jsonb_populate_record(cast(null as "person_address"), $1) as result
   )
   SELECT
     *

--- a/crates/query-engine/translation/tests/snapshots/tests__select_where_album_id_equals_self_nested_object_relationship.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_where_album_id_equals_self_nested_object_relationship.snap
@@ -75,7 +75,9 @@ FROM
                   "public"."Album" AS "%2_BOOLEXP_Album"
                 WHERE
                   (
-                    ("%2_BOOLEXP_Album"."Title" = cast($1 as varchar))
+                    (
+                      "%2_BOOLEXP_Album"."Title" = cast($1 as "varchar")
+                    )
                     AND (
                       "%0_Track"."AlbumId" = "%2_BOOLEXP_Album"."AlbumId"
                     )
@@ -88,7 +90,9 @@ FROM
                   "public"."Album" AS "%3_BOOLEXP_Album"
                 WHERE
                   (
-                    ("%3_BOOLEXP_Album"."Title" = cast($2 as varchar))
+                    (
+                      "%3_BOOLEXP_Album"."Title" = cast($2 as "varchar")
+                    )
                     AND (
                       "%0_Track"."AlbumId" = "%3_BOOLEXP_Album"."AlbumId"
                     )
@@ -101,7 +105,9 @@ FROM
                   "public"."Artist" AS "%4_BOOLEXP_Artist"
                 WHERE
                   (
-                    ("%4_BOOLEXP_Artist"."Name" = cast($3 as varchar))
+                    (
+                      "%4_BOOLEXP_Artist"."Name" = cast($3 as "varchar")
+                    )
                     AND (
                       "%3_BOOLEXP_Album"."ArtistId" = "%4_BOOLEXP_Artist"."ArtistId"
                     )

--- a/crates/query-engine/translation/tests/snapshots/tests__select_where_array_relationship.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_where_array_relationship.snap
@@ -56,7 +56,7 @@ FROM
               ) AS "%2_BOOLEXP_Album" ON ('true')
             WHERE
               (
-                "%2_BOOLEXP_Album"."Title" LIKE cast($1 as varchar)
+                "%2_BOOLEXP_Album"."Title" LIKE cast($1 as "varchar")
               )
             ORDER BY
               "%0_Artist"."ArtistId" ASC

--- a/crates/query-engine/translation/tests/snapshots/tests__sorting_by_nested_relationship_column_with_predicate.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__sorting_by_nested_relationship_column_with_predicate.snap
@@ -33,7 +33,7 @@ FROM
                           "%0_track"."AlbumId" = "%1_ORDER_PART_album"."AlbumId"
                         )
                         AND (
-                          "%1_ORDER_PART_album"."Title" = cast($1 as varchar)
+                          "%1_ORDER_PART_album"."Title" = cast($1 as "varchar")
                         )
                       )
                   ) AS "%1_ORDER_PART_album"

--- a/crates/query-engine/translation/tests/snapshots/tests__sorting_by_relationship_count_with_predicate.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__sorting_by_relationship_count_with_predicate.snap
@@ -39,7 +39,7 @@ FROM
                             "public"."Track" AS "%2_track"
                           WHERE
                             (
-                              ("%2_track"."Name" LIKE cast($1 as varchar))
+                              ("%2_track"."Name" LIKE cast($1 as "varchar"))
                               AND (
                                 "%1_ORDER_PART_Album"."AlbumId" = "%2_track"."AlbumId"
                               )

--- a/crates/query-engine/translation/tests/snapshots/tests__types__select_types_on_comparisons.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__types__select_types_on_comparisons.snap
@@ -23,15 +23,15 @@ FROM
                 (
                   (
                     (
-                      ("%0_types"."date" = cast($1 as date))
-                      AND ("%0_types"."time" = cast($2 as time))
+                      ("%0_types"."date" = cast($1 as "date"))
+                      AND ("%0_types"."time" = cast($2 as "time"))
                     )
-                    AND ("%0_types"."timetz" = cast($3 as timetz))
+                    AND ("%0_types"."timetz" = cast($3 as "timetz"))
                   )
-                  AND ("%0_types"."timestamp" = cast($4 as timestamp))
+                  AND ("%0_types"."timestamp" = cast($4 as "timestamp"))
                 )
                 AND (
-                  "%0_types"."timestamptz" = cast($5 as timestamptz)
+                  "%0_types"."timestamptz" = cast($5 as "timestamptz")
                 )
               )
           ) AS "%2_rows"

--- a/crates/query-engine/translation/tests/snapshots/tests__types__select_types_on_native_queries.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__types__select_types_on_native_queries.snap
@@ -5,11 +5,11 @@ expression: result
 WITH "%1_NATIVE_QUERY_types" AS (
   WITH "%6_NATIVE_QUERY_types" AS (
     SELECT
-      cast($1 as date) as date,
-      cast($2 as time) as time,
-      cast($3 as timetz) as timetz,
-      cast($4 as timestamp) as timestamp,
-      cast($5 as timestamptz) as timestamptz
+      cast($1 as "date") as date,
+      cast($2 as "time") as time,
+      cast($3 as "timetz") as timetz,
+      cast($4 as "timestamp") as timestamp,
+      cast($5 as "timestamptz") as timestamptz
   )
   SELECT
     *

--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__explain_tests__explain__select_where_name_nilike.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__explain_tests__explain__select_where_name_nilike.snap
@@ -20,7 +20,7 @@ FROM
             FROM
               "public"."Album" AS "%0_Album"
             WHERE
-              ("%0_Album"."Title" !~~* cast($1 as varchar))
+              ("%0_Album"."Title" !~~* cast($1 as "varchar"))
             ORDER BY
               "%0_Album"."AlbumId" ASC
             LIMIT

--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__explain_tests__explain__select_where_variable.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__explain_tests__explain__select_where_variable.snap
@@ -10,7 +10,7 @@ FROM
     SELECT
       row_to_json("%2_universe") AS "universe"
     FROM
-      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" int, "%variables" jsonb)
+      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" "int4", "%variables" "jsonb")
       CROSS JOIN LATERAL (
         SELECT
           *
@@ -28,4 +28,4 @@ FROM
                   (
                     "%1_Album"."Title" ~~ cast(
                       (
-                        ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as text[])) as varchar)) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%3_rows") AS "%3_rows") AS "%2_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%5_universe_agg"
+                        ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "varchar")) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%3_rows") AS "%3_rows") AS "%2_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%5_universe_agg"

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__explain_tests__explain__select_where_name_nilike.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__explain_tests__explain__select_where_name_nilike.snap
@@ -20,7 +20,9 @@ FROM
             FROM
               "public"."Album" AS "%0_Album"
             WHERE
-              ("%0_Album"."Title" NOT ILIKE cast($1 as varchar))
+              (
+                "%0_Album"."Title" NOT ILIKE cast($1 as "varchar")
+              )
             ORDER BY
               "%0_Album"."AlbumId" ASC
             LIMIT

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__explain_tests__explain__select_where_variable.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__explain_tests__explain__select_where_variable.snap
@@ -10,7 +10,7 @@ FROM
     SELECT
       row_to_json("%2_universe") AS "universe"
     FROM
-      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" int, "%variables" jsonb)
+      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" "int4", "%variables" "jsonb")
       CROSS JOIN LATERAL (
         SELECT
           *
@@ -28,4 +28,4 @@ FROM
                   (
                     "%1_Album"."Title" LIKE cast(
                       (
-                        ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as text[])) as varchar)) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%3_rows") AS "%3_rows") AS "%2_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%5_universe_agg"
+                        ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "varchar")) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%3_rows") AS "%3_rows") AS "%2_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%5_universe_agg"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__insert_artist_album.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__insert_artist_album.snap
@@ -6,7 +6,7 @@ EXPLAIN WITH "%0_NATIVE_QUERY_insert_artist" AS (
   INSERT INTO
     public."Artist"
   VALUES
-    (276, cast($1 as varchar)) RETURNING *
+    (276, cast($1 as "varchar")) RETURNING *
 )
 SELECT
   json_build_object('result', row_to_json("%2_universe"), 'type', $2) AS "universe"
@@ -40,7 +40,7 @@ EXPLAIN WITH "%0_NATIVE_QUERY_insert_album" AS (
   INSERT INTO
     public."Album"
   VALUES
-(348, cast($1 as varchar), 276) RETURNING *
+(348, cast($1 as "varchar"), 276) RETURNING *
 )
 SELECT
   json_build_object('result', row_to_json("%6_universe"), 'type', $2) AS "universe"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__native_queries__embedded_variable.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__native_queries__embedded_variable.snap
@@ -10,7 +10,7 @@ FROM
     SELECT
       row_to_json("%3_universe") AS "universe"
     FROM
-      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" int, "%variables" jsonb)
+      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" "int4", "%variables" "jsonb")
       CROSS JOIN LATERAL (
         WITH "%2_NATIVE_QUERY_album_by_title" AS (
           WITH "%7_NATIVE_QUERY_album_by_title" AS (
@@ -21,7 +21,7 @@ FROM
             WHERE
               "Title" LIKE cast(
                 (
-                  ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as text[])) as varchar) AND "AlbumId" < 500
+                  ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "varchar") AND "AlbumId" < 500
                 )
                 SELECT
                   *

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__select_where_name_nilike.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__select_where_name_nilike.snap
@@ -20,7 +20,7 @@ FROM
             FROM
               "public"."Album" AS "%0_Album"
             WHERE
-              ("%0_Album"."Title" !~~* cast($1 as varchar))
+              ("%0_Album"."Title" !~~* cast($1 as "varchar"))
             ORDER BY
               "%0_Album"."AlbumId" ASC
             LIMIT

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__select_where_no_variable.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__select_where_no_variable.snap
@@ -10,7 +10,7 @@ FROM
     SELECT
       row_to_json("%2_universe") AS "universe"
     FROM
-      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" int, "%variables" jsonb)
+      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" "int4", "%variables" "jsonb")
       CROSS JOIN LATERAL (
         SELECT
           *
@@ -28,4 +28,4 @@ FROM
                   (
                     "%1_Album"."Title" ~~ cast(
                       (
-                        ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as text[])) as varchar)) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%3_rows") AS "%3_rows") AS "%2_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%5_universe_agg"
+                        ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "varchar")) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%3_rows") AS "%3_rows") AS "%2_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%5_universe_agg"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__select_where_variable.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__select_where_variable.snap
@@ -10,7 +10,7 @@ FROM
     SELECT
       row_to_json("%2_universe") AS "universe"
     FROM
-      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" int, "%variables" jsonb)
+      jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" "int4", "%variables" "jsonb")
       CROSS JOIN LATERAL (
         SELECT
           *
@@ -28,4 +28,4 @@ FROM
                   (
                     "%1_Album"."Title" ~~ cast(
                       (
-                        ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as text[])) as varchar)) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%3_rows") AS "%3_rows") AS "%2_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%5_universe_agg"
+                        ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "varchar")) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%3_rows") AS "%3_rows") AS "%2_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%5_universe_agg"


### PR DESCRIPTION
### What

This PR is one step on the way to supporting scalar types living in non-search-path schemas.

It adds fields to the representation of a scalar type name at the SQL AST level, indicating the schema the type is defined in and whether the type is an array type.
