### PR TITLE
Add schema names to composite types.

### DIFF
--- a/crates/configuration/src/version3/mod.rs
+++ b/crates/configuration/src/version3/mod.rs
@@ -656,7 +656,9 @@ fn convert_type(r#type: metadata::Type) -> query_engine_metadata::metadata::Type
         metadata::Type::ScalarType(t) => {
             query_engine_metadata::metadata::Type::ScalarType(convert_scalar_type(t))
         }
-        metadata::Type::CompositeType(t) => query_engine_metadata::metadata::Type::CompositeType(t),
+        metadata::Type::CompositeType(t) => query_engine_metadata::metadata::Type::CompositeType(
+            query_engine_metadata::metadata::CompositeTypeName(t),
+        ),
         metadata::Type::ArrayType(t) => {
             query_engine_metadata::metadata::Type::ArrayType(Box::new(convert_type(*t)))
         }
@@ -884,7 +886,12 @@ fn convert_composite_types(
         composite_types
             .0
             .into_iter()
-            .map(|(k, composite_type)| (k, convert_composite_type(composite_type)))
+            .map(|(k, composite_type)| {
+                (
+                    query_engine_metadata::metadata::CompositeTypeName(k),
+                    convert_composite_type(composite_type),
+                )
+            })
             .collect(),
     )
 }

--- a/crates/configuration/src/version3/mod.rs
+++ b/crates/configuration/src/version3/mod.rs
@@ -901,6 +901,7 @@ fn convert_composite_type(
 ) -> query_engine_metadata::metadata::CompositeType {
     query_engine_metadata::metadata::CompositeType {
         name: composite_type.name,
+        schema_name: None, // Version3 does not capture the schema of a composite type
         fields: composite_type
             .fields
             .into_iter()

--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -256,9 +256,11 @@ pub async fn get_schema(
                     })
                     .collect(),
             };
-            (ctype_name.clone(), object_type)
-        })
+            (ctype_name.0.clone(), object_type)
+        },
+    )
         .collect::<BTreeMap<_, _>>();
+    );
 
     let mut object_types = table_types;
     object_types.extend(native_queries_types);
@@ -347,7 +349,7 @@ fn type_to_type(typ: &metadata::Type) -> models::Type {
         metadata::Type::ScalarType(scalar_type) => models::Type::Named {
             name: scalar_type.0.clone(),
         },
-        metadata::Type::CompositeType(t) => models::Type::Named { name: t.clone() },
+        metadata::Type::CompositeType(t) => models::Type::Named { name: t.0.clone() },
     }
 }
 

--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -258,10 +258,8 @@ pub async fn get_schema(
                     .collect(),
             };
             (ctype_name.0.clone(), object_type)
-        },
-    )
+        })
         .collect::<BTreeMap<_, _>>();
-    );
 
     let mut object_types = table_types;
     object_types.extend(native_queries_types);

--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -10,6 +10,7 @@ use ndc_sdk::models;
 
 use ndc_postgres_configuration as configuration;
 use query_engine_metadata::metadata;
+use query_engine_translation::translation::helpers::Env;
 use query_engine_translation::translation::mutation;
 
 /// Get the connector's schema.
@@ -298,16 +299,14 @@ pub async fn get_schema(
         .collect();
 
     let mut more_object_types = BTreeMap::new();
+    let env = Env::new(metadata, BTreeMap::new(), config.mutations_version, None);
     let generated_procedures: Vec<models::ProcedureInfo> =
-        query_engine_translation::translation::mutation::generate::generate(
-            &metadata.tables,
-            config.mutations_version,
-        )
-        .iter()
-        .map(|(name, mutation)| {
-            mutation_to_procedure(name, mutation, &mut more_object_types, &mut scalar_types)
-        })
-        .collect();
+        query_engine_translation::translation::mutation::generate::generate(&env)
+            .iter()
+            .map(|(name, mutation)| {
+                mutation_to_procedure(name, mutation, &mut more_object_types, &mut scalar_types)
+            })
+            .collect();
 
     procedures.extend(generated_procedures);
     object_types.extend(more_object_types);

--- a/crates/query-engine/metadata/src/metadata/database.rs
+++ b/crates/query-engine/metadata/src/metadata/database.rs
@@ -22,14 +22,20 @@ pub enum Type {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct CompositeTypes(pub BTreeMap<CompositeTypeName, CompositeType>);
 
+impl CompositeTypes {
+    pub fn empty() -> Self {
+        CompositeTypes(BTreeMap::new())
+    }
+}
+
 /// Information about a composite type. These are very similar to tables, but with the crucial
 /// difference that composite types do not support constraints (such as NOT NULL).
 #[derive(Debug, Clone, PartialEq, Eq)]
 
 pub struct CompositeType {
     pub name: String,
+    pub schema_name: Option<String>,
     pub fields: BTreeMap<String, FieldInfo>,
-
     pub description: Option<String>,
 }
 
@@ -48,6 +54,12 @@ pub struct FieldInfo {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 
 pub struct ComparisonOperators(pub BTreeMap<ScalarTypeName, BTreeMap<String, ComparisonOperator>>);
+
+impl ComparisonOperators {
+    pub fn empty() -> Self {
+        ComparisonOperators(BTreeMap::new())
+    }
+}
 
 /// Represents a postgres binary comparison operator
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -73,6 +85,12 @@ pub enum OperatorKind {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 
 pub struct TablesInfo(pub BTreeMap<String, TableInfo>);
+
+impl TablesInfo {
+    pub fn empty() -> Self {
+        TablesInfo(BTreeMap::new())
+    }
+}
 
 /// Information about a database table (or any other kind of relation).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -173,16 +191,26 @@ pub struct ForeignRelation {
 
 pub struct AggregateFunctions(pub BTreeMap<ScalarTypeName, BTreeMap<String, AggregateFunction>>);
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+impl AggregateFunctions {
+    pub fn empty() -> Self {
+        AggregateFunctions(BTreeMap::new())
+    }
+}
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AggregateFunction {
     pub return_type: ScalarTypeName,
 }
 
 /// Type representation of scalar types, grouped by type.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-
 pub struct TypeRepresentations(pub BTreeMap<ScalarTypeName, TypeRepresentation>);
+
+impl TypeRepresentations {
+    pub fn empty() -> Self {
+        TypeRepresentations(BTreeMap::new())
+    }
+}
 
 /// Type representation of a scalar type.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/query-engine/metadata/src/metadata/database.rs
+++ b/crates/query-engine/metadata/src/metadata/database.rs
@@ -2,23 +2,25 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-/// Map of all known composite types.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-
-pub struct CompositeTypes(pub BTreeMap<String, CompositeType>);
-
-/// A Scalar Type.
+/// A name of a Scalar Type, as it appears in the NDC scheme.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ScalarTypeName(pub String);
 
+/// The name of a Composite Type, as it appears in the NDC schema
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CompositeTypeName(pub String);
+
 /// The type of values that a column, field, or argument may take.
 #[derive(Debug, Clone, PartialEq, Eq)]
-
 pub enum Type {
     ScalarType(ScalarTypeName),
-    CompositeType(String),
+    CompositeType(CompositeTypeName),
     ArrayType(Box<Type>),
 }
+
+/// Map of all known composite types.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct CompositeTypes(pub BTreeMap<CompositeTypeName, CompositeType>);
 
 /// Information about a composite type. These are very similar to tables, but with the crucial
 /// difference that composite types do not support constraints (such as NOT NULL).

--- a/crates/query-engine/metadata/src/metadata/mod.rs
+++ b/crates/query-engine/metadata/src/metadata/mod.rs
@@ -21,3 +21,17 @@ pub struct Metadata {
     pub type_representations: TypeRepresentations,
     pub occurring_scalar_types: BTreeSet<ScalarTypeName>,
 }
+
+impl Metadata {
+    pub fn empty() -> Self {
+        Metadata {
+            tables: TablesInfo::empty(),
+            composite_types: CompositeTypes::empty(),
+            native_queries: NativeQueries::empty(),
+            aggregate_functions: AggregateFunctions::empty(),
+            comparison_operators: ComparisonOperators::empty(),
+            type_representations: TypeRepresentations::empty(),
+            occurring_scalar_types: BTreeSet::new(),
+        }
+    }
+}

--- a/crates/query-engine/metadata/src/metadata/native_queries.rs
+++ b/crates/query-engine/metadata/src/metadata/native_queries.rs
@@ -11,6 +11,12 @@ use std::collections::BTreeMap;
 
 pub struct NativeQueries(pub BTreeMap<String, NativeQueryInfo>);
 
+impl NativeQueries {
+    pub fn empty() -> Self {
+        NativeQueries(BTreeMap::new())
+    }
+}
+
 /// Information about a Native Query
 #[derive(Debug, Clone, PartialEq, Eq)]
 

--- a/crates/query-engine/translation/src/translation/helpers.rs
+++ b/crates/query-engine/translation/src/translation/helpers.rs
@@ -125,12 +125,15 @@ impl<'request> Env<'request> {
         match it_is_a_collection {
             Ok(collection_info) => Ok(CompositeTypeInfo::CollectionInfo(collection_info)),
             Err(Error::CollectionNotFound(_)) => {
-                let its_a_type = self.metadata.composite_types.0.get(type_name).map(|t| {
-                    CompositeTypeInfo::CompositeTypeInfo {
+                let its_a_type = self
+                    .metadata
+                    .composite_types
+                    .0
+                    .get(&metadata::CompositeTypeName(type_name.to_string()))
+                    .map(|t| CompositeTypeInfo::CompositeTypeInfo {
                         name: t.name.clone(),
                         info: t.clone(),
-                    }
-                });
+                    });
 
                 its_a_type.ok_or(Error::CollectionNotFound(type_name.to_string()))
             }

--- a/crates/query-engine/translation/src/translation/helpers.rs
+++ b/crates/query-engine/translation/src/translation/helpers.rs
@@ -144,7 +144,7 @@ impl<'a> From<&'a CollectionInfo<'a>> for FieldsInfo<'a> {
 impl<'request> Env<'request> {
     pub fn with_empty<F, R>(f: F) -> R
     where
-        F: FnOnce(&Env) -> R,
+        F: FnOnce(Env) -> R,
     {
         let temp_metadata = metadata::Metadata::empty();
         let temp_env = Env {
@@ -153,7 +153,7 @@ impl<'request> Env<'request> {
             mutations_version: None,
             variables_table: None,
         };
-        f(&temp_env)
+        f(temp_env)
     }
 
     /// Create a new Env by supplying the metadata and relationships.

--- a/crates/query-engine/translation/src/translation/helpers.rs
+++ b/crates/query-engine/translation/src/translation/helpers.rs
@@ -176,6 +176,8 @@ impl<'request> Env<'request> {
         &self,
         type_name: &'request str,
     ) -> Result<FieldsInfo<'request>, Error> {
+        // Lookup the fields of a type name in a specific order:
+        // tables, then composite types, then native queries.
         let info =
             self.metadata
                 .tables

--- a/crates/query-engine/translation/src/translation/mutation/experimental/delete.rs
+++ b/crates/query-engine/translation/src/translation/mutation/experimental/delete.rs
@@ -128,7 +128,8 @@ pub fn translate_delete(
                 .get(&by_column.name)
                 .ok_or(Error::ArgumentNotFound(by_column.name.clone()))?;
 
-            let key_value = translate_json_value(state, unique_key, &by_column.r#type).unwrap();
+            let key_value =
+                translate_json_value(env, state, unique_key, &by_column.r#type).unwrap();
 
             let unique_expression = ast::Expression::BinaryOperation {
                 left: Box::new(ast::Expression::ColumnReference(

--- a/crates/query-engine/translation/src/translation/mutation/experimental/insert.rs
+++ b/crates/query-engine/translation/src/translation/mutation/experimental/insert.rs
@@ -42,6 +42,7 @@ pub fn generate(
 /// Given the description of an insert mutation (ie, `InsertMutation`),
 /// and the arguments, output the SQL AST.
 pub fn translate(
+    env: &crate::translation::helpers::Env,
     state: &mut crate::translation::helpers::State,
     mutation: &InsertMutation,
     arguments: &BTreeMap<String, serde_json::Value>,
@@ -64,7 +65,12 @@ pub fn translate(
                         ))?;
 
                 columns.push(ast::ColumnName(column_info.name.clone()));
-                values.push(translate_json_value(state, value, &column_info.r#type)?);
+                values.push(translate_json_value(
+                    env,
+                    state,
+                    value,
+                    &column_info.r#type,
+                )?);
             }
         }
         _ => todo!(),

--- a/crates/query-engine/translation/src/translation/mutation/experimental/translate.rs
+++ b/crates/query-engine/translation/src/translation/mutation/experimental/translate.rs
@@ -36,7 +36,7 @@ pub fn translate(
             let return_collection = insert.collection_name.clone();
             (
                 return_collection,
-                sql::ast::CTExpr::Insert(super::insert::translate(state, &insert, arguments)?),
+                sql::ast::CTExpr::Insert(super::insert::translate(env, state, &insert, arguments)?),
             )
         }
     })

--- a/crates/query-engine/translation/src/translation/mutation/generate.rs
+++ b/crates/query-engine/translation/src/translation/mutation/generate.rs
@@ -1,7 +1,9 @@
 //! Given introspection data, generate a set of standard mutation procedures
 
-use query_engine_metadata::metadata::{database, mutations};
+use query_engine_metadata::metadata::mutations;
 use std::collections::BTreeMap;
+
+use crate::translation::helpers::Env;
 
 use super::experimental;
 use super::v1;
@@ -13,17 +15,14 @@ pub enum Mutation {
 }
 
 /// Given our introspection data, work out all the mutations we can generate
-pub fn generate(
-    tables_info: &database::TablesInfo,
-    mutations_version: Option<mutations::MutationsVersion>,
-) -> BTreeMap<String, Mutation> {
-    match mutations_version {
-        Some(mutations::MutationsVersion::V1) => v1::generate(tables_info)
+pub fn generate(env: &Env) -> BTreeMap<String, Mutation> {
+    match env.mutations_version {
+        Some(mutations::MutationsVersion::V1) => v1::generate(env)
             .into_iter()
             .map(|(name, mutation)| (name, Mutation::V1(mutation)))
             .collect(),
         Some(mutations::MutationsVersion::VeryExperimentalWip) => {
-            experimental::generate(tables_info)
+            experimental::generate(&env.metadata.tables)
                 .into_iter()
                 .map(|(name, mutation)| (name, Mutation::Experimental(mutation)))
                 .collect()

--- a/crates/query-engine/translation/src/translation/mutation/v1/generate.rs
+++ b/crates/query-engine/translation/src/translation/mutation/v1/generate.rs
@@ -14,7 +14,7 @@ pub enum Mutation {
 /// Given our introspection data, work out all the mutations we can generate
 pub fn generate(env: &crate::translation::helpers::Env) -> BTreeMap<String, Mutation> {
     let mut mutations = BTreeMap::new();
-    for (collection_name, table_info) in env.metadata.tables.0.iter() {
+    for (collection_name, table_info) in &env.metadata.tables.0 {
         let delete_mutations = generate_delete_by_unique(collection_name, table_info);
 
         for (name, delete_mutation) in delete_mutations {

--- a/crates/query-engine/translation/src/translation/mutation/v1/generate.rs
+++ b/crates/query-engine/translation/src/translation/mutation/v1/generate.rs
@@ -3,7 +3,6 @@
 use super::delete::{generate_delete_by_unique, DeleteMutation};
 use super::insert;
 use super::insert::InsertMutation;
-use query_engine_metadata::metadata::database;
 use std::collections::BTreeMap;
 
 #[derive(Debug, Clone)]
@@ -13,9 +12,9 @@ pub enum Mutation {
 }
 
 /// Given our introspection data, work out all the mutations we can generate
-pub fn generate(tables_info: &database::TablesInfo) -> BTreeMap<String, Mutation> {
+pub fn generate(env: &crate::translation::helpers::Env) -> BTreeMap<String, Mutation> {
     let mut mutations = BTreeMap::new();
-    for (collection_name, table_info) in &tables_info.0 {
+    for (collection_name, table_info) in env.metadata.tables.0.iter() {
         let delete_mutations = generate_delete_by_unique(collection_name, table_info);
 
         for (name, delete_mutation) in delete_mutations {

--- a/crates/query-engine/translation/src/translation/mutation/v1/insert.rs
+++ b/crates/query-engine/translation/src/translation/mutation/v1/insert.rs
@@ -42,6 +42,7 @@ pub fn generate(
 /// Given the description of an insert mutation (ie, `InsertMutation`),
 /// and the arguments, output the SQL AST.
 pub fn translate(
+    env: &crate::translation::helpers::Env,
     state: &mut crate::translation::helpers::State,
     mutation: &InsertMutation,
     arguments: &BTreeMap<String, serde_json::Value>,
@@ -64,7 +65,12 @@ pub fn translate(
                         ))?;
 
                 columns.push(ast::ColumnName(column_info.name.clone()));
-                values.push(translate_json_value(state, value, &column_info.r#type)?);
+                values.push(translate_json_value(
+                    env,
+                    state,
+                    value,
+                    &column_info.r#type,
+                )?);
             }
         }
         _ => todo!(),

--- a/crates/query-engine/translation/src/translation/mutation/v1/translate.rs
+++ b/crates/query-engine/translation/src/translation/mutation/v1/translate.rs
@@ -28,7 +28,7 @@ pub fn translate(
             (
                 return_collection,
                 sql::ast::CTExpr::Delete(super::delete::translate_delete(
-                    state, &delete, arguments,
+                    env, state, &delete, arguments,
                 )?),
             )
         }
@@ -36,7 +36,7 @@ pub fn translate(
             let return_collection = insert.collection_name.clone();
             (
                 return_collection,
-                sql::ast::CTExpr::Insert(super::insert::translate(state, &insert, arguments)?),
+                sql::ast::CTExpr::Insert(super::insert::translate(env, state, &insert, arguments)?),
             )
         }
     })
@@ -51,7 +51,7 @@ fn lookup_generated_mutation(
     // this means we generate them on every mutation request
     // i don't think this is optimal but I'd like to get this working before working out
     // where best to store these
-    let generated = super::generate(&env.metadata.tables);
+    let generated = super::generate(env);
 
     generated
         .get(procedure_name)

--- a/crates/query-engine/translation/src/translation/query/fields.rs
+++ b/crates/query-engine/translation/src/translation/query/fields.rs
@@ -4,6 +4,7 @@ use indexmap::indexmap;
 use indexmap::IndexMap;
 
 use ndc_sdk::models;
+use query_engine_metadata::metadata;
 
 use super::relationships;
 use crate::translation::error::Error;
@@ -280,7 +281,7 @@ fn translate_nested_field(
 
     // The recursive call to the next layer of fields
     let nested_field_table_reference = TableNameAndReference {
-        name: nested_field_type_name,
+        name: nested_field_type_name.0,
         reference: sql::ast::TableReference::AliasedTable(nested_field_binding_alias),
     };
     let mut fields_select = translate_fields(
@@ -507,9 +508,12 @@ fn get_type_representation_cast_type(
 }
 
 /// Create an explicit NestedField that selects all fields (1 level) of a composite type.
-fn unpack_composite_type(env: &Env, composite_type: &str) -> Result<models::NestedField, Error> {
+fn unpack_composite_type(
+    env: &Env,
+    composite_type: &metadata::CompositeTypeName,
+) -> Result<models::NestedField, Error> {
     Ok(models::NestedField::Object({
-        let composite_type = env.lookup_composite_type(composite_type)?;
+        let composite_type = env.lookup_composite_type(&composite_type.0)?;
         let mut fields = indexmap!();
         for (result_name, field_name) in composite_type.fields() {
             fields.insert(

--- a/crates/query-engine/translation/src/translation/query/filtering.rs
+++ b/crates/query-engine/translation/src/translation/query/filtering.rs
@@ -413,11 +413,11 @@ fn translate_comparison_value(
             translate_comparison_target(env, state, root_and_current_tables, column)
         }
         models::ComparisonValue::Scalar { value: json_value } => Ok((
-            values::translate_json_value(state, json_value, typ)?,
+            values::translate_json_value(env, state, json_value, typ)?,
             vec![],
         )),
         models::ComparisonValue::Variable { name: var } => Ok((
-            values::translate_variable(state, env.get_variables_table()?, var, typ),
+            values::translate_variable(env, state, env.get_variables_table()?, var, typ)?,
             vec![],
         )),
     }

--- a/crates/query-engine/translation/src/translation/query/native_queries.rs
+++ b/crates/query-engine/translation/src/translation/query/native_queries.rs
@@ -48,17 +48,21 @@ pub fn translate(
                     let exp = match native_query.arguments.get(&param) {
                         None => Err(Error::ArgumentNotFound(param.clone())),
                         Some(argument) => match argument {
-                            models::Argument::Literal { value } => {
-                                values::translate_json_value(&mut translation_state, value, &typ)
-                            }
+                            models::Argument::Literal { value } => values::translate_json_value(
+                                env,
+                                &mut translation_state,
+                                value,
+                                &typ,
+                            ),
                             models::Argument::Variable { name } => match &variables_table {
                                 Err(err) => Err(err.clone()),
-                                Ok(variables_table) => Ok(values::translate_variable(
+                                Ok(variables_table) => values::translate_variable(
+                                    env,
                                     &mut translation_state,
                                     variables_table.clone(),
                                     name,
                                     &typ,
-                                )),
+                                ),
                             },
                         },
                     }?;

--- a/crates/query-engine/translation/src/translation/query/values.rs
+++ b/crates/query-engine/translation/src/translation/query/values.rs
@@ -1,12 +1,14 @@
 //! Handle the translation of literal values.
 
-use crate::translation::{error::Error, helpers::State};
+use crate::translation::{error::Error, helpers::Env, helpers::State};
 use query_engine_metadata::metadata::database;
-use query_engine_sql::sql::{self, ast::ColumnReference, helpers::simple_select};
-use sql::ast::{Expression, Value};
+use query_engine_sql::sql;
+use query_engine_sql::sql::ast::{ColumnReference, Expression, Value};
+use query_engine_sql::sql::helpers::simple_select;
 
 /// Convert a JSON value into a SQL value.
 pub fn translate_json_value(
+    env: &Env,
     state: &mut State,
     value: &serde_json::Value,
     r#type: &database::Type,
@@ -14,7 +16,7 @@ pub fn translate_json_value(
     match (value, r#type) {
         (serde_json::Value::Null, _) => Ok(Expression::Cast {
             expression: Box::new(Expression::Value(Value::Null)),
-            r#type: type_to_ast_scalar_type(r#type),
+            r#type: type_to_ast_scalar_type(env, r#type)?,
         }),
         (serde_json::Value::Bool(b), _) => Ok(Expression::Value(Value::Bool(*b))),
         (serde_json::Value::Number(n), _) => {
@@ -25,25 +27,17 @@ pub fn translate_json_value(
         }
         (serde_json::Value::String(str), _) => Ok(Expression::Cast {
             expression: Box::new(Expression::Value(Value::String(str.clone()))),
-            r#type: type_to_ast_scalar_type(r#type),
+            r#type: type_to_ast_scalar_type(env, r#type)?,
         }),
         (serde_json::Value::Array(_), database::Type::ArrayType(_)) => {
             let value_expression =
                 sql::ast::Expression::Value(sql::ast::Value::JsonValue(value.clone()));
-            Ok(translate_projected_variable(
-                state,
-                r#type,
-                value_expression,
-            ))
+            translate_projected_variable(env, state, r#type, value_expression)
         }
         (serde_json::Value::Object(_obj), database::Type::CompositeType(_type_name)) => {
             let value_expression =
                 sql::ast::Expression::Value(sql::ast::Value::JsonValue(value.clone()));
-            Ok(translate_projected_variable(
-                state,
-                r#type,
-                value_expression,
-            ))
+            translate_projected_variable(env, state, r#type, value_expression)
         }
         // If the type is not congruent with the value constructor we simply pass the json value
         // raw and cast to the specified type. This allows users to consume any json values,
@@ -53,39 +47,50 @@ pub fn translate_json_value(
                 expression: Box::new(Expression::Value(Value::JsonValue(value.clone()))),
                 r#type: sql::ast::ScalarTypeName::new_unqualified("jsonb"),
             }),
-            r#type: type_to_ast_scalar_type(r#type),
+            r#type: type_to_ast_scalar_type(env, r#type)?,
         }),
     }
 }
 
 /// Translate a NDC 'Type' to an SQL type name.
-fn type_to_ast_scalar_type(typ: &database::Type) -> sql::ast::ScalarTypeName {
+fn type_to_ast_scalar_type(
+    env: &Env,
+    typ: &database::Type,
+) -> Result<sql::ast::ScalarTypeName, Error> {
     match typ {
         query_engine_metadata::metadata::Type::ArrayType(t) => {
             // This will collapse nested arrays. This is fine since it matches the behavior of
             // Postgres where these are unsupported anyway.
-            let mut scalar_type = type_to_ast_scalar_type(t);
+            let mut scalar_type = type_to_ast_scalar_type(env, t)?;
             scalar_type.is_array = true;
-            scalar_type
+            Ok(scalar_type)
         }
         query_engine_metadata::metadata::Type::ScalarType(t) => {
-            // TODO: This will need access to a mapping between ndc-type names and db type names
-            sql::ast::ScalarTypeName::new_unqualified(&t.0)
+            // TODO: When adding schema suppor to scalar types this will need access to a mapping
+            // between ndc-type names and db type names like we have for composite types.
+            Ok(sql::ast::ScalarTypeName::new_unqualified(&t.0))
         }
         query_engine_metadata::metadata::Type::CompositeType(t) => {
-            // TODO: This will need access to a mapping between ndc-type names and db type names
-            sql::ast::ScalarTypeName::new_unqualified(&t.0)
+            let type_info = env.lookup_composite_type(t)?;
+            Ok(sql::ast::ScalarTypeName {
+                type_name: type_info.type_name().to_string(),
+                schema_name: type_info
+                    .schema_name()
+                    .map(|s| sql::ast::SchemaName(s.clone())),
+                is_array: false,
+            })
         }
     }
 }
 
 /// Convert a variable into a SQL value.
 pub fn translate_variable(
+    env: &Env,
     state: &mut State,
     variables_table: sql::ast::TableReference,
     variable: &str,
     r#type: &database::Type,
-) -> sql::ast::Expression {
+) -> Result<sql::ast::Expression, Error> {
     let variables_reference = Expression::ColumnReference(ColumnReference::AliasedColumn {
         table: variables_table,
         column: sql::helpers::make_column_alias(sql::helpers::VARIABLES_FIELD.to_string()),
@@ -101,7 +106,7 @@ pub fn translate_variable(
         ))),
     };
 
-    translate_projected_variable(state, r#type, projected_variable_exp)
+    translate_projected_variable(env, state, r#type, projected_variable_exp)
 }
 
 /// Produce a SQL expression that translates an expression of Postgres type 'jsonb' into a given
@@ -113,17 +118,18 @@ pub fn translate_variable(
 /// Arrays are more complex since there isn't a builtin function that handles array
 /// types.
 pub fn translate_projected_variable(
+    env: &Env,
     state: &mut State,
     r#type: &database::Type,
     exp: sql::ast::Expression,
-) -> sql::ast::Expression {
-    match r#type {
+) -> Result<sql::ast::Expression, Error> {
+    let result = match r#type {
         database::Type::CompositeType(_type_name) => sql::ast::Expression::FunctionCall {
             function: sql::ast::Function::JsonbPopulateRecord,
             args: vec![
                 sql::ast::Expression::Cast {
                     expression: Box::new(sql::ast::Expression::Value(sql::ast::Value::Null)),
-                    r#type: type_to_ast_scalar_type(r#type),
+                    r#type: type_to_ast_scalar_type(env, r#type)?,
                 },
                 exp,
             ],
@@ -157,7 +163,7 @@ pub fn translate_projected_variable(
                 });
 
             let converted_element_exp =
-                translate_projected_variable(state, type_name, element_expression);
+                translate_projected_variable(env, state, type_name, element_expression)?;
 
             let mut result_select = simple_select(vec![(
                 element_column.clone(),
@@ -186,7 +192,9 @@ pub fn translate_projected_variable(
                     },
                 }),
             }),
-            r#type: type_to_ast_scalar_type(r#type),
+            r#type: type_to_ast_scalar_type(env, r#type)?,
         },
-    }
+    };
+
+    Ok(result)
 }

--- a/crates/query-engine/translation/src/translation/query/values.rs
+++ b/crates/query-engine/translation/src/translation/query/values.rs
@@ -74,7 +74,7 @@ fn type_to_ast_scalar_type(typ: &database::Type) -> sql::ast::ScalarTypeName {
         }
         query_engine_metadata::metadata::Type::CompositeType(t) => {
             // TODO: This will need access to a mapping between ndc-type names and db type names
-            sql::ast::ScalarTypeName::new_unqualified(t)
+            sql::ast::ScalarTypeName::new_unqualified(&t.0)
         }
     }
 }


### PR DESCRIPTION
### What

This PR adds schema names to composite types in metadata. Schema names are not introspected yet, but this will happen in a subsequent PR.

Also translate composite types into sql::ast::ScalarTypeName using their
name and schema rather than the ndc-schema object type name, which had
incidentally been the same as the (unqualified) type name.

This means we need access to the `Env` when translating values/variables of
composite type. Most of the files changed in this PR is a result from
knock-on effects of this.

This PR is a follow-up to https://github.com/hasura/ndc-postgres/pull/431.