### PR TITLE
Display the connection pool span to the user.

### DIFF
--- a/crates/connectors/ndc-postgres/src/state.rs
+++ b/crates/connectors/ndc-postgres/src/state.rs
@@ -31,7 +31,10 @@ pub async fn create_state(
         .parse()
         .map_err(InitializationError::InvalidConnectionUri)?;
     let pool = create_pool(&connection_url, pool_settings)
-        .instrument(info_span!("Create connection pool"))
+        .instrument(info_span!(
+            "Create connection pool",
+            internal.visibility = "user",
+        ))
         .await?;
 
     let database_version = {


### PR DESCRIPTION
### What

Establishing the connection pool can take a little while and it's important that we convey this to the user, lest they believe that we're just sitting around not processing their request.

### How

```rust
internal.visibility = "user"
```