### PR TITLE
Use the full SHA when updating ndc-postgres-multitenant.

### DIFF
--- a/.github/workflows/update-multitenant-dep.yaml
+++ b/.github/workflows/update-multitenant-dep.yaml
@@ -33,7 +33,7 @@ jobs:
           set -eux
 
           # get newest commit to use
-          LATEST_SHA="$(cd ndc-postgres && git rev-parse --short HEAD)"
+          LATEST_SHA="$(cd ndc-postgres && git rev-parse HEAD)"
 
           BRANCH_NAME="update-ndc-postgres-to-$LATEST_SHA"
           DEP_FILEPATH="Cargo.toml"


### PR DESCRIPTION
### What

Cargo chokes when using different variations of Git commit refs, even if they eventually point to the same commit. It believes they're different versions and won't reconcile them, as there's no semver-based versioning to lean on.

It's safer to always use the full SHA in order to avoid the situation where different SHA lengths are used.

### How

I removed `--short`.