### PR TITLE
Introduce configuration version 4: Support schema-qualified type

### DIFF
--- a/crates/cli/tests/update_tests.rs
+++ b/crates/cli/tests/update_tests.rs
@@ -55,6 +55,7 @@ async fn test_update_configuration() -> anyhow::Result<()> {
             let some_table_metadata = metadata.tables.0.get("Artist");
             assert!(some_table_metadata.is_some());
         }
+        _ => assert!(false, "Expected version 3"),
     }
 
     Ok(())

--- a/crates/cli/tests/update_tests.rs
+++ b/crates/cli/tests/update_tests.rs
@@ -55,7 +55,7 @@ async fn test_update_configuration() -> anyhow::Result<()> {
             let some_table_metadata = metadata.tables.0.get("Artist");
             assert!(some_table_metadata.is_some());
         }
-        _ => assert!(false, "Expected version 3"),
+        RawConfiguration::Version4(_) => panic!("Expected version 3"),
     }
 
     Ok(())

--- a/crates/configuration/src/error.rs
+++ b/crates/configuration/src/error.rs
@@ -27,4 +27,10 @@ pub enum Error {
 
     #[error("I/O error: {0}")]
     IoError(#[from] std::io::Error),
+
+    #[error("Did not find expected version tag: \"{0}\"")]
+    DidNotFindExpectedVersionTag(String),
+
+    #[error("Unable to parse any configuration versions: TODO")]
+    UnableToParseAnyVersions(Vec<Error>),
 }

--- a/crates/configuration/src/lib.rs
+++ b/crates/configuration/src/lib.rs
@@ -4,6 +4,7 @@ mod values;
 pub mod environment;
 mod error;
 pub mod version3;
+pub mod version4;
 
 pub use configuration::{
     introspect, parse_configuration, Configuration, RawConfiguration, CONFIGURATION_FILENAME,
@@ -11,4 +12,3 @@ pub use configuration::{
 };
 pub use error::Error;
 pub use values::{ConnectionUri, IsolationLevel, PoolSettings, Secret};
-pub use version3::occurring_scalar_types;

--- a/crates/configuration/src/version3/mod.rs
+++ b/crates/configuration/src/version3/mod.rs
@@ -557,7 +557,6 @@ pub fn convert_metadata(metadata: metadata::Metadata) -> query_engine_metadata::
         native_queries: convert_native_queries(metadata.native_queries),
         aggregate_functions: convert_aggregate_functions(metadata.aggregate_functions.clone()),
         comparison_operators: convert_comparison_operators(metadata.comparison_operators.clone()),
-        type_representations: convert_type_representations(metadata.type_representations.clone()),
         scalar_types: convert_scalar_types(
             scalar_types,
             metadata.aggregate_functions,

--- a/crates/configuration/src/version3/mod.rs
+++ b/crates/configuration/src/version3/mod.rs
@@ -558,7 +558,6 @@ pub fn convert_metadata(metadata: metadata::Metadata) -> query_engine_metadata::
         aggregate_functions: convert_aggregate_functions(metadata.aggregate_functions.clone()),
         comparison_operators: convert_comparison_operators(metadata.comparison_operators.clone()),
         type_representations: convert_type_representations(metadata.type_representations.clone()),
-        occurring_scalar_types: convert_occurring_scalar_types(scalar_types.clone()),
         scalar_types: convert_scalar_types(
             scalar_types,
             metadata.aggregate_functions,
@@ -615,12 +614,6 @@ fn convert_scalar_types(
             })
             .collect(),
     )
-}
-
-fn convert_occurring_scalar_types(
-    scalar_types: BTreeSet<metadata::ScalarType>,
-) -> BTreeSet<query_engine_metadata::metadata::ScalarTypeName> {
-    scalar_types.into_iter().map(convert_scalar_type).collect()
 }
 
 fn convert_scalar_type(

--- a/crates/configuration/src/version3/mod.rs
+++ b/crates/configuration/src/version3/mod.rs
@@ -555,7 +555,6 @@ pub fn convert_metadata(metadata: metadata::Metadata) -> query_engine_metadata::
         tables: convert_tables(metadata.tables),
         composite_types: convert_composite_types(composite_types),
         native_queries: convert_native_queries(metadata.native_queries),
-        aggregate_functions: convert_aggregate_functions(metadata.aggregate_functions.clone()),
         scalar_types: convert_scalar_types(
             scalar_types,
             metadata.aggregate_functions,

--- a/crates/configuration/src/version3/mod.rs
+++ b/crates/configuration/src/version3/mod.rs
@@ -556,7 +556,6 @@ pub fn convert_metadata(metadata: metadata::Metadata) -> query_engine_metadata::
         composite_types: convert_composite_types(composite_types),
         native_queries: convert_native_queries(metadata.native_queries),
         aggregate_functions: convert_aggregate_functions(metadata.aggregate_functions.clone()),
-        comparison_operators: convert_comparison_operators(metadata.comparison_operators.clone()),
         scalar_types: convert_scalar_types(
             scalar_types,
             metadata.aggregate_functions,

--- a/crates/configuration/src/version4/comparison.rs
+++ b/crates/configuration/src/version4/comparison.rs
@@ -1,0 +1,133 @@
+//! Helpers for the comparison operators configuration.
+
+use super::database::OperatorKind;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Define the names that comparison operators will be exposed as by the automatic introspection.
+#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ComparisonOperatorMapping {
+    /// The name of the operator as defined by the database
+    pub operator_name: String,
+    /// The name the operator will appear under in the exposed API
+    pub exposed_name: String,
+    /// Equal, In or Custom.
+    pub operator_kind: OperatorKind,
+}
+
+impl ComparisonOperatorMapping {
+    /// The default comparison operator mappings apply the aliases that are used in graphql-engine v2.
+    pub fn default_mappings() -> Vec<ComparisonOperatorMapping> {
+        vec![
+            // Common mappings
+            ComparisonOperatorMapping {
+                operator_name: "=".to_string(),
+                exposed_name: "_eq".to_string(),
+                operator_kind: OperatorKind::Equal,
+            },
+            ComparisonOperatorMapping {
+                operator_name: "<=".to_string(),
+                exposed_name: "_lte".to_string(),
+                operator_kind: OperatorKind::Custom,
+            },
+            ComparisonOperatorMapping {
+                operator_name: ">".to_string(),
+                exposed_name: "_gt".to_string(),
+                operator_kind: OperatorKind::Custom,
+            },
+            ComparisonOperatorMapping {
+                operator_name: ">=".to_string(),
+                exposed_name: "_gte".to_string(),
+                operator_kind: OperatorKind::Custom,
+            },
+            ComparisonOperatorMapping {
+                operator_name: "<".to_string(),
+                exposed_name: "_lt".to_string(),
+                operator_kind: OperatorKind::Custom,
+            },
+            // Preferred by CockroachDB
+            ComparisonOperatorMapping {
+                operator_name: "!=".to_string(),
+                exposed_name: "_neq".to_string(),
+                operator_kind: OperatorKind::Custom,
+            },
+            ComparisonOperatorMapping {
+                operator_name: "LIKE".to_string(),
+                exposed_name: "_like".to_string(),
+                operator_kind: OperatorKind::Custom,
+            },
+            ComparisonOperatorMapping {
+                operator_name: "NOT LIKE".to_string(),
+                exposed_name: "_nlike".to_string(),
+                operator_kind: OperatorKind::Custom,
+            },
+            ComparisonOperatorMapping {
+                operator_name: "ILIKE".to_string(),
+                exposed_name: "_ilike".to_string(),
+                operator_kind: OperatorKind::Custom,
+            },
+            ComparisonOperatorMapping {
+                operator_name: "NOT ILIKE".to_string(),
+                exposed_name: "_nilike".to_string(),
+                operator_kind: OperatorKind::Custom,
+            },
+            ComparisonOperatorMapping {
+                operator_name: "SIMILAR TO".to_string(),
+                exposed_name: "_similar".to_string(),
+                operator_kind: OperatorKind::Custom,
+            },
+            ComparisonOperatorMapping {
+                operator_name: "NOT SIMILAR TO".to_string(),
+                exposed_name: "_nsimilar".to_string(),
+                operator_kind: OperatorKind::Custom,
+            },
+            // Preferred by Postgres
+            ComparisonOperatorMapping {
+                operator_name: "<>".to_string(),
+                exposed_name: "_neq".to_string(),
+                operator_kind: OperatorKind::Custom,
+            },
+            ComparisonOperatorMapping {
+                operator_name: "~~".to_string(),
+                exposed_name: "_like".to_string(),
+                operator_kind: OperatorKind::Custom,
+            },
+            ComparisonOperatorMapping {
+                operator_name: "!~~".to_string(),
+                exposed_name: "_nlike".to_string(),
+                operator_kind: OperatorKind::Custom,
+            },
+            ComparisonOperatorMapping {
+                operator_name: "~~*".to_string(),
+                exposed_name: "_ilike".to_string(),
+                operator_kind: OperatorKind::Custom,
+            },
+            ComparisonOperatorMapping {
+                operator_name: "!~~*".to_string(),
+                exposed_name: "_nilike".to_string(),
+                operator_kind: OperatorKind::Custom,
+            },
+            ComparisonOperatorMapping {
+                operator_name: "~".to_string(),
+                exposed_name: "_regex".to_string(),
+                operator_kind: OperatorKind::Custom,
+            },
+            ComparisonOperatorMapping {
+                operator_name: "!~".to_string(),
+                exposed_name: "_nregex".to_string(),
+                operator_kind: OperatorKind::Custom,
+            },
+            ComparisonOperatorMapping {
+                operator_name: "~*".to_string(),
+                exposed_name: "_iregex".to_string(),
+                operator_kind: OperatorKind::Custom,
+            },
+            ComparisonOperatorMapping {
+                operator_name: "!~*".to_string(),
+                exposed_name: "_niregex".to_string(),
+                operator_kind: OperatorKind::Custom,
+            },
+        ]
+    }
+}

--- a/crates/configuration/src/version4/connection_settings.rs
+++ b/crates/configuration/src/version4/connection_settings.rs
@@ -1,0 +1,33 @@
+//! Database connection settings.
+
+use crate::values::{ConnectionUri, IsolationLevel, PoolSettings, Secret};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_CONNECTION_URI_VARIABLE: &str = "CONNECTION_URI";
+
+/// Database connection settings.
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DatabaseConnectionSettings {
+    /// Connection string for a Postgres-compatible database.
+    pub connection_uri: ConnectionUri,
+    /// Connection pool settings.
+    #[serde(default)]
+    pub pool_settings: PoolSettings,
+    /// Query isolation level.
+    #[serde(default)]
+    pub isolation_level: IsolationLevel,
+}
+
+impl DatabaseConnectionSettings {
+    pub fn empty() -> Self {
+        Self {
+            connection_uri: ConnectionUri(Secret::FromEnvironment {
+                variable: DEFAULT_CONNECTION_URI_VARIABLE.into(),
+            }),
+            pool_settings: PoolSettings::default(),
+            isolation_level: IsolationLevel::default(),
+        }
+    }
+}

--- a/crates/configuration/src/version4/introspection.sql
+++ b/crates/configuration/src/version4/introspection.sql
@@ -594,7 +594,7 @@ WITH
         c.column_name,
         jsonb_build_object
         (
-          'name',
+          'fieldName',
           c.column_name,
           'type',
           t.result,
@@ -1536,9 +1536,9 @@ WITH
           (
             'typeName', type_name,
             'schemaName', schema_name,
-            'aggregate_functions', coalesce(aggregates.result, '{}'::jsonb),
-            'comparison_functions', coalesce(comparisons.result, '{}'::jsonb),
-            'type_representation', representation.result
+            'aggregateFunctions', coalesce(aggregates.result, '{}'::jsonb),
+            'comparisonOperators', coalesce(comparisons.result, '{}'::jsonb),
+            'typeRepresentation', representation.result
           )
           AS result
         FROM
@@ -1742,9 +1742,9 @@ WITH
   )
 
 SELECT
-  jsonb_pretty(coalesce(tables_json.result, '{}'::jsonb)) AS "Tables",
-  jsonb_pretty(coalesce(scalar_types_json.result, '{}'::jsonb)) AS "ScalarTypes",
-  jsonb_pretty(coalesce(composite_types_json.result, '{}'::jsonb)) AS "CompositeTypes"
+  coalesce(tables_json.result, '{}'::jsonb) AS "Tables",
+  coalesce(scalar_types_json.result, '{}'::jsonb) AS "ScalarTypes",
+  coalesce(composite_types_json.result, '{}'::jsonb) AS "CompositeTypes"
 FROM scalar_types_json
 CROSS JOIN composite_types_json
 CROSS JOIN tables_json

--- a/crates/configuration/src/version4/introspection.sql
+++ b/crates/configuration/src/version4/introspection.sql
@@ -1,0 +1,1778 @@
+-- This query introspects the relations and types defined in the connected
+-- database using the system catalog tables in the `pg_catalog` namespace.
+--
+-- The data model of these tables is quite involved and carries with it decades
+-- of legacy. Supporting notes on this are kept in 'introspection-notes.md'.
+--
+-- When debugging in 'psql', uncomment the lines below to be able to run the
+-- query with arguments set.
+
+-- DEALLOCATE ALL; -- Or use 'DEALLOCATE configuration' between reloads
+-- PREPARE configuration(varchar[], varchar[], varchar[], jsonb, varchar[], jsonb) AS
+
+WITH
+  -- The overall structure of this query is a CTE (i.e. 'WITH .. SELECT')
+  -- statement which define projections of the catalog tables into forms that are
+  -- more convenient to work with:
+  --
+  -- * We project only the columns that we need for constructing the ndc instance
+  --   schema and serving queries, and we try apply consistent naming.
+  --
+  -- * We resolve references (oid's) to names.
+  --
+  -- * We avoid aggregations over sub-selects and lateral joins since those have
+  --   proven brittle across postgres variants by experience. Instead we use
+  --   regular joins over tables that have been grouped by the join key to ensure
+  --   the 1:1 correspondance.
+  --
+  -- One benefit of using a CTE is that it's easy to experiment with the query,
+  -- as you can query each of the WITH-bound sub-queries independently in the
+  -- main statement.
+
+  -- Schemas are recorded in `pg_namespace`, see
+  -- https://www.postgresql.org/docs/current/catalog-pg-namespace.html for its
+  -- schema.
+  schemas_for_table_collections AS
+  (
+    SELECT
+      ns.oid::regnamespace AS schema_id,
+      ns.nspname AS schema_name
+    FROM pg_namespace AS ns
+    WHERE
+      -- Various schemas are patently uninteresting:
+      NOT (ns.nspname = ANY ($1))
+  ),
+
+  -- These are the schemas of which tables will be unqualified
+  unqualified_schemas_for_tables AS
+  (
+    SELECT DISTINCT
+      ns.oid::regnamespace as schema_id
+    FROM
+      UNNEST($2) AS t(schema_name)
+    INNER JOIN
+      pg_namespace
+      AS ns
+      ON (ns.nspname = schema_name)
+  ),
+
+  -- These are the schemas of which types and procedures will be
+  -- exported unqualified.
+  unqualified_schemas_for_types_and_procedures AS
+  (
+    SELECT DISTINCT
+      ns.oid::regnamespace as schema_id
+    FROM
+      UNNEST($3) AS t(schema_name)
+    INNER JOIN
+      pg_namespace
+      AS ns
+      ON (ns.nspname = schema_name)
+  ),
+
+  -- Tables and views etc. are recorded in `pg_class`, see
+  -- https://www.postgresql.org/docs/current/catalog-pg-class.html for its
+  -- schema.
+  relations AS
+  (
+    SELECT
+      cl.oid::regclass AS relation_id
+    FROM
+      pg_class cl
+
+    -- We only want to know about relations that don't live in uninteresting schemas.
+    INNER JOIN
+      schemas_for_table_collections
+      ON (schemas_for_table_collections.schema_id = cl.relnamespace)
+    WHERE relkind IN
+      -- Lots of different types of relations exist, but we're only interested in
+      -- the ones that can be queried.
+      (
+        'r', -- = ordinary table
+        'v', -- = view
+        'm', -- = materialized view
+        'f', -- = foreign table
+        'p'  -- = partitioned table
+        -- i = index,
+        -- S = sequence,
+        -- t = TOAST table,
+        -- c = composite type,
+        -- I = partitioned index
+      )
+  ),
+
+  -- This relation collects the various names we want to call relations by, and
+  -- how it should appear in the schema.
+  --
+  -- All intermediate processing of relations uses exclusively 'regclass'
+  -- identifiers. We only tack on names when we generate the final json output.
+  relation_names AS
+  (
+    SELECT
+      cl.oid::regclass AS relation_id,
+
+      CASE
+        -- Note: This does not deal with schema names (or type names) containing spaces.
+        WHEN unqualified.schema_id IS NOT NULL
+        THEN cl.relname
+        ELSE schemas.nspname || '_' || cl.relname
+      END
+      AS
+      name_in_ndc_schema,
+      cl.relname AS relation_name,
+      schemas.nspname as schema_name
+    FROM
+      pg_class AS cl
+
+    -- Filter, so we only include types we can understand
+    INNER JOIN
+      relations
+    ON
+      (cl.oid = relations.relation_id)
+
+    -- Collect schema names. We _could_ instead just do
+    -- 'schema_id::regnamespace::text', but that would produce a proper,
+    -- quoted identifier.
+    INNER JOIN
+      pg_namespace AS schemas
+    ON (cl.relnamespace = schemas.oid)
+
+    -- Tack on whether we want to qualify the name in the ndc schema or not
+    LEFT OUTER JOIN
+      unqualified_schemas_for_tables
+      AS unqualified
+      ON (cl.relnamespace = unqualified.schema_id)
+  ),
+
+  -- Columns are recorded in `pg_attribute`. An 'attribute' is the generic term
+  -- for the parts that together make up a relation in general, and only in the
+  -- case of a table do we actually call them 'columns'. See
+  -- https://www.postgresql.org/docs/current/catalog-pg-attribute.html for its
+  -- schema.
+  columns AS
+  (
+    SELECT
+      att.attrelid AS relation_id,
+      att.attname AS column_name,
+      att.attnum AS column_number,
+      att.atttypid AS type_id,
+      CASE WHEN att.attnotnull THEN 'nonNullable' ELSE 'nullable' END
+      AS nullable,
+      CASE WHEN att.atthasdef THEN 'hasDefault' ELSE 'noDefault' END
+      AS has_default,
+      CASE WHEN att.attidentity = 'd' THEN 'identityByDefault'
+           WHEN att.attidentity = 'a' THEN 'identityAlways'
+           ELSE 'notIdentity'
+      END
+      AS is_identity,
+      CASE WHEN attgenerated_exists
+           THEN CASE WHEN attgenerated::text = 's' THEN 'stored' ELSE 'notGenerated' END
+           ELSE 'notGenerated'
+      END as is_generated
+    FROM
+      pg_catalog.pg_attribute AS att
+      CROSS JOIN (SELECT current_setting('server_version_num')::int >= 120000) AS attgenerated(attgenerated_exists)
+    WHERE
+      -- We only include columns that are actually part of the table currently.
+      NOT att.attisdropped -- This table also records historic columns.
+      AND att.attnum > 0   -- attnum <= 0 are special system-defined columns.
+  ),
+
+  -- Comments on database objects are recorded in `pg_description`. See
+  -- 'https://www.postgresql.org/docs/current/catalog-pg-description.html' for its schema.
+  --
+  -- The modelling has some non-obvious use of indirection, which smells a bit
+  -- of Russel's paradox: 'classoid' is a 'pg_class.oid' value, which indicates
+  -- which _other_ pg_catalog table you need to consult in order to find the
+  -- object with oid 'objoid'.
+  --
+  -- As an example, the comment of a table or view column will always have
+  --
+  --   (classoid = 1259)
+  --
+  -- since the 'pg_class.oid' 1259 refers to the 'pg_class' table _itself_
+  -- (remember that, since 'pg_class' records all tables (and other relations)
+  -- that exist in the database, it also has a record of itself).
+  --
+  -- Rather than using literal numerical oids in this query we use the special
+  -- built-in datatype 'regclass' which resolves names to oids automatically.
+  -- See https://www.postgresql.org/docs/current/datatype-oid.html
+  column_comments AS
+  (
+    SELECT
+      col.relation_id,
+      col.column_name,
+      comm.description
+    FROM
+    (
+      SELECT
+        objoid::regclass AS relation_id,
+        objsubid AS column_number,
+        description
+      FROM
+        pg_description
+      WHERE
+        classoid = 'pg_catalog.pg_class'::regclass
+    ) AS comm
+    INNER JOIN
+      columns
+      AS col
+      USING (relation_id, column_number)
+  ),
+
+  table_comments AS
+  (
+    SELECT
+      objoid::regclass AS relation_id,
+      description
+    FROM
+      pg_description
+    WHERE
+      classoid = 'pg_catalog.pg_class'::regclass
+      AND objsubid = 0
+  ),
+
+  type_comments AS
+  (
+    SELECT
+      objoid::regtype AS type_id,
+      description
+    FROM
+      pg_description
+    WHERE
+      classoid = 'pg_catalog.pg_type'::regclass
+      AND objsubid = 0
+  ),
+
+  -- Composite types, including those defined implicitly through a table and
+  -- explicitly via `CREATE TYPE`.
+  composite_types AS
+  (
+    SELECT
+      t.oid::regtype AS type_id,
+      t.typrelid::regclass AS relation_id
+    FROM
+      pg_type t
+    -- We only want to know about composite types that don't live in uninteresting schemas.
+    INNER JOIN
+      schemas_for_table_collections
+      ON (schemas_for_table_collections.schema_id = t.typnamespace)
+    WHERE typtype = 'c'
+  ),
+
+  -- This relation collects the various names we want to call composite types
+  -- by, and how it should appear in the schema.
+  --
+  -- All intermediate processing of types uses exclusively 'regtype'
+  -- identifiers. We only tack on names when we generate the final json output.
+  composite_type_names AS
+  (
+    SELECT
+      t.oid::regtype AS type_id,
+
+      CASE
+        -- Note: This does not deal with schema names (or type names) containing spaces.
+        WHEN unqualified.schema_id IS NOT NULL
+        THEN t.typname
+        ELSE schemas.nspname || '_' || t.typname
+      END
+      AS
+      name_in_ndc_schema,
+      t.typname AS type_name,
+      schemas.nspname as schema_name
+    FROM
+      pg_type AS t
+
+    -- Filter, so we only include types we can understand
+    INNER JOIN
+      composite_types
+    ON
+      (t.oid = composite_types.type_id)
+
+    -- Collect schema names. We _could_ instead just do
+    -- 'schema_id::regnamespace::text', but that would produce a proper,
+    -- quoted identifier.
+    INNER JOIN
+      pg_namespace AS schemas
+    ON (t.typnamespace = schemas.oid)
+
+    -- Tack on whether we want to qualify the name in the ndc schema or not
+    LEFT OUTER JOIN
+      unqualified_schemas_for_tables
+      AS unqualified
+      ON (t.typnamespace = unqualified.schema_id)
+  ),
+
+  -- Composite types, except those which are also tables.
+  -- We collect these separately at the top level because we need to be able to
+  -- talk about them but also know that they are not tables that you can query.
+  exclusively_composite_types AS
+  (
+    WITH
+      exclusively_composite_type_ids AS
+      (
+        SELECT relation_id FROM composite_types
+        EXCEPT
+        SELECT relation_id FROM relations
+      )
+    SELECT
+      *
+    FROM composite_types
+    NATURAL INNER JOIN exclusively_composite_type_ids
+  ),
+
+  -- Types are recorded in 'pg_types', see
+  -- https://www.postgresql.org/docs/current/catalog-pg-type.html for its
+  -- schema.
+  scalar_types AS
+  (
+    SELECT
+      t.oid::regtype AS type_id
+    FROM
+      pg_catalog.pg_type AS t
+    WHERE
+      -- We currently filter out pseudo (polymorphic) types, because our schema
+      -- can only deal with monomorphic types.
+      --
+      -- We also filter out composite (record) types and arrays. We would like
+      -- to support those properly, which requires support in the schema and
+      -- query execution. If we export them as opaque scalar types, adding
+      -- proper support later becomes a breaking change, which we'd like to
+      -- avoid.
+      --
+      -- We intentionally do not filter out domain types, see the relation
+      -- `domain_types` below.
+      t.typtype NOT IN
+      (
+        -- Interesting t.typtype 'types of types':
+        -- 'b' for base type
+        'c', -- for composite type
+        -- 'd', for domain (a predicate-restricted version of a type)
+        -- 'e' for enum
+        'p' -- for pseudo-type (anyelement etc)
+        -- 'r' for range
+        -- 'm' for multi-range
+      )
+      AND NOT
+        (
+          -- Exclude arrays (see 'array_types' below).
+          t.typelem != 0 -- whether you can subscript into the type
+          AND typcategory = 'A' -- The parsers considers this type an array for
+                                -- the purpose of selecting preferred implicit casts.
+        )
+      -- Ignore types that are (primarily) for internal postgres use.
+      -- This is a good candidate for a configuration option.
+      AND NOT typname IN
+        (
+        'aclitem',
+        'cid',
+        'gidx',
+        'name',
+        'oid',
+        'pg_dependencies',
+        'pg_lsn',
+        'pg_mcv_list',
+        'pg_ndistinct',
+        'pg_node_tree',
+        'regclass',
+        'regcollation',
+        'regconfig',
+        'regdictionary',
+        'regnamespace',
+        'regoper',
+        'regoperator',
+        'regproc',
+        'regprocedure',
+        'regrole',
+        'regtype',
+        'tid',
+        'xid',
+        'xid8'
+        )
+  ),
+
+  -- This relation collects the various names we want to call scalar types by
+  -- (schema, name of the type itself, and how it should appear in the schema.
+  --
+  -- All intermediate processing of types uses exclusively 'regtype'
+  -- identifiers. We only tack on names when we generate the final json output.
+  scalar_type_names AS
+  (
+    SELECT
+      t.oid::regtype AS type_id,
+
+      CASE
+        -- Note: This does not deal with schema names (or type names) containing spaces.
+        WHEN unqualified.schema_id IS NOT NULL
+        THEN t.typname
+        ELSE schemas.nspname || '_' || t.typname
+      END
+      AS
+      name_in_ndc_schema,
+      t.typname AS type_name,
+      schemas.nspname as schema_name
+    FROM
+      pg_type AS t
+
+    -- Filter, so we only include types we can understand
+    INNER JOIN
+      scalar_types
+    ON
+      (t.oid = scalar_types.type_id)
+
+    -- Collect schema names. We _could_ instead just do
+    -- 'schema_id::regnamespace::text', but that would produce a proper,
+    -- quoted identifier.
+    INNER JOIN
+      pg_namespace AS schemas
+    ON (t.typnamespace = schemas.oid)
+
+    -- Tack on whether we want to qualify the name in the ndc schema or not
+    LEFT OUTER JOIN
+      unqualified_schemas_for_types_and_procedures
+      AS unqualified
+      ON (t.typnamespace = unqualified.schema_id)
+  ),
+  -- Domain types are scalar types that have been adorned with a CHECK
+  -- expression that any instance of the type must satisfy.
+  --
+  -- While the `scalar_types` relation above does pick up on domain types as
+  -- well we also need to keep track of them separately in order to be able to
+  -- infer comparison operators and aggregation functions.
+  --
+  -- Domain types are created using the `CREATE DOMAIN` statement (see
+  -- https://www.postgresql.org/docs/current/sql-createdomain.html).
+  domain_types AS
+  (
+    SELECT
+      t.oid::regtype AS type_id,
+      t.typbasetype::regtype AS base_type
+    FROM
+      pg_catalog.pg_type AS t
+    WHERE
+      t.typtype = 'd'
+  ),
+
+  -- Enum types are scalar types that consist of a finite, enumerated set of
+  -- labelled values. See
+  -- https://www.postgresql.org/docs/current/datatype-enum.html
+  --
+  -- The catalog table `pg_catalog.pg_enum` records the enum types defined in
+  -- the database. See https://www.postgresql.org/docs/current/catalog-pg-enum.html
+  --
+  -- Enum types support certain comparisons and aggregations, but these are not
+  -- registered in any of the catalog tables. Therefore we need some amount of
+  -- special case handling for enum types.
+  --
+  -- Furthermore we are interested in collecting the labels for each enum type
+  -- to reflect in the NDC schema.
+  enum_types AS
+  (
+    SELECT
+      t.oid::regtype AS type_id,
+      array_agg(e.enumlabel ORDER BY e.enumsortorder) AS enum_labels
+    FROM
+      pg_catalog.pg_type AS t
+    INNER JOIN
+      pg_enum
+      AS e
+      ON (e.enumtypid = t.oid)
+    GROUP BY (t.oid, t.typnamespace, t.typname)
+  ),
+
+  array_types AS
+  (
+    SELECT
+      t.oid::regtype AS type_id,
+      et.type_id as element_type_id,
+      et.element_type_kind
+    FROM
+      pg_catalog.pg_type AS t
+    INNER JOIN
+      -- Postgres does not distinguish nested arrays at the type level, so we
+      -- can already tell what the element type is.
+      (
+        SELECT
+          type_id,
+          'scalarType' AS element_type_kind
+        FROM scalar_types
+        UNION
+        SELECT
+          type_id,
+          'compositeType' AS element_type_kind
+        FROM composite_types
+      )
+      AS et
+      ON (et.type_id = t.typelem)
+    WHERE
+      -- See 'scalar_types' above
+      t.typtype = 'b'
+      -- What makes a type an 'array' type in postgres is a surprisingly
+      -- nuanced question.
+      --
+      -- Ideally, we should identify the types we consider array types for
+      -- ndc purposes as those which postgres calls 'true array types', since
+      -- those are the ones you can query as arrays (i.e., call 'unnest' on)
+      -- and which ought reasonably to display as arrays, see
+      -- introspection-notes.md.
+      --
+      -- There might be other types which will display as arrays (e.g., when
+      -- serializing to json), but we shouldn't recognize those as arrays
+      -- in the schema, because we cannot expect to be able to exploit that
+      -- structure when querying.
+      --
+      -- The check for whether a type is a 'true array type' is not portable
+      -- across Postgres and CockroachDB.
+      -- Here we're interested in censoring to avoid future breaking changes,
+      -- so we're content to censor a bit too much rather than too little.
+      --
+      -- The best check I could come up with that works for the builtin types
+      -- and the PostGIS extension is this:
+      AND t.typelem != 0 -- whether you can subscript into the type
+      AND typcategory = 'A' -- The parsers considers this type an array for
+                            -- the purpose of selecting preferred implicit casts.
+  ),
+
+  type_names AS
+  (
+    SELECT * FROM scalar_type_names
+    UNION
+    SELECT * FROM composite_type_names
+  ),
+
+  column_types_json AS
+  (
+    SELECT
+      scalar_types.type_id,
+      jsonb_build_object(
+        'scalarType',
+        name_in_ndc_schema
+        )
+        AS result
+    FROM
+      scalar_types
+    INNER JOIN
+      scalar_type_names
+      ON (scalar_types.type_id = scalar_type_names.type_id)
+    UNION
+    SELECT
+      array_types.type_id,
+      jsonb_build_object(
+        'arrayType',
+        jsonb_build_object(
+          element_type_kind,
+          name_in_ndc_schema
+          )
+        )
+        AS result
+    FROM
+      array_types
+    INNER JOIN
+      type_names
+      ON (array_types.element_type_id = type_names.type_id)
+    UNION
+    SELECT
+      composite_types.type_id,
+      jsonb_build_object(
+        'compositeType',
+        name_in_ndc_schema
+        )
+        AS result
+    FROM
+      composite_types
+    INNER JOIN
+      type_names
+      ON (composite_types.type_id = type_names.type_id)
+  ),
+
+  composite_type_fields_json AS
+  (
+    SELECT
+      c.relation_id,
+      jsonb_object_agg
+      (
+        c.column_name,
+        jsonb_build_object
+        (
+          'name',
+          c.column_name,
+          'type',
+          t.result,
+          'description',
+          comm.description
+        )
+      )
+      AS result
+    FROM columns
+      AS c
+    LEFT OUTER JOIN column_types_json
+      AS t
+      ON (c.type_id = t.type_id)
+    LEFT OUTER JOIN column_comments
+      AS comm
+      USING (relation_id, column_name)
+    GROUP BY relation_id
+    HAVING
+      -- All columns must have a supported type.
+      bool_and(NOT t.result IS NULL)
+  ),
+
+  composite_types_json AS
+  (
+    WITH
+      composite_types_definitions AS
+      (
+        SELECT
+        names.name_in_ndc_schema,
+        jsonb_build_object
+        (
+          'typeName',
+          names.type_name,
+          'schemaName',
+          names.schema_name,
+          'fields',
+          fields.result,
+          'description',
+          comm.description
+        )
+        AS result
+      FROM
+        exclusively_composite_types
+        AS ct
+      INNER JOIN
+        composite_type_names
+        AS names
+        ON (ct.type_id = names.type_id)
+      INNER JOIN
+        composite_type_fields_json
+        AS fields
+        USING (relation_id)
+      LEFT OUTER JOIN
+        type_comments
+        AS comm
+        ON (ct.type_id = comm.type_id)
+    )
+  SELECT
+    jsonb_object_agg
+    (
+      name_in_ndc_schema,
+      result
+    )
+    AS result
+  FROM
+    composite_types_definitions
+),
+
+  implicit_casts AS
+  (
+    SELECT
+      t_from.type_id as from_type,
+      t_to.type_id as to_type
+    FROM
+      pg_cast
+    INNER JOIN
+      scalar_types
+      AS t_from
+      ON (t_from.type_id = pg_cast.castsource)
+    INNER JOIN
+      scalar_types
+      AS t_to
+      ON (t_to.type_id = pg_cast.casttarget)
+    WHERE
+      pg_cast.castcontext = 'i'
+      AND t_from.type_id != t_to.type_id
+
+      -- This is a good candidate for a configurable option.
+      AND (t_from.type_id, t_to.type_id) NOT IN
+        (
+          -- Ignore other casts that are unlikely to ever be relevant.
+          -- Note that these list **does not** take schemas into account.
+          SELECT f.oid, t.oid
+          FROM pg_type f
+          CROSS JOIN pg_type t
+          WHERE
+            (f.typname, t.typname) IN
+              (
+                ('bytea', 'geography'),
+                ('bytea', 'geometry'),
+                ('geography', 'bytea'),
+                ('geometry', 'bytea'),
+                ('geometry', 'text'),
+                ('text', 'geometry'),
+                ('text', 'bpchar'),
+                ('varchar', 'bpchar')
+              )
+        )
+    UNION
+    -- Any domain type may be implicitly cast to its base type, even though these casts
+    -- are not declared in `pg_cast`.
+    SELECT
+      domain_types.type_id as from_type,
+      domain_types.base_type as to_type
+    FROM
+      domain_types
+  ),
+
+  implicit_casts_closure AS
+  (
+    WITH
+      RECURSIVE transitive_closure(from_type, to_type, cast_chain_length, cast_chain, cast_chain_arr) AS
+      (
+        SELECT
+          *,
+          1 AS cast_chain_length,
+          from_type || ' -> ' || to_type AS cast_chain,
+          array[from_type, to_type] AS cast_chain_arr
+        FROM
+          implicit_casts
+        UNION
+        SELECT
+          base.from_type,
+          closure.to_type,
+          closure.cast_chain_length + 1 AS cast_chain_length,
+          base.from_type || ' -> ' || closure.cast_chain AS cast_chain,
+          array[base.from_type] || closure.cast_chain_arr AS cast_chain_arr
+        FROM
+          implicit_casts
+          AS base
+        INNER JOIN
+          transitive_closure
+          AS closure
+          ON (base.to_type = closure.from_type)
+        WHERE
+          -- Don't allow cycles
+          NOT (base.from_type = ANY(closure.cast_chain_arr))
+          -- As a safety, let's not consider cast chains longer than 5.
+          AND closure.cast_chain_length <= 5
+      )
+    SELECT
+      from_type,
+      to_type,
+      cast_chain_length,
+      cast_chain
+    FROM
+      transitive_closure
+  ),
+
+  -- Enum types support the aggregates 'min' and 'max'. However, these are not
+  -- registered as such in `pg_proc`, and so we have to make them them up
+  -- ourselves.
+  enum_aggregates AS
+  (
+    SELECT
+      proc.proname AS proc_name,
+      e.type_id AS argument_type,
+      e.type_id AS return_type
+    FROM
+      (VALUES
+        ('min'),
+        ('max')
+      )
+      AS proc(proname),
+      enum_types e
+  ),
+
+  -- Aggregate functions are recorded across 'pg_proc' and 'pg_aggregate', see
+  -- https://www.postgresql.org/docs/current/catalog-pg-proc.html and
+  -- https://www.postgresql.org/docs/current/catalog-pg-aggregate.html for
+  -- their schema.
+  declared_aggregates AS
+  (
+    SELECT
+      proc.oid::regprocedure AS proc_id,
+      proc.proname AS proc_name,
+      proc.pronamespace AS schema_id,
+      arg_type.type_id as argument_type,
+      ret_type.type_id as return_type
+      -- Columns that will likely be of interest soon:
+      -- proc.proargnames AS argument_names,
+
+    FROM
+      pg_catalog.pg_proc AS proc
+
+    INNER JOIN
+      -- Until the schema is made part of our model of types we only consider
+      -- types defined in the public schema.
+      unqualified_schemas_for_types_and_procedures
+      AS q
+      ON (q.schema_id = proc.pronamespace)
+
+    -- fetch the argument type name, discarding any unsupported types
+    INNER JOIN scalar_types AS arg_type
+      ON (arg_type.type_id = proc.proargtypes[0])
+
+    -- fetch the return type name, discarding any unsupported types
+    INNER JOIN scalar_types AS ret_type
+      ON (ret_type.type_id = proc.prorettype)
+
+    -- restrict our scope to only aggregation functions
+    INNER JOIN pg_aggregate AS aggregate
+      ON (aggregate.aggfnoid = proc.oid)
+
+    WHERE
+      -- We are only interested in functions:
+      -- * which take a single input argument
+      -- * which are aggregation functions
+      -- * which don't take any 'direct' (i.e., non-aggregation) arguments
+      proc.pronargs = 1
+      AND aggregate.aggnumdirectargs = 0
+
+  ),
+  aggregates AS
+  (
+    SELECT
+      proc_name,
+      return_type,
+      argument_type
+    FROM
+      declared_aggregates
+    UNION
+    SELECT
+      proc_name,
+      return_type,
+      argument_type
+    FROM enum_aggregates
+  ),
+
+  aggregates_cast_extended AS
+  (
+    WITH
+      type_combinations AS
+    (
+      SELECT
+        agg.proc_name AS proc_name,
+        agg.return_type AS return_type,
+        cast1.from_type AS argument_type,
+        cast1.cast_chain_length AS argument_cast_chain_length,
+        cast1.cast_chain AS argument_cast_chain
+      FROM
+        aggregates
+        AS agg
+      INNER JOIN
+        implicit_casts_closure
+        AS cast1
+        ON (cast1.to_type = agg.argument_type)
+      UNION
+      SELECT
+        agg.proc_name AS proc_name,
+        agg.return_type AS return_type,
+        agg.argument_type AS argument_type,
+        0 AS argument_cast_chain_length,
+        '<empty>' AS argument_cast_chain
+      FROM
+        aggregates
+        AS agg
+    ),
+
+    preferred_combinations AS
+    (
+      SELECT
+        *,
+        -- CockroachDB does not observe ORDER BY of nested expressions,
+        -- So we cannot use the DISTINCT ON idiom to remove duplicates.
+        -- Therefore we resort to filtering by ordered ROW_NUMBER().
+        ROW_NUMBER()
+          OVER
+          (
+            PARTITION BY
+              proc_name, argument_type
+            ORDER BY
+              -- Prefer least cast argument
+              argument_cast_chain_length ASC,
+              -- Arbitrary desperation: Lexical ordering
+              return_type ASC
+          )
+          AS row_number
+      FROM
+        type_combinations
+    )
+    SELECT
+      proc_name,
+      argument_type,
+      argument_cast_chain,
+      return_type
+    FROM
+      preferred_combinations
+    WHERE
+      row_number = 1
+  ),
+
+  -- Comparison procedures are any entries in 'pg_proc' that happen to be
+  -- binary functions that return booleans. We also require, for the sake of
+  -- simplicity, that these functions be non-variadic (i.e. no default values).
+  -- Within this CTE, we attempt to generate a table of comparison procedures
+  -- to match the shape of the 'comparison_operators'.
+  comparison_procedures AS
+  (
+    SELECT
+      proc.proname AS operator_name,
+      proc.proargtypes[0] as argument1_type,
+      proc.proargtypes[1] as argument2_type,
+      false AS is_infix
+    FROM
+      pg_catalog.pg_proc AS proc
+    INNER JOIN scalar_types
+      AS ret_type
+      ON (ret_type.type_id = proc.prorettype)
+    INNER JOIN
+      -- Until the schema is made part of our model of types we only consider
+      -- types defined in the public schema.
+      unqualified_schemas_for_types_and_procedures
+      AS q
+      ON (q.schema_id = proc.pronamespace)
+    WHERE
+      ret_type.type_id = 'pg_catalog.bool'::regtype
+      -- We check that we only consider procedures which take two regular
+      -- arguments.
+      AND cardinality(proc.proargtypes) = 2
+      AND proc.prokind = 'f'
+      AND proc.provariadic = 0
+      AND proc.pronargdefaults = 0
+      -- Include only procedures that are explicitly selected.
+      -- This is controlled by the
+      -- 'introspectPrefixFunctionComparisonOperators' configuration option.
+      AND proc.proname = ANY ($5)
+  ),
+
+  -- Operators are recorded across 'pg_proc', pg_operator, and 'pg_aggregate', see
+  -- https://www.postgresql.org/docs/current/catalog-pg-proc.html,
+  -- https://www.postgresql.org/docs/current/catalog-pg-operator.html and
+  -- https://www.postgresql.org/docs/current/catalog-pg-aggregate.html for
+  -- their schema.
+  --
+  -- In PostgreSQL, operators and aggregation functions each relate to a `pg_proc`
+  -- procedure. On CockroachDB, however, they are independent.
+  comparison_infix_operators AS
+  (
+    SELECT
+      op.oprname AS operator_name,
+      t1.type_id AS argument1_type,
+      t2.type_id AS argument2_type,
+      true AS is_infix
+    FROM
+      pg_operator
+      AS op
+    INNER JOIN
+      scalar_types
+      AS t1
+      ON (op.oprleft = t1.type_id)
+    INNER JOIN
+      scalar_types
+      AS t2
+      ON (op.oprright = t2.type_id)
+    INNER JOIN
+      scalar_types
+      AS t_res
+      ON (op.oprresult = t_res.type_id)
+    INNER JOIN
+      -- Until the schema is made part of our model of operators we only consider
+      -- those defined in the public schema.
+      unqualified_schemas_for_types_and_procedures
+      AS q
+      ON (q.schema_id = op.oprnamespace)
+    WHERE
+      t_res.type_id = 'pg_catalog.bool'::regtype
+    ORDER BY op.oprname
+  ),
+
+  -- Enum types are totally ordered and support the conventional comparison operators.
+  -- They are defined implicitly (i.e., not registered in `pg_proc` or
+  -- `pg_operator`) so we have to make up some definitions for them.
+  enum_comparison_operators AS
+  (
+    SELECT
+      op.oprname AS operator_name,
+      e.type_id AS argument1_type,
+      e.type_id AS argument2_type,
+      true AS is_infix
+    FROM
+      (VALUES
+        ('='),
+        ('!='),
+        ('<>'),
+        ('<='),
+        ('>'),
+        ('>='),
+        ('<')
+      )
+      AS op(oprname),
+      enum_types e
+  ),
+
+  -- Here, we reunite our binary infix procedures and our binary prefix
+  -- procedures under the umbrella of 'comparison_operators'. We do this
+  -- here so that we can treat them uniformly form this point on.
+  -- Specifically, we generate all the various type coercion permutations
+  -- for both in 'comparison_operators_cast_extended'.
+  comparison_operators AS
+  (
+    SELECT * FROM comparison_infix_operators
+    UNION
+    SELECT * FROM comparison_procedures
+    UNION
+    SELECT * FROM enum_comparison_operators
+  ),
+
+  -- Some comparison operators are not defined explicitly for every type they would be
+  -- valid for, relying instead on implicit casts to extend the types they can apply to.
+  --
+  -- Examples:
+  --
+  --   Postgres only defines 'like' for 'text', not for 'varchar'. But there's
+  --   an implicit cast for varchar->text.
+  --
+  --   CockroachDB does not define any comparison operators for 'float4', but does
+  --   for 'float8', along with an implict cast for float4->float8.
+  --
+  --   Curiously, Cockroach _also_ goes on to define (e.g.) '!=' on both of
+  --   '(int8,int8)' _and_ '(int8,float8)' choosing not to rely on casts in this case.
+  --
+  -- As such, we can expect to have to deal with two sources of overloading: From
+  -- multiple definitions for different types and from implicit casts.
+  --
+  -- However, the NDC API is very 'argument1'-centric in the sense that its
+  -- notion of a scalar type is defined in part by the set of comparison
+  -- operators that take a value of this type as their first argument.
+  --
+  -- A consequence of this is that, in a boolean filter expression the type of
+  -- the first argument of a comparison operator is given by the context it
+  -- appears in. In English we can equivalently say that "on this field of type
+  -- T we want to perform one of T's comparison operators."
+  --
+  -- Under this framing, in order to make as many comparisons available as
+  -- possible, we need to extend the set of comparsion operators by the
+  -- implicit casts available on their first argument.
+  --
+  -- For example consider hypothetically:
+  --
+  --   A function 'like':
+  --     like(varchar, varchar) -> bool
+  --
+  --   .. and implicit casts:
+  --     varchar -> name
+  --     name -> varchar
+  --
+  -- Extending the definition of 'like' with implit casts on argument1 gives the set:
+  --
+  --    like(varchar, varchar) -> bool
+  --    like(name, varchar) -> bool
+  --
+  -- Which means that each of 'varchar' and 'name' can get 'like' operator.
+  --
+  -- Of course we would also want to accept as many types as possible for the
+  -- second argument. However, we hit a bottleneck if we try the same thing to argument 2.
+  --
+  -- Extending argument2 gives us:
+  --
+  --    like(varchar, varchar) -> bool
+  --    like(varchar, name) -> bool
+  --    like(name, varchar) -> bool
+  --    like(name, name) -> bool
+  --
+  -- It is now not given which single variant of 'like' to pick for each of
+  -- 'varchar' and 'name'.
+  --
+  -- To avoid this problem for now we apply the limitation of only
+  -- cast-extending by the first argument.
+  --
+  -- Other solutions are possible, such as including the argument type names in
+  -- the exposed name of the operator. Or requiring the user provide more
+  -- information to drive the application of cast extension.
+  --
+  -- Note that since NDC configuration introspection is only a sort of
+  -- conventional convenience it is still possible to manually expose whatever
+  -- comparison function is required by manually adding a metadata entry for
+  -- it.
+  --
+  -- Note also that since the various infix comparison operators on text-like
+  -- types are only defined on 'text', (and the same for numerical types only
+    -- on float8) a non-intuitive consequence of the above limitation is that
+  -- e.g. the equality comparison operator for e.g. 'char' ends up being
+  -- '_eq(char, text) -> bool'.
+  comparison_operators_cast_extended AS
+  (
+    WITH
+      type_combinations AS
+    (
+      SELECT
+        op.operator_name,
+        cast1.from_type as argument1_type,
+        op.argument2_type,
+        op.is_infix,
+        cast1.cast_chain_length as argument1_cast_chain_length,
+        cast1.cast_chain AS argument1_cast_chain,
+        0 as argument2_cast_chain_length,
+        '<empty>' AS argument2_cast_chain
+      FROM
+        comparison_operators
+        AS op
+      INNER JOIN
+        implicit_casts_closure
+        AS cast1
+        ON (cast1.to_type = op.argument1_type)
+      UNION
+      SELECT
+        op.operator_name,
+        op.argument1_type,
+        cast2.from_type as argument2_type,
+        op.is_infix,
+        0 as argument1_cast_chain_length,
+        '<empty>' AS argument1_cast_chain,
+        cast2.cast_chain_length as argument2_cast_chain_length,
+        cast2.cast_chain AS argument2_cast_chain
+      FROM
+        comparison_operators
+        AS op
+      INNER JOIN
+        implicit_casts_closure
+        AS cast2
+        ON (cast2.to_type = op.argument2_type)
+      UNION
+      SELECT
+        op.operator_name,
+        cast1.from_type as argument1_type,
+        cast2.from_type as argument2_type,
+        op.is_infix,
+        cast1.cast_chain_length as argument1_cast_chain_length,
+        cast1.cast_chain AS argument1_cast_chain,
+        cast2.cast_chain_length as argument2_cast_chain_length,
+        cast2.cast_chain AS argument2_cast_chain
+      FROM
+        comparison_operators
+        AS op
+      INNER JOIN
+        implicit_casts_closure
+        AS cast1
+        ON (cast1.to_type = op.argument1_type)
+      INNER JOIN
+        implicit_casts_closure
+        AS cast2
+        ON (cast2.to_type = op.argument2_type)
+      UNION
+      SELECT
+        op.operator_name,
+        op.argument1_type,
+        op.argument2_type,
+        op.is_infix,
+        0 as argument1_cast_chain_length,
+        '<empty>' AS argument1_cast_chain,
+        0 as argument2_cast_chain_length,
+        '<empty>' AS argument2_cast_chain
+      FROM
+        comparison_operators
+        AS op
+    ),
+
+    preferred_combinations AS
+    (
+      SELECT
+        *,
+        -- CockroachDB does not observe ORDER BY of nested expressions,
+        -- So we cannot use the DISTINCT ON idiom to remove duplicates.
+        -- Therefore we resort to filtering by ordered ROW_NUMBER().
+        ROW_NUMBER()
+          OVER
+          (
+            PARTITION BY
+              operator_name, argument1_type
+            ORDER BY
+              -- In case of ambiguities:
+
+              -- 1. Prefer directly defined versions first which uses the same
+              -- type.
+              (argument1_cast_chain_length = 0 AND argument2_cast_chain_length = 0)
+                AND (argument1_type = argument2_type) DESC,
+
+              -- 2. Prefer directly defined versions first which use different
+              -- types.
+              (argument1_cast_chain_length = 0 AND argument2_cast_chain_length = 0) DESC,
+
+              -- 3. If argument1 was casted, prefer any version on the same type
+              -- P → Q = ¬P ∨ Q
+              (argument1_cast_chain_length = 0) OR (argument1_type = argument2_type) DESC,
+
+              -- 4. Prefer uncast argument2.
+              argument2_cast_chain_length = 0 DESC,
+
+              -- 5. Prefer least cast arguments
+              argument1_cast_chain_length + argument2_cast_chain_length ASC,
+
+              -- 6. Arbitrary desperation: Lexical ordering
+              argument2_type ASC
+          )
+          AS row_number
+      FROM
+        type_combinations
+    )
+    SELECT
+      operator_name,
+      argument1_type,
+      argument2_type,
+      is_infix,
+      argument1_cast_chain,
+      argument1_cast_chain_length,
+      argument2_cast_chain,
+      argument2_cast_chain_length,
+      row_number
+    FROM
+      preferred_combinations
+    WHERE
+      row_number = 1
+  ),
+
+  -- The names that comparison operators are exposed under is configurable.
+  operator_mappings AS
+  (
+    SELECT
+      v ->> 'operatorName' AS operator_name,
+      v ->> 'exposedName' AS exposed_name,
+      v ->> 'operatorKind' AS operator_kind
+    FROM
+      jsonb_array_elements($4) AS v
+  ),
+
+  -- Constraints are recorded in 'pg_constraint', see
+  -- https://www.postgresql.org/docs/current/catalog-pg-constraint.html for its
+  -- schema.
+  --
+  -- This form captures both uniqueness constraints and foreign key
+  -- constraints. The 'constraint_type' column determines which columns will be
+  -- non-null.
+  constraints AS
+  (
+    WITH
+      -- The columns that make up a constraint are recorded in
+      -- pg_constraint(conkey, confkey), keyed by column number (attnum).
+      -- 'constraint_columns' and 'constraint_referenced_columns' dereference
+      -- these to column names.
+      --
+      -- This involves unnesting, joining 'columns', and re-constructing the
+      -- array.
+      constraint_columns AS
+      (
+        SELECT
+          c_unnest.constraint_id,
+          array_agg(col.column_name) as key_columns
+        FROM
+          (
+            SELECT
+              c.oid as constraint_id,
+              c.conrelid as relation_id,
+              unnest(c.conkey) as column_number
+            FROM
+              pg_catalog.pg_constraint as c
+          ) AS c_unnest
+        INNER JOIN
+          columns col
+          USING (relation_id, column_number)
+        GROUP BY c_unnest.constraint_id
+      ),
+      constraint_referenced_columns AS
+      (
+        SELECT
+          c_unnest.constraint_id,
+          array_agg(col.column_name) as referenced_columns
+        FROM
+          (
+            SELECT
+              c.oid as constraint_id,
+              c.confrelid as relation_id,
+              unnest(c.confkey) as column_number
+            FROM
+              pg_catalog.pg_constraint as c
+          ) AS c_unnest
+        INNER JOIN
+          columns col
+          USING (relation_id, column_number)
+        GROUP BY c_unnest.constraint_id
+      )
+    SELECT
+      c.oid as constraint_id,
+      c.connamespace as schema_id,
+      c.conname as constraint_name,
+      c.conrelid as relation_id,
+      c.contype as constraint_type,
+      con_cols.key_columns,
+
+      -- These will be null for non-foreign- keys
+      c.confrelid as referenced_relation_id,
+      con_fcols.referenced_columns
+    FROM
+      pg_catalog.pg_constraint AS c
+    LEFT OUTER JOIN
+      constraint_columns as con_cols
+      ON (con_cols.constraint_id = c.oid)
+    LEFT OUTER JOIN
+      constraint_referenced_columns as con_fcols
+      ON (con_fcols.constraint_id = c.oid)
+  ),
+  uniqueness_constraints AS
+  (
+    SELECT
+      constraint_id,
+      schema_id,
+      constraint_name,
+      relation_id,
+      key_columns
+    FROM
+      constraints AS c
+    WHERE
+      c.constraint_type in
+      (
+        'u', -- For uniqueness constraints
+        'p'  -- For primary keys
+      )
+  ),
+  foreign_key_constraints AS
+  (
+    SELECT
+      constraint_id,
+      schema_id,
+      constraint_name,
+      relation_id,
+      key_columns,
+      referenced_relation_id,
+      referenced_columns
+    FROM
+      constraints AS c
+    WHERE
+      c.constraint_type = 'f' -- For foreign-key constraints
+  ),
+
+  base_type_representations AS
+  (
+    SELECT
+      to_regtype(key) AS type_id,
+      value AS representation
+    FROM
+      jsonb_each($6)
+    WHERE
+      to_regtype(key) IS NOT NULL
+  ),
+
+  enum_type_representations AS
+  (
+    SELECT
+      enum_types.type_id,
+      jsonb_build_object(
+        'enum', enum_types.enum_labels
+      )
+      AS representation
+    FROM
+      enum_types
+  ),
+
+  domain_type_representations AS
+  (
+    SELECT
+      domain_types.type_id,
+      representation
+    FROM
+      domain_types
+
+    INNER JOIN
+      base_type_representations
+      ON (domain_types.base_type = base_type_representations.type_id)
+  ),
+
+  type_representations_json AS
+  (
+    SELECT
+        type_representations.type_id,
+        type_representations.representation
+        AS result
+    FROM
+    (
+      SELECT * FROM base_type_representations
+      UNION
+      SELECT * FROM domain_type_representations
+      UNION
+      SELECT * FROM enum_type_representations
+    )
+    AS type_representations
+  ),
+
+  comparison_functions_json AS
+  (
+    -- Comparison Operators
+    WITH
+      comparison_infix_operators_mapped AS
+      (
+        SELECT
+          map.exposed_name,
+          op.operator_name,
+          map.operator_kind,
+          op.argument1_type,
+          op.argument2_type,
+          op.argument1_cast_chain,
+          op.argument1_cast_chain_length,
+          op.argument2_cast_chain,
+          op.argument2_cast_chain_length,
+          op.is_infix -- always 't'
+        FROM
+          comparison_operators_cast_extended
+          AS op
+        INNER JOIN
+          operator_mappings
+          AS map
+          USING (operator_name)
+        WHERE
+          op.is_infix = 't'
+      ),
+
+      comparison_prefix_operators AS
+      (
+        SELECT
+          operator_name as exposed_name,
+          operator_name,
+          'custom' as operator_kind,
+          argument1_type,
+          argument2_type,
+          argument1_cast_chain,
+          argument1_cast_chain_length,
+          argument2_cast_chain,
+          argument2_cast_chain_length,
+          is_infix -- always 'f'
+        FROM
+          comparison_operators_cast_extended
+        WHERE
+          is_infix = 'f'
+      ),
+
+      comparison_operators_processed AS
+      (
+        SELECT * FROM comparison_infix_operators_mapped
+        UNION
+        SELECT * FROM comparison_prefix_operators
+      ),
+
+      comparison_operators_by_first_arg AS
+      (
+        SELECT
+          op.argument1_type,
+          jsonb_object_agg(
+            op.exposed_name,
+            jsonb_build_object(
+              'operatorName', op.operator_name,
+              'operatorKind', op.operator_kind,
+              'argumentType', argument2_type_names.name_in_ndc_schema,
+              'isInfix', op.is_infix,
+
+              -- The below columns serve to aid with debugging
+              -- the selection of implicit casts. They do not
+              -- appear in the final metadata
+              'argument1_cast_chain',
+              op.argument1_cast_chain,
+              'argument2_cast_chain',
+              op.argument2_cast_chain
+            )
+          )
+          AS result
+        FROM
+          comparison_operators_processed
+          AS op
+        INNER JOIN
+          scalar_type_names
+          AS argument2_type_names
+          ON (op.argument2_type = argument2_type_names.type_id)
+        GROUP BY op.argument1_type
+      )
+    SELECT
+        op.argument1_type as type_id,
+        op.result
+    FROM
+      comparison_operators_by_first_arg
+      AS op
+  ),
+
+  -- Aggregation functions
+  aggregate_functions_json AS
+  (
+    WITH
+      aggregate_by_argument_type AS
+      (
+        SELECT
+          agg.proc_name,
+          agg.argument_type,
+          agg.argument_cast_chain,
+          return_type_names.name_in_ndc_schema as return_type_name
+        FROM
+          aggregates_cast_extended AS agg
+        INNER JOIN
+          scalar_type_names
+          AS return_type_names
+          ON (agg.return_type = return_type_names.type_id)
+        ORDER BY argument_type, proc_name, return_type
+      )
+    SELECT
+      agg.argument_type as type_id,
+      jsonb_object_agg(
+        -- Since we are _not_ grouping by a key we need 'agg' to be ordered
+        -- and distinct to get deterministic results.
+        -- I.e. both functions 'f: A -> B' and 'f: A -> C' can coexist, but we
+        -- can only chose one with our current scheme
+        agg.proc_name,
+        jsonb_build_object(
+          'returnType',
+          return_type_name,
+          'argument_cast_chain',
+          argument_cast_chain
+        )
+      ) AS result
+    FROM
+      aggregate_by_argument_type
+      AS agg
+    GROUP BY agg.argument_type
+  ),
+
+  scalar_types_json AS
+  (
+    WITH
+      scalar_type_definition AS
+      (
+        SELECT
+          names.name_in_ndc_schema,
+          jsonb_build_object
+          (
+            'typeName', type_name,
+            'schemaName', schema_name,
+            'aggregate_functions', coalesce(aggregates.result, '{}'::jsonb),
+            'comparison_functions', coalesce(comparisons.result, '{}'::jsonb),
+            'type_representation', representation.result
+          )
+          AS result
+        FROM
+          scalar_type_names
+          AS names
+        LEFT OUTER JOIN
+          aggregate_functions_json
+          AS aggregates
+          USING (type_id)
+        LEFT OUTER JOIN
+          comparison_functions_json
+          AS comparisons
+          USING (type_id)
+        LEFT OUTER JOIN
+          type_representations_json
+          AS representation
+          USING (type_id)
+      )
+
+    SELECT
+      jsonb_object_agg
+      (
+        name_in_ndc_schema,
+        result
+      )
+      AS result
+    FROM
+      scalar_type_definition
+  ),
+
+  tables_json AS
+  (
+    WITH
+
+    uniqueness_constraints_json AS
+    (
+      SELECT
+        con.relation_id,
+        jsonb_object_agg(
+          con.constraint_name,
+          to_jsonb(con.key_columns)
+        )
+        AS result
+      FROM uniqueness_constraints
+        AS con
+      GROUP BY relation_id
+    ),
+
+    foreign_key_constraints_json AS
+    (
+      WITH
+        column_mapping_unzipped AS
+        (
+            -- We need to unnest both the key_columns and referenced_columns,
+            -- which essentially works like 'unzip'.
+            -- The result is one row per column appearing in the constraint,
+            -- which we can then re-group and aggregate as json.
+            SELECT
+              relation_id,
+              constraint_name,
+              unnest(key_columns) as key_column,
+              referenced_relation_id,
+              unnest(referenced_columns) as referenced_column
+            FROM
+             foreign_key_constraints
+        ),
+
+        column_mapping_json AS
+        (
+          SELECT
+              con.relation_id,
+              con.constraint_name,
+              con.referenced_relation_id,
+              -- The column mapping is an object '{<local column>: <referenced column>}'
+              json_object_agg(
+                con.key_column,
+                con.referenced_column
+              ) AS result
+          FROM
+            column_mapping_unzipped
+            AS con
+          GROUP BY
+            (relation_id, constraint_name, referenced_relation_id)
+        )
+
+      -- These take on the form:
+      --   {
+      --     <constraint_name>:
+      --       {
+      --         foreign_table:
+      --           <referenced relation_name>,
+      --         column_mapping:
+      --           {
+      --             <local column_name>: <referenced column_name>
+      --           }
+      --       }
+      --   }
+      SELECT
+        column_mapping_json.relation_id,
+        jsonb_object_agg(
+          column_mapping_json.constraint_name,
+          jsonb_build_object(
+            'foreignSchema',
+            foreign_relation.schema_name,
+            'foreignTable',
+            foreign_relation.relation_name,
+            'columnMapping',
+            column_mapping_json.result
+          )
+        )
+        AS result
+      FROM
+        column_mapping_json
+      INNER JOIN
+        relation_names
+        AS foreign_relation
+        ON (foreign_relation.relation_id = column_mapping_json.referenced_relation_id)
+      GROUP BY column_mapping_json.relation_id
+    ),
+
+    columns_json AS
+    (
+      SELECT
+        c.relation_id,
+        jsonb_object_agg(
+          c.column_name,
+          jsonb_build_object(
+            'name',
+            c.column_name,
+            'type',
+            t.result,
+            'nullable',
+            c.nullable,
+            'hasDefault',
+            c.has_default,
+            'isIdentity',
+            c.is_identity,
+            'isGenerated',
+            c.is_generated,
+            'description',
+            comm.description
+            )
+        )
+        AS result
+      FROM columns
+        AS c
+      LEFT OUTER JOIN column_types_json
+        AS t
+        USING (type_id)
+      LEFT OUTER JOIN column_comments
+        AS comm
+        USING (relation_id, column_name)
+      GROUP BY relation_id
+      HAVING
+        -- All columns must have a supported type for us to list this table.
+        bool_and(NOT t.result IS NULL)
+    )
+    -- Tables and views
+    SELECT
+      jsonb_object_agg(
+        rel.name_in_ndc_schema,
+        jsonb_build_object(
+          'schemaName',
+          rel.schema_name,
+          'tableName',
+          rel.relation_name,
+          'description',
+          comm.description,
+          'columns',
+          columns_json.result,
+          'uniquenessConstraints',
+          coalesce(uniqueness_constraints_json.result, '{}'::jsonb),
+          'foreignRelations',
+          coalesce(foreign_key_constraints_json.result, '{}'::jsonb)
+        )
+      )
+      AS result
+    FROM
+      relation_names
+      AS rel
+
+    LEFT OUTER JOIN
+      table_comments
+      AS comm
+      USING (relation_id)
+
+    -- Columns
+    INNER JOIN
+      columns_json
+    USING (relation_id)
+
+    -- Uniqueness constraints
+    LEFT OUTER JOIN
+      uniqueness_constraints_json
+    USING (relation_id)
+
+    -- Foreign-key constraints.
+    LEFT OUTER JOIN
+      foreign_key_constraints_json
+    USING (relation_id)
+  )
+
+SELECT
+  jsonb_pretty(coalesce(tables_json.result, '{}'::jsonb)) AS "Tables",
+  jsonb_pretty(coalesce(scalar_types_json.result, '{}'::jsonb)) AS "ScalarTypes",
+  jsonb_pretty(coalesce(composite_types_json.result, '{}'::jsonb)) AS "CompositeTypes"
+FROM scalar_types_json
+CROSS JOIN composite_types_json
+CROSS JOIN tables_json
+;
+
+-- Uncomment the following lines to just run the configuration query with reasonable default arguments
+--
+-- EXECUTE configuration(
+--   '{"information_schema", "tiger", "pg_catalog", "topology"}'::varchar[],
+--   '{"public"}'::varchar[],
+--   '{"public", "pg_catalog", "tiger"}'::varchar[],
+--   '[
+--     {"operatorName": "=", "exposedName": "_eq", "operatorKind": "equal"},
+--     {"operatorName": "!=", "exposedName": "_neq", "operatorKind": "custom"},
+--     {"operatorName": "<>", "exposedName": "_neq", "operatorKind": "custom"},
+--     {"operatorName": "<=", "exposedName": "_lte", "operatorKind": "custom"},
+--     {"operatorName": ">", "exposedName": "_gt", "operatorKind": "custom"},
+--     {"operatorName": ">=", "exposedName": "_gte", "operatorKind": "custom"},
+--     {"operatorName": "<", "exposedName": "_lt", "operatorKind": "custom"},
+--     {"operatorName": "~~", "exposedName": "_like", "operatorKind": "custom"},
+--     {"operatorName": "!~~", "exposedName": "_nlike", "operatorKind": "custom"},
+--     {"operatorName": "~~*", "exposedName": "_ilike", "operatorKind": "custom"},
+--     {"operatorName": "!~~*", "exposedName": "_nilike", "operatorKind": "custom"},
+--     {"operatorName": "~", "exposedName": "_regex", "operatorKind": "custom"},
+--     {"operatorName": "!~", "exposedName": "_nregex", "operatorKind": "custom"},
+--     {"operatorName": "~*", "exposedName": "_iregex", "operatorKind": "custom"},
+--     {"operatorName": "!~*", "exposedName": "_niregex", "operatorKind": "custom"}
+--    ]'::jsonb,
+--   '{box_above,box_below, st_covers, st_coveredby}'::varchar[],
+--   '{"int4": "integer"}'::jsonb
+-- );

--- a/crates/configuration/src/version4/metadata/database.rs
+++ b/crates/configuration/src/version4/metadata/database.rs
@@ -1,0 +1,300 @@
+//! Metadata information regarding the database and tracked information.
+
+// This code was copied from a different place that predated the introduction of clippy to the
+// project. Therefore we disregard certain clippy lints:
+#![allow(
+    clippy::enum_variant_names,
+    clippy::upper_case_acronyms,
+    clippy::wrong_self_convention
+)]
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Map of all known composite types.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CompositeTypes(pub BTreeMap<String, CompositeType>);
+
+/// A Scalar Type.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ScalarType(pub String);
+
+/// The type of values that a column, field, or argument may take.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum Type {
+    ScalarType(ScalarType),
+    CompositeType(String),
+    ArrayType(Box<Type>),
+}
+
+/// Information about a composite type. These are very similar to tables, but with the crucial
+/// difference that composite types do not support constraints (such as NOT NULL).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CompositeType {
+    pub name: String,
+    pub fields: BTreeMap<String, FieldInfo>,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// Information about a composite type field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct FieldInfo {
+    pub name: String,
+    pub r#type: Type,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// The complete list of supported binary operators for scalar types.
+/// Not all of these are supported for every type.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ComparisonOperators(pub BTreeMap<ScalarType, BTreeMap<String, ComparisonOperator>>);
+
+/// Represents a postgres binary comparison operator
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ComparisonOperator {
+    pub operator_name: String,
+    pub operator_kind: OperatorKind,
+    pub argument_type: ScalarType,
+
+    #[serde(default = "default_true")]
+    pub is_infix: bool,
+}
+
+/// Is it a built-in operator, or a custom operator.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum OperatorKind {
+    Equal,
+    In,
+    Custom,
+}
+
+/// This is quite unfortunate: https://github.com/serde-rs/serde/issues/368
+/// TL;DR: we can't set default literals for serde, so if we want 'is_infix' to
+/// default to 'true', we have to set its default as a function that returns 'true'.
+fn default_true() -> bool {
+    true
+}
+
+/// Mapping from a "table" name to its information.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TablesInfo(pub BTreeMap<String, TableInfo>);
+
+/// Information about a database table (or any other kind of relation).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TableInfo {
+    pub schema_name: String,
+    pub table_name: String,
+    pub columns: BTreeMap<String, ColumnInfo>,
+    #[serde(default)]
+    pub uniqueness_constraints: UniquenessConstraints,
+    #[serde(default)]
+    pub foreign_relations: ForeignRelations,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// Can this column contain null values
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum Nullable {
+    #[default]
+    Nullable,
+    NonNullable,
+}
+
+/// Does this column have a default value.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum HasDefault {
+    #[default]
+    NoDefault,
+    HasDefault,
+}
+
+/// Is this column an identity column.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum IsIdentity {
+    #[default]
+    NotIdentity,
+    IdentityByDefault,
+    IdentityAlways,
+}
+
+/// Is this column a generated column.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum IsGenerated {
+    #[default]
+    NotGenerated,
+    Stored,
+}
+
+/// Information about a database column.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ColumnInfo {
+    pub name: String,
+    pub r#type: Type,
+    #[serde(default)]
+    pub nullable: Nullable,
+    #[serde(skip_serializing_if = "does_not_have_default")]
+    #[serde(default)]
+    pub has_default: HasDefault,
+    #[serde(skip_serializing_if = "is_not_identity")]
+    #[serde(default)]
+    pub is_identity: IsIdentity,
+    #[serde(skip_serializing_if = "is_not_generated")]
+    #[serde(default)]
+    pub is_generated: IsGenerated,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+fn does_not_have_default(has_default: &HasDefault) -> bool {
+    matches!(has_default, HasDefault::NoDefault)
+}
+
+fn is_not_identity(is_identity: &IsIdentity) -> bool {
+    matches!(is_identity, IsIdentity::NotIdentity)
+}
+
+fn is_not_generated(is_generated: &IsGenerated) -> bool {
+    matches!(is_generated, IsGenerated::NotGenerated)
+}
+
+/// A mapping from the name of a unique constraint to its value.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UniquenessConstraints(pub BTreeMap<String, UniquenessConstraint>);
+
+/// The set of columns that make up a uniqueness constraint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UniquenessConstraint(pub BTreeSet<String>);
+
+/// A mapping from the name of a foreign key constraint to its value.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ForeignRelations(pub BTreeMap<String, ForeignRelation>);
+
+/// A foreign key constraint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ForeignRelation {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub foreign_schema: Option<String>,
+    pub foreign_table: String,
+    pub column_mapping: BTreeMap<String, String>,
+}
+
+/// All supported aggregate functions, grouped by type.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AggregateFunctions(pub BTreeMap<ScalarType, BTreeMap<String, AggregateFunction>>);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AggregateFunction {
+    pub return_type: ScalarType,
+}
+
+/// Type representation of scalar types, grouped by type.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TypeRepresentations(pub BTreeMap<ScalarType, TypeRepresentation>);
+
+/// Type representation of a scalar type.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum TypeRepresentation {
+    /// JSON booleans
+    Boolean,
+    /// Any JSON string
+    String,
+    /// float4
+    Float32,
+    /// float8
+    Float64,
+    /// int2
+    Int16,
+    /// int4
+    Int32,
+    /// int8 as integer
+    Int64,
+    /// int8 as string
+    Int64AsString,
+    /// numeric
+    BigDecimal,
+    /// numeric as string
+    BigDecimalAsString,
+
+    /// timestamp
+    Timestamp,
+    /// timestamp with timezone
+    Timestamptz,
+    /// time
+    Time,
+    /// time with timezone
+    Timetz,
+    /// date
+    Date,
+    /// uuid
+    UUID,
+    /// geography
+    Geography,
+    /// geometry
+    Geometry,
+    /// Any JSON number
+    Number,
+    /// Any JSON number, with no decimal part
+    Integer,
+    /// An arbitrary json.
+    Json,
+    /// One of the specified string values
+    Enum(Vec<String>),
+}
+
+// tests
+
+#[cfg(test)]
+mod tests {
+    use super::{ScalarType, TypeRepresentation, TypeRepresentations};
+
+    #[test]
+    fn parse_type_representations() {
+        assert_eq!(
+            serde_json::from_str::<TypeRepresentations>(
+                r#"{"int4": "integer", "card_suit": {"enum": ["hearts", "clubs", "diamonds", "spades"]}}"#
+            )
+            .unwrap(),
+            TypeRepresentations(
+                [(
+                    ScalarType("int4".to_string()),
+                    TypeRepresentation::Integer
+                ), (
+                    ScalarType("card_suit".to_string()),
+                    TypeRepresentation::Enum(vec![
+                        "hearts".into(),
+                        "clubs".into(),
+                        "diamonds".into(),
+                        "spades".into()
+                    ])
+                )]
+                .into()
+            )
+        );
+    }
+}

--- a/crates/configuration/src/version4/metadata/mod.rs
+++ b/crates/configuration/src/version4/metadata/mod.rs
@@ -18,13 +18,9 @@ pub struct Metadata {
     #[serde(default)]
     pub tables: TablesInfo,
     #[serde(default)]
+    pub scalar_types: ScalarTypes,
+    #[serde(default)]
     pub composite_types: CompositeTypes,
     #[serde(default)]
     pub native_queries: NativeQueries,
-    #[serde(default)]
-    pub aggregate_functions: AggregateFunctions,
-    #[serde(default)]
-    pub comparison_operators: ComparisonOperators,
-    #[serde(default)]
-    pub type_representations: TypeRepresentations,
 }

--- a/crates/configuration/src/version4/metadata/mod.rs
+++ b/crates/configuration/src/version4/metadata/mod.rs
@@ -1,0 +1,30 @@
+//! Metadata information regarding the database and tracked information.
+
+pub mod database;
+pub mod mutations;
+pub mod native_queries;
+
+// re-export without modules
+pub use database::*;
+pub use native_queries::*;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Metadata information.
+#[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Metadata {
+    #[serde(default)]
+    pub tables: TablesInfo,
+    #[serde(default)]
+    pub composite_types: CompositeTypes,
+    #[serde(default)]
+    pub native_queries: NativeQueries,
+    #[serde(default)]
+    pub aggregate_functions: AggregateFunctions,
+    #[serde(default)]
+    pub comparison_operators: ComparisonOperators,
+    #[serde(default)]
+    pub type_representations: TypeRepresentations,
+}

--- a/crates/configuration/src/version4/metadata/mutations.rs
+++ b/crates/configuration/src/version4/metadata/mutations.rs
@@ -1,0 +1,12 @@
+//! Generated mutations-related metadata information.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Which version of the generated mutations will be included in the schema
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum MutationsVersion {
+    V1,
+    VeryExperimentalWip,
+}

--- a/crates/configuration/src/version4/metadata/native_queries.rs
+++ b/crates/configuration/src/version4/metadata/native_queries.rs
@@ -219,7 +219,7 @@ impl From<NativeQueryParts> for String {
             match part {
                 NativeQueryPart::Text(text) => sql.push_str(text.as_str()),
                 NativeQueryPart::Parameter(param) => {
-                    sql.push_str(format!("{{{{{}}}}}", param).as_str())
+                    sql.push_str(format!("{{{{{param}}}}}").as_str());
                 }
             }
         }

--- a/crates/configuration/src/version4/metadata/native_queries.rs
+++ b/crates/configuration/src/version4/metadata/native_queries.rs
@@ -1,0 +1,345 @@
+//! Metadata information regarding native queries.
+
+// This code was copied from a different place that predated the introduction of clippy to the
+// project. Therefore we disregard certain clippy lints:
+#![allow(clippy::wrong_self_convention)]
+use super::database::*;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+
+// Types
+
+/// Metadata information of native queries.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeQueries(pub BTreeMap<String, NativeQueryInfo>);
+
+/// Information about a Native Query
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeQueryInfo {
+    /// SQL expression to use for the Native Query.
+    /// We can interpolate values using `{{variable_name}}` syntax,
+    /// such as `SELECT * FROM authors WHERE name = {{author_name}}`
+    pub sql: NativeQuerySqlEither,
+    /// Columns returned by the Native Query
+    pub columns: BTreeMap<String, ReadOnlyColumnInfo>,
+    #[serde(default)]
+    /// Names and types of arguments that can be passed to this Native Query
+    pub arguments: BTreeMap<String, ReadOnlyColumnInfo>,
+    #[serde(default)]
+    pub description: Option<String>,
+    /// True if this native query mutates the database
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default)]
+    pub is_procedure: bool,
+}
+
+/// Information about a native query column.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReadOnlyColumnInfo {
+    pub name: String,
+    pub r#type: Type,
+    #[serde(default)]
+    pub nullable: Nullable,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// This type contains information that still needs to be resolved.
+/// After deserializing, we expect the value to be "external",
+/// and after a subsequent step where we read from files,
+/// they should all be converted to NativeQuerySql.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(from = "NativeQuerySqlExternal")]
+#[serde(into = "NativeQuerySqlExternal")]
+pub enum NativeQuerySqlEither {
+    NativeQuerySql(NativeQuerySql),
+    NativeQuerySqlExternal(NativeQuerySqlExternal),
+}
+
+impl NativeQuerySqlEither {
+    /// Extract the actual native query sql from this type.
+    /// If this happens before reading a file, it will fail with an error.
+    pub fn sql(self) -> Result<NativeQueryParts, String> {
+        match self {
+            NativeQuerySqlEither::NativeQuerySql(
+                NativeQuerySql::Inline { sql } | NativeQuerySql::FromFile { sql, .. },
+            ) => Ok(sql),
+            NativeQuerySqlEither::NativeQuerySqlExternal(
+                NativeQuerySqlExternal::Inline { inline }
+                | NativeQuerySqlExternal::InlineUntagged(inline),
+            ) => Ok(inline),
+            NativeQuerySqlEither::NativeQuerySqlExternal(NativeQuerySqlExternal::File {
+                ..
+            }) => Err("not all native query sql files were read during parsing".to_string()),
+        }
+    }
+}
+
+impl From<NativeQuerySqlExternal> for NativeQuerySqlEither {
+    /// We use this to deserialize.
+    fn from(value: NativeQuerySqlExternal) -> Self {
+        NativeQuerySqlEither::NativeQuerySqlExternal(value)
+    }
+}
+
+impl From<NativeQuerySqlEither> for NativeQuerySqlExternal {
+    /// We use this to serialize.
+    fn from(value: NativeQuerySqlEither) -> Self {
+        match value {
+            NativeQuerySqlEither::NativeQuerySqlExternal(value) => value,
+            NativeQuerySqlEither::NativeQuerySql(value) => value.into(),
+        }
+    }
+}
+
+/// A Native Query SQL after file resolution.
+/// This is the underlying type of the `NativeQuerySqlEither` variant with the same name
+/// that is expected in the metadata when translating requests. A subsequent phase after de-serializing
+/// Should convert NativeQuerySqlExternal values to values of this type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NativeQuerySql {
+    FromFile {
+        file: std::path::PathBuf,
+        sql: NativeQueryParts,
+    },
+    Inline {
+        sql: NativeQueryParts,
+    },
+}
+
+impl NativeQuerySql {
+    /// Extract the native query sql expression.
+    pub fn sql(self) -> NativeQueryParts {
+        match self {
+            NativeQuerySql::Inline { sql } | NativeQuerySql::FromFile { sql, .. } => sql,
+        }
+    }
+}
+
+// We use this type as an intermediate representation for serialization/deserialization
+// of native query sql location/expression.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[serde(untagged)]
+/// Native Query SQL location.
+pub enum NativeQuerySqlExternal {
+    /// Refer to an external Native Query SQL file.
+    File {
+        /// Relative path to a sql file.
+        file: std::path::PathBuf,
+    },
+    /// Inline Native Query SQL string.
+    Inline {
+        /// An inline Native Query SQL string.
+        inline: NativeQueryParts,
+    },
+    InlineUntagged(
+        /// An inline Native Query SQL string.
+        NativeQueryParts,
+    ),
+}
+
+impl NativeQuerySqlEither {
+    /// Convert an external native query sql type to NativeQuerySql,
+    /// including reading files from disk.
+    pub fn from_external(
+        &self,
+        absolute_configuration_directory: &std::path::Path,
+    ) -> Result<NativeQuerySql, String> {
+        match self {
+            // unexpected we get this, but ok.
+            NativeQuerySqlEither::NativeQuerySql(value) => Ok(value.clone()),
+            NativeQuerySqlEither::NativeQuerySqlExternal(external) => match external {
+                NativeQuerySqlExternal::File { file } => {
+                    parse_native_query_from_file(absolute_configuration_directory.join(file))
+                }
+                NativeQuerySqlExternal::Inline { inline }
+                | NativeQuerySqlExternal::InlineUntagged(inline) => Ok(NativeQuerySql::Inline {
+                    sql: inline.clone(),
+                }),
+            },
+        }
+    }
+}
+
+impl From<NativeQuerySql> for NativeQuerySqlExternal {
+    /// used for deserialization.
+    fn from(value: NativeQuerySql) -> Self {
+        match value {
+            NativeQuerySql::Inline { sql } => NativeQuerySqlExternal::Inline { inline: sql },
+            NativeQuerySql::FromFile { file, .. } => NativeQuerySqlExternal::File { file },
+        }
+    }
+}
+
+impl JsonSchema for NativeQuerySqlEither {
+    fn schema_name() -> String {
+        "NativeQuerySql".to_string()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        NativeQuerySqlExternal::json_schema(gen)
+    }
+}
+
+/// A part of a Native Query text, either raw text or a parameter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NativeQueryPart {
+    /// A raw text part
+    Text(String),
+    /// A parameter
+    Parameter(String),
+}
+
+/// A Native Query SQL parts after parsing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "String")]
+#[serde(into = "String")]
+pub struct NativeQueryParts(pub Vec<NativeQueryPart>);
+
+impl From<String> for NativeQueryParts {
+    /// Used for de-serialization.
+    fn from(value: String) -> Self {
+        parse_native_query(&value)
+    }
+}
+
+impl From<NativeQueryParts> for String {
+    /// Used for serialization.
+    fn from(value: NativeQueryParts) -> Self {
+        let mut sql: String = String::new();
+        for part in &value.0 {
+            match part {
+                NativeQueryPart::Text(text) => sql.push_str(text.as_str()),
+                NativeQueryPart::Parameter(param) => {
+                    sql.push_str(format!("{{{{{}}}}}", param).as_str())
+                }
+            }
+        }
+        sql
+    }
+}
+
+impl JsonSchema for NativeQueryParts {
+    fn schema_name() -> String {
+        "InlineNativeQuerySql".to_string()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(gen)
+    }
+}
+
+// Parsing
+
+/// Read a file a parse it into native query parts.
+pub fn parse_native_query_from_file(file: std::path::PathBuf) -> Result<NativeQuerySql, String> {
+    let contents: String = match fs::read_to_string(&file) {
+        Ok(ok) => Ok(ok),
+        Err(err) => Err(format!("{}: {}", &file.display(), err)),
+    }?;
+    let sql = parse_native_query(&contents);
+    Ok(NativeQuerySql::FromFile { file, sql })
+}
+
+/// Parse a native query into parts where variables have the syntax `{{<variable>}}`.
+fn parse_native_query(string: &str) -> NativeQueryParts {
+    let vec: Vec<Vec<NativeQueryPart>> = string
+        .split("{{")
+        .map(|part| match part.split_once("}}") {
+            None => vec![NativeQueryPart::Text(part.to_string())],
+            Some((var, text)) => {
+                if text.is_empty() {
+                    vec![NativeQueryPart::Parameter(var.to_string())]
+                } else {
+                    vec![
+                        NativeQueryPart::Parameter(var.to_string()),
+                        NativeQueryPart::Text(text.to_string()),
+                    ]
+                }
+            }
+        })
+        .collect();
+    NativeQueryParts(vec.concat())
+}
+
+// tests
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_native_query, NativeQueryPart, NativeQueryParts, NativeQuerySqlExternal};
+
+    #[test]
+    fn no_parameters() {
+        assert_eq!(
+            parse_native_query("select 1"),
+            NativeQueryParts(vec![NativeQueryPart::Text("select 1".to_string())])
+        );
+    }
+
+    #[test]
+    fn one_parameter() {
+        assert_eq!(
+            parse_native_query("select * from t where {{name}} = name"),
+            NativeQueryParts(vec![
+                NativeQueryPart::Text("select * from t where ".to_string()),
+                NativeQueryPart::Parameter("name".to_string()),
+                NativeQueryPart::Text(" = name".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn multiple_parameters() {
+        assert_eq!(
+            parse_native_query("select * from t where id = {{id}} and {{name}} = {{other_name}}"),
+            NativeQueryParts(vec![
+                NativeQueryPart::Text("select * from t where id = ".to_string()),
+                NativeQueryPart::Parameter("id".to_string()),
+                NativeQueryPart::Text(" and ".to_string()),
+                NativeQueryPart::Parameter("name".to_string()),
+                NativeQueryPart::Text(" = ".to_string()),
+                NativeQueryPart::Parameter("other_name".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn one_parameter_and_curly_text() {
+        assert_eq!(
+            parse_native_query("select * from t where {{name}} = '{name}'"),
+            NativeQueryParts(vec![
+                NativeQueryPart::Text("select * from t where ".to_string()),
+                NativeQueryPart::Parameter("name".to_string()),
+                NativeQueryPart::Text(" = '{name}'".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn parse_inline_untagged() {
+        assert_eq!(
+            serde_json::from_str::<NativeQuerySqlExternal>(r#""select 1""#).unwrap(),
+            NativeQuerySqlExternal::InlineUntagged(NativeQueryParts(vec![NativeQueryPart::Text(
+                "select 1".to_string()
+            )]))
+        );
+    }
+
+    #[test]
+    fn parse_inline_tagged() {
+        assert_eq!(
+            serde_json::from_str::<NativeQuerySqlExternal>(r#"{ "inline": "select 1" }"#).unwrap(),
+            NativeQuerySqlExternal::Inline {
+                inline: NativeQueryParts(vec![NativeQueryPart::Text("select 1".to_string())])
+            }
+        );
+    }
+}

--- a/crates/configuration/src/version4/mod.rs
+++ b/crates/configuration/src/version4/mod.rs
@@ -1,0 +1,1094 @@
+//! Internal Configuration and state for our connector.
+
+mod comparison;
+pub mod connection_settings;
+mod metadata;
+mod options;
+
+use std::borrow::Cow;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use sqlx::postgres::PgConnection;
+use sqlx::{Connection, Executor, Row};
+use tokio::fs;
+use tracing::{info_span, Instrument};
+
+use metadata::database;
+
+use crate::environment::Environment;
+use crate::error::Error;
+use crate::values::{ConnectionUri, Secret};
+
+const CONFIGURATION_QUERY: &str = include_str!("version3.sql");
+
+/// Initial configuration, just enough to connect to a database and elaborate a full
+/// 'Configuration'.
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RawConfiguration {
+    /// Jsonschema of the configuration format.
+    #[serde(rename = "$schema")]
+    #[serde(default)]
+    pub schema: Option<String>,
+    /// Database connection settings.
+    pub connection_settings: connection_settings::DatabaseConnectionSettings,
+    /// Connector metadata.
+    #[serde(default)]
+    pub metadata: metadata::Metadata,
+    /// Database introspection options.
+    #[serde(default)]
+    pub introspection_options: options::IntrospectionOptions,
+    /// Which version of the generated mutation procedures to include in the schema response
+    #[serde(default)]
+    pub mutations_version: Option<metadata::mutations::MutationsVersion>,
+}
+
+impl RawConfiguration {
+    pub fn empty() -> Self {
+        Self {
+            schema: Some(crate::CONFIGURATION_JSONSCHEMA_FILENAME.to_string()),
+            connection_settings: connection_settings::DatabaseConnectionSettings::empty(),
+            metadata: metadata::Metadata::default(),
+            introspection_options: options::IntrospectionOptions::default(),
+            // we'll change this to `Some(MutationsVersions::V1)` when we
+            // want to "release" this behaviour
+            mutations_version: None,
+        }
+    }
+}
+
+/// Validate the user configuration.
+pub fn validate_raw_configuration(
+    file_path: PathBuf,
+    config: RawConfiguration,
+) -> Result<RawConfiguration, Error> {
+    match &config.connection_settings.connection_uri {
+        ConnectionUri(Secret::Plain(uri)) if uri.is_empty() => {
+            Err(Error::EmptyConnectionUri { file_path })
+        }
+        _ => Ok(()),
+    }?;
+
+    Ok(config)
+}
+
+/// Construct the NDC metadata configuration by introspecting the database.
+pub async fn introspect(
+    args: RawConfiguration,
+    environment: impl Environment,
+) -> anyhow::Result<RawConfiguration> {
+    let uri = match &args.connection_settings.connection_uri {
+        ConnectionUri(Secret::Plain(value)) => Cow::Borrowed(value),
+        ConnectionUri(Secret::FromEnvironment { variable }) => {
+            Cow::Owned(environment.read(variable)?)
+        }
+    };
+
+    let mut connection = PgConnection::connect(&uri)
+        .instrument(info_span!("Connect to database"))
+        .await?;
+
+    let query = sqlx::query(CONFIGURATION_QUERY)
+        .bind(&args.introspection_options.excluded_schemas)
+        .bind(&args.introspection_options.unqualified_schemas_for_tables)
+        .bind(
+            &args
+                .introspection_options
+                .unqualified_schemas_for_types_and_procedures,
+        )
+        .bind(serde_json::to_value(
+            &args.introspection_options.comparison_operator_mapping,
+        )?)
+        .bind(
+            &args
+                .introspection_options
+                .introspect_prefix_function_comparison_operators,
+        )
+        .bind(serde_json::to_value(
+            base_type_representations(args.metadata.type_representations).0,
+        )?);
+
+    let row = connection
+        .fetch_one(query)
+        .instrument(info_span!("Run introspection query"))
+        .await?;
+
+    let (tables, aggregate_functions, comparison_operators, composite_types, type_representations) = async {
+        let tables: metadata::TablesInfo = serde_json::from_value(row.get(0))?;
+
+        let aggregate_functions: metadata::AggregateFunctions = serde_json::from_value(row.get(1))?;
+
+        let metadata::ComparisonOperators(mut comparison_operators): metadata::ComparisonOperators =
+            serde_json::from_value(row.get(2))?;
+
+        let composite_types: metadata::CompositeTypes = serde_json::from_value(row.get(3))?;
+
+        let type_representations: metadata::TypeRepresentations =
+            serde_json::from_value(row.get(4))?;
+
+        // We need to include `in` as a comparison operator in the schema, and since it is syntax, it is not introspectable.
+        // Instead, we will check if the scalar type defines an equals operator and if yes, we will insert the `_in` operator
+        // as well.
+        for (scalar_type, operators) in &mut comparison_operators {
+            if operators
+                .values()
+                .any(|op| op.operator_kind == metadata::OperatorKind::Equal)
+            {
+                operators.insert(
+                    "_in".to_string(),
+                    metadata::ComparisonOperator {
+                        operator_name: "IN".to_string(),
+                        operator_kind: metadata::OperatorKind::In,
+                        argument_type: scalar_type.clone(),
+                        is_infix: true,
+                    },
+                );
+            }
+        }
+
+        // We need to specify the concrete return type explicitly so that rustc knows that it can
+        // be sent across an async boundary.
+        // (last verified with rustc 1.72.1)
+        Ok::<_, anyhow::Error>((
+            tables,
+            aggregate_functions,
+            metadata::ComparisonOperators(comparison_operators),
+            composite_types,
+            type_representations,
+        ))
+    }
+    .instrument(info_span!("Decode introspection result"))
+    .await?;
+
+    let (scalar_types, composite_types) = transitively_occurring_types(
+        occurring_scalar_types(
+            &tables,
+            &args.metadata.native_queries,
+            &args.metadata.aggregate_functions,
+        ),
+        &occurring_composite_types(&tables, &args.metadata.native_queries),
+        composite_types,
+    );
+
+    // We filter our comparison operators and aggregate functions to only include those relevant to
+    // types that may actually occur in the schema.
+    let relevant_comparison_operators =
+        filter_comparison_operators(&scalar_types, comparison_operators);
+    let relevant_aggregate_functions =
+        filter_aggregate_functions(&scalar_types, aggregate_functions);
+    let relevant_type_representations =
+        filter_type_representations(&scalar_types, type_representations);
+
+    Ok(RawConfiguration {
+        schema: args.schema,
+        connection_settings: args.connection_settings,
+        metadata: metadata::Metadata {
+            tables,
+            native_queries: args.metadata.native_queries,
+            aggregate_functions: relevant_aggregate_functions,
+            comparison_operators: relevant_comparison_operators,
+            composite_types,
+            type_representations: relevant_type_representations,
+        },
+        introspection_options: args.introspection_options,
+        mutations_version: args.mutations_version,
+    })
+}
+
+/// Merge the type representations currenting defined in the user's configuration with
+/// our base defaults. User configuration takes precedence.
+fn base_type_representations(
+    database::TypeRepresentations(existing_type_representations): database::TypeRepresentations,
+) -> database::TypeRepresentations {
+    // Start with the default type representations
+    let mut type_representations: database::TypeRepresentations = database::TypeRepresentations(
+        [
+            // Bit strings:
+            //   https://www.postgresql.org/docs/current/datatype-bit.html
+            //   https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-BIT-STRINGS
+            //
+            // We hint these to String, meaning a sequence of '0' and '1' chars, but more choices are
+            // possible.
+            (
+                database::ScalarType("bit".to_string()),
+                database::TypeRepresentation::String,
+            ),
+            (
+                database::ScalarType("bool".to_string()),
+                database::TypeRepresentation::Boolean,
+            ),
+            (
+                database::ScalarType("bpchar".to_string()),
+                database::TypeRepresentation::String,
+            ),
+            (
+                database::ScalarType("char".to_string()),
+                database::TypeRepresentation::String,
+            ),
+            (
+                database::ScalarType("date".to_string()),
+                database::TypeRepresentation::Date,
+            ),
+            (
+                database::ScalarType("float4".to_string()),
+                database::TypeRepresentation::Float32,
+            ),
+            (
+                database::ScalarType("float8".to_string()),
+                database::TypeRepresentation::Float64,
+            ),
+            (
+                database::ScalarType("int2".to_string()),
+                database::TypeRepresentation::Int16,
+            ),
+            (
+                database::ScalarType("int4".to_string()),
+                database::TypeRepresentation::Int32,
+            ),
+            (
+                database::ScalarType("int8".to_string()),
+                // ndc-spec defines that Int64 has the json representation of a string.
+                // This is not what we do now and is a breaking change.
+                // This will need to be changed in the future. In the meantime, we report
+                // The type representation to be json.
+                database::TypeRepresentation::Int64AsString,
+            ),
+            (
+                database::ScalarType("numeric".to_string()),
+                database::TypeRepresentation::BigDecimalAsString,
+            ),
+            (
+                database::ScalarType("text".to_string()),
+                database::TypeRepresentation::String,
+            ),
+            (
+                database::ScalarType("time".to_string()),
+                database::TypeRepresentation::Time,
+            ),
+            (
+                database::ScalarType("timestamp".to_string()),
+                database::TypeRepresentation::Timestamp,
+            ),
+            (
+                database::ScalarType("timestamptz".to_string()),
+                database::TypeRepresentation::Timestamptz,
+            ),
+            (
+                database::ScalarType("timetz".to_string()),
+                database::TypeRepresentation::Timetz,
+            ),
+            (
+                database::ScalarType("uuid".to_string()),
+                database::TypeRepresentation::UUID,
+            ),
+            (
+                database::ScalarType("varchar".to_string()),
+                database::TypeRepresentation::String,
+            ),
+        ]
+        .into(),
+    );
+    // If the user already has existing type representations defined,
+    // override the default ones using `insert`.
+    // We do this to not change the behaviour for the user on update.
+    for (typ, type_rep) in existing_type_representations {
+        match type_rep {
+            // we don't want to do this for enums as they should be overwritten according to the database.
+            database::TypeRepresentation::Enum(_) => {}
+            _ => {
+                type_representations.0.insert(typ, type_rep);
+            }
+        }
+    }
+    type_representations
+}
+
+/// Collect all the composite types that can occur in the metadata.
+pub fn occurring_composite_types(
+    tables: &metadata::TablesInfo,
+    native_queries: &metadata::NativeQueries,
+) -> BTreeSet<String> {
+    let tables_column_types = tables
+        .0
+        .values()
+        .flat_map(|v| v.columns.values().map(|c| &c.r#type));
+    let native_queries_column_types = native_queries
+        .0
+        .values()
+        .flat_map(|v| v.columns.values().map(|c| &c.r#type));
+    let native_queries_arguments_types = native_queries
+        .0
+        .values()
+        .flat_map(|v| v.arguments.values().map(|c| &c.r#type));
+
+    tables_column_types
+        .chain(native_queries_column_types)
+        .chain(native_queries_arguments_types)
+        .filter_map(|t| match t {
+            metadata::Type::CompositeType(ref t) => Some(t.clone()),
+            metadata::Type::ArrayType(t) => match **t {
+                metadata::Type::CompositeType(ref t) => Some(t.clone()),
+                metadata::Type::ArrayType(_) | metadata::Type::ScalarType(_) => None,
+            },
+            metadata::Type::ScalarType(_) => None,
+        })
+        .collect::<BTreeSet<String>>()
+}
+
+// Since array types and composite types may refer to other types we have to transitively discover
+// the full set of types that are relevant to the schema.
+pub fn transitively_occurring_types(
+    mut occurring_scalar_types: BTreeSet<metadata::ScalarType>,
+    occurring_type_names: &BTreeSet<String>,
+    mut composite_types: metadata::CompositeTypes,
+) -> (BTreeSet<metadata::ScalarType>, metadata::CompositeTypes) {
+    let mut discovered_type_names = occurring_type_names.clone();
+
+    for t in occurring_type_names {
+        match composite_types.0.get(t) {
+            None => (),
+            Some(ct) => {
+                for f in ct.fields.values() {
+                    match &f.r#type {
+                        metadata::Type::CompositeType(ct2) => {
+                            discovered_type_names.insert(ct2.to_string());
+                        }
+                        metadata::Type::ScalarType(t) => {
+                            occurring_scalar_types.insert(t.clone());
+                        }
+                        metadata::Type::ArrayType(arr_ty) => match **arr_ty {
+                            metadata::Type::CompositeType(ref ct2) => {
+                                discovered_type_names.insert(ct2.to_string());
+                            }
+                            metadata::Type::ScalarType(ref t) => {
+                                occurring_scalar_types.insert(t.clone());
+                            }
+                            metadata::Type::ArrayType(_) => {
+                                // This case is impossible, because we do not support nested arrays
+                            }
+                        },
+                    }
+                }
+            }
+        }
+    }
+
+    // Since 'discovered_type_names' only grows monotonically starting from 'occurring_type_names'
+    // we just have to compare the number of elements to know if new types have been discovered.
+    if discovered_type_names.len() == occurring_type_names.len() {
+        // Iterating over occurring types discovered no new types
+        composite_types
+            .0
+            .retain(|t, _| occurring_type_names.contains(t));
+        (occurring_scalar_types, composite_types)
+    } else {
+        // Iterating over occurring types did discover new types,
+        // so we keep on going.
+        transitively_occurring_types(
+            occurring_scalar_types,
+            &discovered_type_names,
+            composite_types,
+        )
+    }
+}
+
+/// Collect all the scalar types that can occur in the metadata. This is a bit circumstantial. A better
+/// approach is likely to record scalar type names directly in the metadata via version2.sql.
+pub fn occurring_scalar_types(
+    tables: &metadata::TablesInfo,
+    native_queries: &metadata::NativeQueries,
+    aggregate_functions: &metadata::AggregateFunctions,
+) -> BTreeSet<metadata::ScalarType> {
+    let tables_column_types = tables
+        .0
+        .values()
+        .flat_map(|v| v.columns.values().map(|c| &c.r#type));
+    let native_queries_column_types = native_queries
+        .0
+        .values()
+        .flat_map(|v| v.columns.values().map(|c| &c.r#type));
+    let native_queries_arguments_types = native_queries
+        .0
+        .values()
+        .flat_map(|v| v.arguments.values().map(|c| &c.r#type));
+    let aggregate_functions_result_types = aggregate_functions
+        .0
+        .values()
+        .flat_map(|x| x.values().map(|agg_fn| agg_fn.return_type.clone()));
+
+    tables_column_types
+        .chain(native_queries_column_types)
+        .chain(native_queries_arguments_types)
+        .filter_map(|t| match t {
+            metadata::Type::ScalarType(ref t) => Some(t.clone()), // only keep scalar types
+            metadata::Type::ArrayType(_) | metadata::Type::CompositeType(_) => None,
+        })
+        .chain(aggregate_functions_result_types)
+        .collect::<BTreeSet<metadata::ScalarType>>()
+}
+
+/// Filter predicate for comparison operators. Preserves only comparison operators that are
+/// relevant to any of the given scalar types.
+///
+/// This function is public to enable use in later versions that retain the same metadata types.
+fn filter_comparison_operators(
+    scalar_types: &BTreeSet<metadata::ScalarType>,
+    comparison_operators: metadata::ComparisonOperators,
+) -> metadata::ComparisonOperators {
+    metadata::ComparisonOperators(
+        comparison_operators
+            .0
+            .into_iter()
+            .filter(|(typ, _)| scalar_types.contains(typ))
+            .map(|(typ, ops)| {
+                (
+                    typ,
+                    ops.into_iter()
+                        .filter(|(_, op)| scalar_types.contains(&op.argument_type))
+                        .collect(),
+                )
+            })
+            .collect(),
+    )
+}
+
+/// Filter predicate for aggregation functions. Preserves only aggregation functions that are
+/// relevant to any of the given scalar types.
+///
+/// This function is public to enable use in later versions that retain the same metadata types.
+fn filter_aggregate_functions(
+    scalar_types: &BTreeSet<metadata::ScalarType>,
+    aggregate_functions: metadata::AggregateFunctions,
+) -> metadata::AggregateFunctions {
+    metadata::AggregateFunctions(
+        aggregate_functions
+            .0
+            .into_iter()
+            .filter(|(typ, _)| scalar_types.contains(typ))
+            .collect(),
+    )
+}
+
+/// Filter predicate for type representations. Preserves only type representations that are
+/// relevant to any of the given scalar types.
+///
+/// This function is public to enable use in later versions that retain the same metadata types.
+fn filter_type_representations(
+    scalar_types: &BTreeSet<metadata::ScalarType>,
+    type_representations: metadata::TypeRepresentations,
+) -> metadata::TypeRepresentations {
+    metadata::TypeRepresentations(
+        type_representations
+            .0
+            .into_iter()
+            .filter(|(typ, _)| scalar_types.contains(typ))
+            .collect(),
+    )
+}
+
+pub async fn parse_configuration(
+    configuration_dir: impl AsRef<Path>,
+    environment: impl Environment,
+) -> Result<crate::Configuration, Error> {
+    let configuration_file = configuration_dir
+        .as_ref()
+        .join(crate::CONFIGURATION_FILENAME);
+
+    let configuration_file_contents =
+        fs::read_to_string(&configuration_file)
+            .await
+            .map_err(|err| {
+                Error::IoErrorButStringified(format!("{}: {}", &configuration_file.display(), err))
+            })?;
+    let mut configuration: RawConfiguration = serde_json::from_str(&configuration_file_contents)
+        .map_err(|error| Error::ParseError {
+            file_path: configuration_file.clone(),
+            line: error.line(),
+            column: error.column(),
+            message: error.to_string(),
+        })?;
+    // look for native query sql file references and read from disk.
+    for native_query_sql in configuration.metadata.native_queries.0.values_mut() {
+        native_query_sql.sql = metadata::NativeQuerySqlEither::NativeQuerySql(
+            native_query_sql
+                .sql
+                .from_external(configuration_dir.as_ref())
+                .map_err(Error::IoErrorButStringified)?,
+        );
+    }
+
+    let connection_uri =
+        match configuration.connection_settings.connection_uri {
+            ConnectionUri(Secret::Plain(uri)) => Ok(uri),
+            ConnectionUri(Secret::FromEnvironment { variable }) => environment
+                .read(&variable)
+                .map_err(|error| Error::MissingEnvironmentVariable {
+                    file_path: configuration_file,
+                    message: error.to_string(),
+                }),
+        }?;
+    Ok(crate::Configuration {
+        metadata: convert_metadata(configuration.metadata),
+        pool_settings: configuration.connection_settings.pool_settings,
+        connection_uri,
+        isolation_level: configuration.connection_settings.isolation_level,
+        mutations_version: convert_mutations_version(configuration.mutations_version),
+    })
+}
+
+// This function is used by tests as well
+pub fn convert_metadata(metadata: metadata::Metadata) -> query_engine_metadata::metadata::Metadata {
+    let (scalar_types, composite_types) = transitively_occurring_types(
+        occurring_scalar_types(
+            &metadata.tables,
+            &metadata.native_queries,
+            &metadata.aggregate_functions,
+        ),
+        &occurring_composite_types(&metadata.tables, &metadata.native_queries),
+        metadata.composite_types,
+    );
+
+    query_engine_metadata::metadata::Metadata {
+        tables: convert_tables(metadata.tables),
+        composite_types: convert_composite_types(composite_types),
+        native_queries: convert_native_queries(metadata.native_queries),
+        scalar_types: convert_scalar_types(
+            scalar_types,
+            metadata.aggregate_functions,
+            metadata.comparison_operators,
+            metadata.type_representations,
+        ),
+    }
+}
+
+fn convert_scalar_types(
+    scalar_types: BTreeSet<metadata::ScalarType>,
+    aggregate_functions: metadata::AggregateFunctions,
+    comparison_operators: metadata::ComparisonOperators,
+    type_representations: metadata::TypeRepresentations,
+) -> query_engine_metadata::metadata::ScalarTypes {
+    let aggregates = convert_aggregate_functions(aggregate_functions);
+    let comparisons = convert_comparison_operators(comparison_operators);
+    let representations = convert_type_representations(type_representations);
+
+    query_engine_metadata::metadata::ScalarTypes(
+        scalar_types
+            .into_iter()
+            .map(|t| {
+                (
+                    convert_scalar_type(t.clone()),
+                    query_engine_metadata::metadata::ScalarType {
+                        name: t.0.clone(),
+                        schema_name: None, // Version 3 does not capture the schema of scalar
+                        // types.
+                        description: None,
+                        aggregate_functions: aggregates
+                            .0
+                            .get(&query_engine_metadata::metadata::ScalarTypeName(
+                                t.0.clone(),
+                            ))
+                            .cloned()
+                            .unwrap_or(BTreeMap::new()),
+                        comparison_operators: comparisons
+                            .0
+                            .get(&query_engine_metadata::metadata::ScalarTypeName(
+                                t.0.clone(),
+                            ))
+                            .cloned()
+                            .unwrap_or(BTreeMap::new()),
+
+                        type_representation: representations
+                            .0
+                            .get(&query_engine_metadata::metadata::ScalarTypeName(
+                                t.0.clone(),
+                            ))
+                            .cloned(),
+                    },
+                )
+            })
+            .collect(),
+    )
+}
+
+fn convert_scalar_type(
+    scalar_type: metadata::ScalarType,
+) -> query_engine_metadata::metadata::ScalarTypeName {
+    query_engine_metadata::metadata::ScalarTypeName(scalar_type.0)
+}
+
+fn convert_aggregate_functions(
+    aggregate_functions: metadata::AggregateFunctions,
+) -> query_engine_metadata::metadata::AggregateFunctions {
+    let res = aggregate_functions
+        .0
+        .into_iter()
+        .map(|(k, v)| {
+            (
+                convert_scalar_type(k),
+                v.into_iter()
+                    .map(|(k, v)| (k, convert_aggregate_function(v)))
+                    .collect(),
+            )
+        })
+        .collect();
+
+    query_engine_metadata::metadata::AggregateFunctions(res)
+}
+
+fn convert_aggregate_function(
+    aggregate_function: metadata::AggregateFunction,
+) -> query_engine_metadata::metadata::AggregateFunction {
+    query_engine_metadata::metadata::AggregateFunction {
+        return_type: convert_scalar_type(aggregate_function.return_type),
+    }
+}
+
+fn convert_native_queries(
+    native_queries: metadata::NativeQueries,
+) -> query_engine_metadata::metadata::NativeQueries {
+    query_engine_metadata::metadata::NativeQueries(
+        native_queries
+            .0
+            .into_iter()
+            .map(|(k, v)| (k, convert_native_query_info(v)))
+            .collect(),
+    )
+}
+
+fn convert_native_query_info(
+    native_query_info: metadata::NativeQueryInfo,
+) -> query_engine_metadata::metadata::NativeQueryInfo {
+    query_engine_metadata::metadata::NativeQueryInfo {
+        sql: convert_native_query_sql_either(native_query_info.sql),
+        columns: native_query_info
+            .columns
+            .into_iter()
+            .map(|(k, v)| (k, convert_read_only_column_info(v)))
+            .collect(),
+        arguments: native_query_info
+            .arguments
+            .into_iter()
+            .map(|(k, v)| (k, convert_read_only_column_info(v)))
+            .collect(),
+        description: native_query_info.description,
+        is_procedure: native_query_info.is_procedure,
+    }
+}
+
+fn convert_read_only_column_info(
+    read_only_column_info: metadata::ReadOnlyColumnInfo,
+) -> query_engine_metadata::metadata::ReadOnlyColumnInfo {
+    query_engine_metadata::metadata::ReadOnlyColumnInfo {
+        name: read_only_column_info.name,
+        r#type: convert_type(read_only_column_info.r#type),
+        nullable: convert_nullable(&read_only_column_info.nullable),
+        description: read_only_column_info.description,
+    }
+}
+
+fn convert_nullable(nullable: &metadata::Nullable) -> query_engine_metadata::metadata::Nullable {
+    match nullable {
+        metadata::Nullable::Nullable => query_engine_metadata::metadata::Nullable::Nullable,
+        metadata::Nullable::NonNullable => query_engine_metadata::metadata::Nullable::NonNullable,
+    }
+}
+
+fn convert_type(r#type: metadata::Type) -> query_engine_metadata::metadata::Type {
+    match r#type {
+        metadata::Type::ScalarType(t) => {
+            query_engine_metadata::metadata::Type::ScalarType(convert_scalar_type(t))
+        }
+        metadata::Type::CompositeType(t) => query_engine_metadata::metadata::Type::CompositeType(
+            query_engine_metadata::metadata::CompositeTypeName(t),
+        ),
+        metadata::Type::ArrayType(t) => {
+            query_engine_metadata::metadata::Type::ArrayType(Box::new(convert_type(*t)))
+        }
+    }
+}
+
+fn convert_native_query_sql_either(
+    sql: metadata::NativeQuerySqlEither,
+) -> query_engine_metadata::metadata::NativeQuerySqlEither {
+    match sql {
+        metadata::NativeQuerySqlEither::NativeQuerySql(internal_sql) => {
+            query_engine_metadata::metadata::NativeQuerySqlEither::NativeQuerySql(
+                convert_native_query_sql_internal(internal_sql),
+            )
+        }
+        metadata::NativeQuerySqlEither::NativeQuerySqlExternal(external_sql) => {
+            query_engine_metadata::metadata::NativeQuerySqlEither::NativeQuerySqlExternal(
+                convert_native_query_sql_external(external_sql),
+            )
+        }
+    }
+}
+
+fn convert_native_query_sql_internal(
+    internal_sql: metadata::NativeQuerySql,
+) -> query_engine_metadata::metadata::NativeQuerySql {
+    match internal_sql {
+        metadata::NativeQuerySql::FromFile { file, sql } => {
+            query_engine_metadata::metadata::NativeQuerySql::FromFile {
+                file,
+                sql: convert_native_query_parts(sql),
+            }
+        }
+        metadata::NativeQuerySql::Inline { sql } => {
+            query_engine_metadata::metadata::NativeQuerySql::Inline {
+                sql: convert_native_query_parts(sql),
+            }
+        }
+    }
+}
+
+fn convert_native_query_sql_external(
+    external_sql: metadata::NativeQuerySqlExternal,
+) -> query_engine_metadata::metadata::NativeQuerySqlExternal {
+    match external_sql {
+        metadata::NativeQuerySqlExternal::File { file } => {
+            query_engine_metadata::metadata::NativeQuerySqlExternal::File { file }
+        }
+        metadata::NativeQuerySqlExternal::Inline { inline } => {
+            query_engine_metadata::metadata::NativeQuerySqlExternal::Inline {
+                inline: convert_native_query_parts(inline),
+            }
+        }
+        metadata::NativeQuerySqlExternal::InlineUntagged(parts) => {
+            query_engine_metadata::metadata::NativeQuerySqlExternal::InlineUntagged(
+                convert_native_query_parts(parts),
+            )
+        }
+    }
+}
+
+fn convert_native_query_parts(
+    inline: metadata::NativeQueryParts,
+) -> query_engine_metadata::metadata::NativeQueryParts {
+    query_engine_metadata::metadata::NativeQueryParts(
+        inline
+            .0
+            .into_iter()
+            .map(convert_native_query_part)
+            .collect(),
+    )
+}
+
+fn convert_native_query_part(
+    native_query_part: metadata::NativeQueryPart,
+) -> query_engine_metadata::metadata::NativeQueryPart {
+    match native_query_part {
+        metadata::NativeQueryPart::Text(t) => {
+            query_engine_metadata::metadata::NativeQueryPart::Text(t)
+        }
+        metadata::NativeQueryPart::Parameter(p) => {
+            query_engine_metadata::metadata::NativeQueryPart::Parameter(p)
+        }
+    }
+}
+
+fn convert_type_representations(
+    type_representations: metadata::TypeRepresentations,
+) -> query_engine_metadata::metadata::TypeRepresentations {
+    query_engine_metadata::metadata::TypeRepresentations(
+        type_representations
+            .0
+            .into_iter()
+            .map(|(k, type_representation)| {
+                (
+                    convert_scalar_type(k),
+                    convert_type_representation(type_representation),
+                )
+            })
+            .collect(),
+    )
+}
+
+fn convert_type_representation(
+    type_representation: metadata::TypeRepresentation,
+) -> query_engine_metadata::metadata::TypeRepresentation {
+    match type_representation {
+        metadata::TypeRepresentation::Boolean => {
+            query_engine_metadata::metadata::TypeRepresentation::Boolean
+        }
+        metadata::TypeRepresentation::String => {
+            query_engine_metadata::metadata::TypeRepresentation::String
+        }
+        metadata::TypeRepresentation::Float32 => {
+            query_engine_metadata::metadata::TypeRepresentation::Float32
+        }
+        metadata::TypeRepresentation::Float64 => {
+            query_engine_metadata::metadata::TypeRepresentation::Float64
+        }
+        metadata::TypeRepresentation::Int16 => {
+            query_engine_metadata::metadata::TypeRepresentation::Int16
+        }
+        metadata::TypeRepresentation::Int32 => {
+            query_engine_metadata::metadata::TypeRepresentation::Int32
+        }
+        metadata::TypeRepresentation::Int64 => {
+            query_engine_metadata::metadata::TypeRepresentation::Int64
+        }
+        metadata::TypeRepresentation::Int64AsString => {
+            query_engine_metadata::metadata::TypeRepresentation::Int64AsString
+        }
+        metadata::TypeRepresentation::BigDecimal => {
+            query_engine_metadata::metadata::TypeRepresentation::BigDecimal
+        }
+        metadata::TypeRepresentation::BigDecimalAsString => {
+            query_engine_metadata::metadata::TypeRepresentation::BigDecimalAsString
+        }
+        metadata::TypeRepresentation::Timestamp => {
+            query_engine_metadata::metadata::TypeRepresentation::Timestamp
+        }
+        metadata::TypeRepresentation::Timestamptz => {
+            query_engine_metadata::metadata::TypeRepresentation::Timestamptz
+        }
+        metadata::TypeRepresentation::Time => {
+            query_engine_metadata::metadata::TypeRepresentation::Time
+        }
+        metadata::TypeRepresentation::Timetz => {
+            query_engine_metadata::metadata::TypeRepresentation::Timetz
+        }
+        metadata::TypeRepresentation::Date => {
+            query_engine_metadata::metadata::TypeRepresentation::Date
+        }
+        metadata::TypeRepresentation::UUID => {
+            query_engine_metadata::metadata::TypeRepresentation::UUID
+        }
+        metadata::TypeRepresentation::Geography => {
+            query_engine_metadata::metadata::TypeRepresentation::Geography
+        }
+        metadata::TypeRepresentation::Geometry => {
+            query_engine_metadata::metadata::TypeRepresentation::Geometry
+        }
+        // This is deprecated in ndc-spec
+        metadata::TypeRepresentation::Number
+        | metadata::TypeRepresentation::Integer
+        | metadata::TypeRepresentation::Json => {
+            query_engine_metadata::metadata::TypeRepresentation::Json
+        }
+        metadata::TypeRepresentation::Enum(v) => {
+            query_engine_metadata::metadata::TypeRepresentation::Enum(v)
+        }
+    }
+}
+
+fn convert_comparison_operators(
+    comparison_operators: metadata::ComparisonOperators,
+) -> query_engine_metadata::metadata::ComparisonOperators {
+    query_engine_metadata::metadata::ComparisonOperators(
+        comparison_operators
+            .0
+            .into_iter()
+            .map(|(k, v)| {
+                (
+                    convert_scalar_type(k),
+                    v.into_iter()
+                        .map(|(k, comparison_operator)| {
+                            (k, convert_comparison_operator(comparison_operator))
+                        })
+                        .collect(),
+                )
+            })
+            .collect(),
+    )
+}
+
+fn convert_comparison_operator(
+    comparison_operator: metadata::ComparisonOperator,
+) -> query_engine_metadata::metadata::ComparisonOperator {
+    query_engine_metadata::metadata::ComparisonOperator {
+        operator_name: comparison_operator.operator_name,
+        operator_kind: convert_operator_kind(&comparison_operator.operator_kind),
+        argument_type: convert_scalar_type(comparison_operator.argument_type),
+        is_infix: comparison_operator.is_infix,
+    }
+}
+
+fn convert_operator_kind(
+    operator_kind: &metadata::OperatorKind,
+) -> query_engine_metadata::metadata::OperatorKind {
+    match operator_kind {
+        metadata::OperatorKind::Equal => query_engine_metadata::metadata::OperatorKind::Equal,
+        metadata::OperatorKind::In => query_engine_metadata::metadata::OperatorKind::In,
+        metadata::OperatorKind::Custom => query_engine_metadata::metadata::OperatorKind::Custom,
+    }
+}
+
+fn convert_composite_types(
+    composite_types: metadata::CompositeTypes,
+) -> query_engine_metadata::metadata::CompositeTypes {
+    query_engine_metadata::metadata::CompositeTypes(
+        composite_types
+            .0
+            .into_iter()
+            .map(|(k, composite_type)| {
+                (
+                    query_engine_metadata::metadata::CompositeTypeName(k),
+                    convert_composite_type(composite_type),
+                )
+            })
+            .collect(),
+    )
+}
+
+fn convert_composite_type(
+    composite_type: metadata::CompositeType,
+) -> query_engine_metadata::metadata::CompositeType {
+    query_engine_metadata::metadata::CompositeType {
+        name: composite_type.name,
+        schema_name: None, // Version3 does not capture the schema of a composite type
+        fields: composite_type
+            .fields
+            .into_iter()
+            .map(|(k, field)| (k, convert_composite_type_field_info(field)))
+            .collect(),
+        description: composite_type.description,
+    }
+}
+
+fn convert_composite_type_field_info(
+    field: metadata::FieldInfo,
+) -> query_engine_metadata::metadata::FieldInfo {
+    query_engine_metadata::metadata::FieldInfo {
+        name: field.name,
+        r#type: convert_type(field.r#type),
+        description: field.description,
+    }
+}
+
+pub fn convert_tables(tables: metadata::TablesInfo) -> query_engine_metadata::metadata::TablesInfo {
+    query_engine_metadata::metadata::TablesInfo(
+        tables
+            .0
+            .into_iter()
+            .map(|(k, table_info)| (k, convert_table_info(table_info)))
+            .collect(),
+    )
+}
+
+fn convert_table_info(
+    table_info: metadata::TableInfo,
+) -> query_engine_metadata::metadata::TableInfo {
+    query_engine_metadata::metadata::TableInfo {
+        schema_name: table_info.schema_name,
+        table_name: table_info.table_name,
+        columns: table_info
+            .columns
+            .into_iter()
+            .map(|(k, column_info)| (k, convert_column_info(column_info)))
+            .collect(),
+        uniqueness_constraints: convert_uniqueness_constraints(table_info.uniqueness_constraints),
+        foreign_relations: convert_foreign_relations(table_info.foreign_relations),
+        description: table_info.description,
+    }
+}
+
+fn convert_foreign_relations(
+    foreign_relations: metadata::ForeignRelations,
+) -> query_engine_metadata::metadata::ForeignRelations {
+    query_engine_metadata::metadata::ForeignRelations(
+        foreign_relations
+            .0
+            .into_iter()
+            .map(|(k, foreign_relation)| (k, convert_foreign_relation(foreign_relation)))
+            .collect(),
+    )
+}
+
+fn convert_foreign_relation(
+    foreign_relation: metadata::ForeignRelation,
+) -> query_engine_metadata::metadata::ForeignRelation {
+    query_engine_metadata::metadata::ForeignRelation {
+        foreign_schema: foreign_relation.foreign_schema,
+        foreign_table: foreign_relation.foreign_table,
+        column_mapping: foreign_relation.column_mapping,
+    }
+}
+
+fn convert_uniqueness_constraints(
+    uniqueness_constraints: metadata::UniquenessConstraints,
+) -> query_engine_metadata::metadata::UniquenessConstraints {
+    query_engine_metadata::metadata::UniquenessConstraints(
+        uniqueness_constraints
+            .0
+            .into_iter()
+            .map(|(k, uniqueness_constraint)| {
+                (k, convert_uniqueness_constraint(uniqueness_constraint))
+            })
+            .collect(),
+    )
+}
+
+fn convert_uniqueness_constraint(
+    uniqueness_constraint: metadata::UniquenessConstraint,
+) -> query_engine_metadata::metadata::UniquenessConstraint {
+    query_engine_metadata::metadata::UniquenessConstraint(uniqueness_constraint.0)
+}
+
+fn convert_column_info(
+    column_info: metadata::ColumnInfo,
+) -> query_engine_metadata::metadata::ColumnInfo {
+    query_engine_metadata::metadata::ColumnInfo {
+        name: column_info.name,
+        r#type: convert_type(column_info.r#type),
+        nullable: convert_nullable(&column_info.nullable),
+        has_default: convert_has_default(&column_info.has_default),
+        is_identity: convert_is_identity(&column_info.is_identity),
+        is_generated: convert_is_generated(&column_info.is_generated),
+        description: column_info.description,
+    }
+}
+
+fn convert_is_generated(
+    is_generated: &metadata::IsGenerated,
+) -> query_engine_metadata::metadata::IsGenerated {
+    match is_generated {
+        metadata::IsGenerated::NotGenerated => {
+            query_engine_metadata::metadata::IsGenerated::NotGenerated
+        }
+        metadata::IsGenerated::Stored => query_engine_metadata::metadata::IsGenerated::Stored,
+    }
+}
+
+fn convert_is_identity(
+    is_identity: &metadata::IsIdentity,
+) -> query_engine_metadata::metadata::IsIdentity {
+    match is_identity {
+        metadata::IsIdentity::NotIdentity => {
+            query_engine_metadata::metadata::IsIdentity::NotIdentity
+        }
+        metadata::IsIdentity::IdentityByDefault => {
+            query_engine_metadata::metadata::IsIdentity::IdentityByDefault
+        }
+        metadata::IsIdentity::IdentityAlways => {
+            query_engine_metadata::metadata::IsIdentity::IdentityAlways
+        }
+    }
+}
+
+fn convert_has_default(
+    has_default: &metadata::HasDefault,
+) -> query_engine_metadata::metadata::HasDefault {
+    match has_default {
+        metadata::HasDefault::NoDefault => query_engine_metadata::metadata::HasDefault::NoDefault,
+        metadata::HasDefault::HasDefault => query_engine_metadata::metadata::HasDefault::HasDefault,
+    }
+}
+
+fn convert_mutations_version(
+    mutations_version_opt: Option<metadata::mutations::MutationsVersion>,
+) -> Option<query_engine_metadata::metadata::mutations::MutationsVersion> {
+    mutations_version_opt.map(|mutations_version| match mutations_version {
+        metadata::mutations::MutationsVersion::V1 => {
+            query_engine_metadata::metadata::mutations::MutationsVersion::V1
+        }
+        metadata::mutations::MutationsVersion::VeryExperimentalWip => {
+            query_engine_metadata::metadata::mutations::MutationsVersion::VeryExperimentalWip
+        }
+    })
+}

--- a/crates/configuration/src/version4/mod.rs
+++ b/crates/configuration/src/version4/mod.rs
@@ -6,9 +6,10 @@ mod metadata;
 mod options;
 
 use std::borrow::Cow;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+use query_engine_metadata;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgConnection;
@@ -22,7 +23,7 @@ use crate::environment::Environment;
 use crate::error::Error;
 use crate::values::{ConnectionUri, Secret};
 
-const CONFIGURATION_QUERY: &str = include_str!("version3.sql");
+const CONFIGURATION_QUERY: &str = include_str!("introspection.sql");
 
 /// Initial configuration, just enough to connect to a database and elaborate a full
 /// 'Configuration'.
@@ -107,387 +108,300 @@ pub async fn introspect(
                 .introspection_options
                 .introspect_prefix_function_comparison_operators,
         )
-        .bind(serde_json::to_value(
-            base_type_representations(args.metadata.type_representations).0,
-        )?);
+        .bind(serde_json::to_value(base_type_representations())?);
 
     let row = connection
         .fetch_one(query)
         .instrument(info_span!("Run introspection query"))
         .await?;
 
-    let (tables, aggregate_functions, comparison_operators, composite_types, type_representations) = async {
+    let (tables, scalar_types, composite_types) = async {
         let tables: metadata::TablesInfo = serde_json::from_value(row.get(0))?;
+        let scalar_types: metadata::ScalarTypes = serde_json::from_value(row.get(1))?;
+        let composite_types: metadata::CompositeTypes = serde_json::from_value(row.get(2))?;
 
-        let aggregate_functions: metadata::AggregateFunctions = serde_json::from_value(row.get(1))?;
-
-        let metadata::ComparisonOperators(mut comparison_operators): metadata::ComparisonOperators =
-            serde_json::from_value(row.get(2))?;
-
-        let composite_types: metadata::CompositeTypes = serde_json::from_value(row.get(3))?;
-
-        let type_representations: metadata::TypeRepresentations =
-            serde_json::from_value(row.get(4))?;
-
+        // TODO!
         // We need to include `in` as a comparison operator in the schema, and since it is syntax, it is not introspectable.
         // Instead, we will check if the scalar type defines an equals operator and if yes, we will insert the `_in` operator
         // as well.
-        for (scalar_type, operators) in &mut comparison_operators {
-            if operators
-                .values()
-                .any(|op| op.operator_kind == metadata::OperatorKind::Equal)
-            {
-                operators.insert(
-                    "_in".to_string(),
-                    metadata::ComparisonOperator {
-                        operator_name: "IN".to_string(),
-                        operator_kind: metadata::OperatorKind::In,
-                        argument_type: scalar_type.clone(),
-                        is_infix: true,
-                    },
-                );
-            }
-        }
+        // for (scalar_type, operators) in &mut comparison_operators {
+        //     if operators
+        //         .values()
+        //         .any(|op| op.operator_kind == metadata::OperatorKind::Equal)
+        //     {
+        //         operators.insert(
+        //             "_in".to_string(),
+        //             metadata::ComparisonOperator {
+        //                 operator_name: "IN".to_string(),
+        //                 operator_kind: metadata::OperatorKind::In,
+        //                 argument_type: scalar_type.clone(),
+        //                 is_infix: true,
+        //             },
+        //         );
+        //     }
+        // }
 
         // We need to specify the concrete return type explicitly so that rustc knows that it can
         // be sent across an async boundary.
         // (last verified with rustc 1.72.1)
-        Ok::<_, anyhow::Error>((
-            tables,
-            aggregate_functions,
-            metadata::ComparisonOperators(comparison_operators),
-            composite_types,
-            type_representations,
-        ))
+        Ok::<_, anyhow::Error>((tables, scalar_types, composite_types))
     }
     .instrument(info_span!("Decode introspection result"))
     .await?;
 
-    let (scalar_types, composite_types) = transitively_occurring_types(
-        occurring_scalar_types(
-            &tables,
-            &args.metadata.native_queries,
-            &args.metadata.aggregate_functions,
-        ),
-        &occurring_composite_types(&tables, &args.metadata.native_queries),
-        composite_types,
-    );
-
-    // We filter our comparison operators and aggregate functions to only include those relevant to
-    // types that may actually occur in the schema.
-    let relevant_comparison_operators =
-        filter_comparison_operators(&scalar_types, comparison_operators);
-    let relevant_aggregate_functions =
-        filter_aggregate_functions(&scalar_types, aggregate_functions);
-    let relevant_type_representations =
-        filter_type_representations(&scalar_types, type_representations);
-
+    // TODO: Only have occurring types. Maybe do this in SQL instead?
+    // let (scalar_types, composite_types) = transitively_occurring_types(
+    //     occurring_scalar_types(
+    //         &tables,
+    //         &args.metadata.native_queries,
+    //         &args.metadata.aggregate_functions,
+    //     ),
+    //     &occurring_composite_types(&tables, &args.metadata.native_queries),
+    //     composite_types,
+    // );
+    //
     Ok(RawConfiguration {
         schema: args.schema,
         connection_settings: args.connection_settings,
         metadata: metadata::Metadata {
             tables,
-            native_queries: args.metadata.native_queries,
-            aggregate_functions: relevant_aggregate_functions,
-            comparison_operators: relevant_comparison_operators,
+            scalar_types,
             composite_types,
-            type_representations: relevant_type_representations,
+            native_queries: args.metadata.native_queries,
         },
         introspection_options: args.introspection_options,
         mutations_version: args.mutations_version,
     })
 }
 
-/// Merge the type representations currenting defined in the user's configuration with
-/// our base defaults. User configuration takes precedence.
-fn base_type_representations(
-    database::TypeRepresentations(existing_type_representations): database::TypeRepresentations,
-) -> database::TypeRepresentations {
-    // Start with the default type representations
-    let mut type_representations: database::TypeRepresentations = database::TypeRepresentations(
-        [
-            // Bit strings:
-            //   https://www.postgresql.org/docs/current/datatype-bit.html
-            //   https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-BIT-STRINGS
-            //
-            // We hint these to String, meaning a sequence of '0' and '1' chars, but more choices are
-            // possible.
-            (
-                database::ScalarType("bit".to_string()),
-                database::TypeRepresentation::String,
-            ),
-            (
-                database::ScalarType("bool".to_string()),
-                database::TypeRepresentation::Boolean,
-            ),
-            (
-                database::ScalarType("bpchar".to_string()),
-                database::TypeRepresentation::String,
-            ),
-            (
-                database::ScalarType("char".to_string()),
-                database::TypeRepresentation::String,
-            ),
-            (
-                database::ScalarType("date".to_string()),
-                database::TypeRepresentation::Date,
-            ),
-            (
-                database::ScalarType("float4".to_string()),
-                database::TypeRepresentation::Float32,
-            ),
-            (
-                database::ScalarType("float8".to_string()),
-                database::TypeRepresentation::Float64,
-            ),
-            (
-                database::ScalarType("int2".to_string()),
-                database::TypeRepresentation::Int16,
-            ),
-            (
-                database::ScalarType("int4".to_string()),
-                database::TypeRepresentation::Int32,
-            ),
-            (
-                database::ScalarType("int8".to_string()),
-                // ndc-spec defines that Int64 has the json representation of a string.
-                // This is not what we do now and is a breaking change.
-                // This will need to be changed in the future. In the meantime, we report
-                // The type representation to be json.
-                database::TypeRepresentation::Int64AsString,
-            ),
-            (
-                database::ScalarType("numeric".to_string()),
-                database::TypeRepresentation::BigDecimalAsString,
-            ),
-            (
-                database::ScalarType("text".to_string()),
-                database::TypeRepresentation::String,
-            ),
-            (
-                database::ScalarType("time".to_string()),
-                database::TypeRepresentation::Time,
-            ),
-            (
-                database::ScalarType("timestamp".to_string()),
-                database::TypeRepresentation::Timestamp,
-            ),
-            (
-                database::ScalarType("timestamptz".to_string()),
-                database::TypeRepresentation::Timestamptz,
-            ),
-            (
-                database::ScalarType("timetz".to_string()),
-                database::TypeRepresentation::Timetz,
-            ),
-            (
-                database::ScalarType("uuid".to_string()),
-                database::TypeRepresentation::UUID,
-            ),
-            (
-                database::ScalarType("varchar".to_string()),
-                database::TypeRepresentation::String,
-            ),
-        ]
-        .into(),
-    );
-    // If the user already has existing type representations defined,
-    // override the default ones using `insert`.
-    // We do this to not change the behaviour for the user on update.
-    for (typ, type_rep) in existing_type_representations {
-        match type_rep {
-            // we don't want to do this for enums as they should be overwritten according to the database.
-            database::TypeRepresentation::Enum(_) => {}
-            _ => {
-                type_representations.0.insert(typ, type_rep);
-            }
-        }
-    }
-    type_representations
+fn base_type_representations() -> BTreeMap<String, database::TypeRepresentation> {
+    [
+        // Bit strings:
+        //   https://www.postgresql.org/docs/current/datatype-bit.html
+        //   https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-BIT-STRINGS
+        //
+        // We hint these to String, meaning a sequence of '0' and '1' chars, but more choices are
+        // possible.
+        ("bit".to_string(), database::TypeRepresentation::String),
+        ("bool".to_string(), database::TypeRepresentation::Boolean),
+        ("bpchar".to_string(), database::TypeRepresentation::String),
+        ("char".to_string(), database::TypeRepresentation::String),
+        ("date".to_string(), database::TypeRepresentation::Date),
+        ("float4".to_string(), database::TypeRepresentation::Float32),
+        ("float8".to_string(), database::TypeRepresentation::Float64),
+        ("int2".to_string(), database::TypeRepresentation::Int16),
+        ("int4".to_string(), database::TypeRepresentation::Int32),
+        (
+            "int8".to_string(),
+            // ndc-spec defines that Int64 has the json representation of a string.
+            // This is not what we do now and is a breaking change.
+            // This will need to be changed in the future. In the meantime, we report
+            // The type representation to be json.
+            database::TypeRepresentation::Int64AsString,
+        ),
+        (
+            "numeric".to_string(),
+            database::TypeRepresentation::BigDecimalAsString,
+        ),
+        ("text".to_string(), database::TypeRepresentation::String),
+        ("time".to_string(), database::TypeRepresentation::Time),
+        (
+            "timestamp".to_string(),
+            database::TypeRepresentation::Timestamp,
+        ),
+        (
+            "timestamptz".to_string(),
+            database::TypeRepresentation::Timestamptz,
+        ),
+        ("timetz".to_string(), database::TypeRepresentation::Timetz),
+        ("uuid".to_string(), database::TypeRepresentation::UUID),
+        ("varchar".to_string(), database::TypeRepresentation::String),
+    ]
+    .into()
 }
 
-/// Collect all the composite types that can occur in the metadata.
-pub fn occurring_composite_types(
-    tables: &metadata::TablesInfo,
-    native_queries: &metadata::NativeQueries,
-) -> BTreeSet<String> {
-    let tables_column_types = tables
-        .0
-        .values()
-        .flat_map(|v| v.columns.values().map(|c| &c.r#type));
-    let native_queries_column_types = native_queries
-        .0
-        .values()
-        .flat_map(|v| v.columns.values().map(|c| &c.r#type));
-    let native_queries_arguments_types = native_queries
-        .0
-        .values()
-        .flat_map(|v| v.arguments.values().map(|c| &c.r#type));
-
-    tables_column_types
-        .chain(native_queries_column_types)
-        .chain(native_queries_arguments_types)
-        .filter_map(|t| match t {
-            metadata::Type::CompositeType(ref t) => Some(t.clone()),
-            metadata::Type::ArrayType(t) => match **t {
-                metadata::Type::CompositeType(ref t) => Some(t.clone()),
-                metadata::Type::ArrayType(_) | metadata::Type::ScalarType(_) => None,
-            },
-            metadata::Type::ScalarType(_) => None,
-        })
-        .collect::<BTreeSet<String>>()
-}
+// /// Collect all the composite types that can occur in the metadata.
+// pub fn occurring_composite_types(
+//     tables: &metadata::TablesInfo,
+//     native_queries: &metadata::NativeQueries,
+// ) -> BTreeSet<String> {
+//     let tables_column_types = tables
+//         .0
+//         .values()
+//         .flat_map(|v| v.columns.values().map(|c| &c.r#type));
+//     let native_queries_column_types = native_queries
+//         .0
+//         .values()
+//         .flat_map(|v| v.columns.values().map(|c| &c.r#type));
+//     let native_queries_arguments_types = native_queries
+//         .0
+//         .values()
+//         .flat_map(|v| v.arguments.values().map(|c| &c.r#type));
+//
+//     tables_column_types
+//         .chain(native_queries_column_types)
+//         .chain(native_queries_arguments_types)
+//         .filter_map(|t| match t {
+//             metadata::Type::CompositeType(ref t) => Some(t.clone()),
+//             metadata::Type::ArrayType(t) => match **t {
+//                 metadata::Type::CompositeType(ref t) => Some(t.clone()),
+//                 metadata::Type::ArrayType(_) | metadata::Type::ScalarType(_) => None,
+//             },
+//             metadata::Type::ScalarType(_) => None,
+//         })
+//         .collect::<BTreeSet<String>>()
+// }
 
 // Since array types and composite types may refer to other types we have to transitively discover
 // the full set of types that are relevant to the schema.
-pub fn transitively_occurring_types(
-    mut occurring_scalar_types: BTreeSet<metadata::ScalarType>,
-    occurring_type_names: &BTreeSet<String>,
-    mut composite_types: metadata::CompositeTypes,
-) -> (BTreeSet<metadata::ScalarType>, metadata::CompositeTypes) {
-    let mut discovered_type_names = occurring_type_names.clone();
+// pub fn transitively_occurring_types(
+//     mut occurring_scalar_types: BTreeSet<metadata::ScalarType>,
+//     occurring_type_names: &BTreeSet<String>,
+//     mut composite_types: metadata::CompositeTypes,
+// ) -> (BTreeSet<metadata::ScalarType>, metadata::CompositeTypes) {
+//     let mut discovered_type_names = occurring_type_names.clone();
+//
+//     for t in occurring_type_names {
+//         match composite_types.0.get(t) {
+//             None => (),
+//             Some(ct) => {
+//                 for f in ct.fields.values() {
+//                     match &f.r#type {
+//                         metadata::Type::CompositeType(ct2) => {
+//                             discovered_type_names.insert(ct2.to_string());
+//                         }
+//                         metadata::Type::ScalarType(t) => {
+//                             occurring_scalar_types.insert(t.clone());
+//                         }
+//                         metadata::Type::ArrayType(arr_ty) => match **arr_ty {
+//                             metadata::Type::CompositeType(ref ct2) => {
+//                                 discovered_type_names.insert(ct2.to_string());
+//                             }
+//                             metadata::Type::ScalarType(ref t) => {
+//                                 occurring_scalar_types.insert(t.clone());
+//                             }
+//                             metadata::Type::ArrayType(_) => {
+//                                 // This case is impossible, because we do not support nested arrays
+//                             }
+//                         },
+//                     }
+//                 }
+//             }
+//         }
+//     }
+//
+//     // Since 'discovered_type_names' only grows monotonically starting from 'occurring_type_names'
+//     // we just have to compare the number of elements to know if new types have been discovered.
+//     if discovered_type_names.len() == occurring_type_names.len() {
+//         // Iterating over occurring types discovered no new types
+//         composite_types
+//             .0
+//             .retain(|t, _| occurring_type_names.contains(t));
+//         (occurring_scalar_types, composite_types)
+//     } else {
+//         // Iterating over occurring types did discover new types,
+//         // so we keep on going.
+//         transitively_occurring_types(
+//             occurring_scalar_types,
+//             &discovered_type_names,
+//             composite_types,
+//         )
+//     }
+// }
 
-    for t in occurring_type_names {
-        match composite_types.0.get(t) {
-            None => (),
-            Some(ct) => {
-                for f in ct.fields.values() {
-                    match &f.r#type {
-                        metadata::Type::CompositeType(ct2) => {
-                            discovered_type_names.insert(ct2.to_string());
-                        }
-                        metadata::Type::ScalarType(t) => {
-                            occurring_scalar_types.insert(t.clone());
-                        }
-                        metadata::Type::ArrayType(arr_ty) => match **arr_ty {
-                            metadata::Type::CompositeType(ref ct2) => {
-                                discovered_type_names.insert(ct2.to_string());
-                            }
-                            metadata::Type::ScalarType(ref t) => {
-                                occurring_scalar_types.insert(t.clone());
-                            }
-                            metadata::Type::ArrayType(_) => {
-                                // This case is impossible, because we do not support nested arrays
-                            }
-                        },
-                    }
-                }
-            }
-        }
-    }
+// /// Collect all the scalar types that can occur in the metadata. This is a bit circumstantial. A better
+// /// approach is likely to record scalar type names directly in the metadata via version2.sql.
+// pub fn occurring_scalar_types(
+//     tables: &metadata::TablesInfo,
+//     native_queries: &metadata::NativeQueries,
+//     aggregate_functions: &metadata::AggregateFunctions,
+// ) -> BTreeSet<metadata::ScalarType> {
+//     let tables_column_types = tables
+//         .0
+//         .values()
+//         .flat_map(|v| v.columns.values().map(|c| &c.r#type));
+//     let native_queries_column_types = native_queries
+//         .0
+//         .values()
+//         .flat_map(|v| v.columns.values().map(|c| &c.r#type));
+//     let native_queries_arguments_types = native_queries
+//         .0
+//         .values()
+//         .flat_map(|v| v.arguments.values().map(|c| &c.r#type));
+//     let aggregate_functions_result_types = aggregate_functions
+//         .0
+//         .values()
+//         .flat_map(|x| x.values().map(|agg_fn| agg_fn.return_type.clone()));
+//
+//     tables_column_types
+//         .chain(native_queries_column_types)
+//         .chain(native_queries_arguments_types)
+//         .filter_map(|t| match t {
+//             metadata::Type::ScalarType(ref t) => Some(t.clone()), // only keep scalar types
+//             metadata::Type::ArrayType(_) | metadata::Type::CompositeType(_) => None,
+//         })
+//         .chain(aggregate_functions_result_types)
+//         .collect::<BTreeSet<metadata::ScalarType>>()
+// }
 
-    // Since 'discovered_type_names' only grows monotonically starting from 'occurring_type_names'
-    // we just have to compare the number of elements to know if new types have been discovered.
-    if discovered_type_names.len() == occurring_type_names.len() {
-        // Iterating over occurring types discovered no new types
-        composite_types
-            .0
-            .retain(|t, _| occurring_type_names.contains(t));
-        (occurring_scalar_types, composite_types)
-    } else {
-        // Iterating over occurring types did discover new types,
-        // so we keep on going.
-        transitively_occurring_types(
-            occurring_scalar_types,
-            &discovered_type_names,
-            composite_types,
-        )
-    }
-}
+// /// Filter predicate for comparison operators. Preserves only comparison operators that are
+// /// relevant to any of the given scalar types.
+// ///
+// /// This function is public to enable use in later versions that retain the same metadata types.
+// fn filter_comparison_operators(
+//     scalar_types: &BTreeSet<metadata::ScalarType>,
+//     comparison_operators: metadata::ComparisonOperators,
+// ) -> metadata::ComparisonOperators {
+//     metadata::ComparisonOperators(
+//         comparison_operators
+//             .0
+//             .into_iter()
+//             .filter(|(typ, _)| scalar_types.contains(typ))
+//             .map(|(typ, ops)| {
+//                 (
+//                     typ,
+//                     ops.into_iter()
+//                         .filter(|(_, op)| scalar_types.contains(&op.argument_type))
+//                         .collect(),
+//                 )
+//             })
+//             .collect(),
+//     )
+// }
 
-/// Collect all the scalar types that can occur in the metadata. This is a bit circumstantial. A better
-/// approach is likely to record scalar type names directly in the metadata via version2.sql.
-pub fn occurring_scalar_types(
-    tables: &metadata::TablesInfo,
-    native_queries: &metadata::NativeQueries,
-    aggregate_functions: &metadata::AggregateFunctions,
-) -> BTreeSet<metadata::ScalarType> {
-    let tables_column_types = tables
-        .0
-        .values()
-        .flat_map(|v| v.columns.values().map(|c| &c.r#type));
-    let native_queries_column_types = native_queries
-        .0
-        .values()
-        .flat_map(|v| v.columns.values().map(|c| &c.r#type));
-    let native_queries_arguments_types = native_queries
-        .0
-        .values()
-        .flat_map(|v| v.arguments.values().map(|c| &c.r#type));
-    let aggregate_functions_result_types = aggregate_functions
-        .0
-        .values()
-        .flat_map(|x| x.values().map(|agg_fn| agg_fn.return_type.clone()));
+// /// Filter predicate for aggregation functions. Preserves only aggregation functions that are
+// /// relevant to any of the given scalar types.
+// ///
+// /// This function is public to enable use in later versions that retain the same metadata types.
+// fn filter_aggregate_functions(
+//     scalar_types: &BTreeSet<metadata::ScalarType>,
+//     aggregate_functions: metadata::AggregateFunctions,
+// ) -> metadata::AggregateFunctions {
+//     metadata::AggregateFunctions(
+//         aggregate_functions
+//             .0
+//             .into_iter()
+//             .filter(|(typ, _)| scalar_types.contains(typ))
+//             .collect(),
+//     )
+// }
 
-    tables_column_types
-        .chain(native_queries_column_types)
-        .chain(native_queries_arguments_types)
-        .filter_map(|t| match t {
-            metadata::Type::ScalarType(ref t) => Some(t.clone()), // only keep scalar types
-            metadata::Type::ArrayType(_) | metadata::Type::CompositeType(_) => None,
-        })
-        .chain(aggregate_functions_result_types)
-        .collect::<BTreeSet<metadata::ScalarType>>()
-}
-
-/// Filter predicate for comparison operators. Preserves only comparison operators that are
-/// relevant to any of the given scalar types.
-///
-/// This function is public to enable use in later versions that retain the same metadata types.
-fn filter_comparison_operators(
-    scalar_types: &BTreeSet<metadata::ScalarType>,
-    comparison_operators: metadata::ComparisonOperators,
-) -> metadata::ComparisonOperators {
-    metadata::ComparisonOperators(
-        comparison_operators
-            .0
-            .into_iter()
-            .filter(|(typ, _)| scalar_types.contains(typ))
-            .map(|(typ, ops)| {
-                (
-                    typ,
-                    ops.into_iter()
-                        .filter(|(_, op)| scalar_types.contains(&op.argument_type))
-                        .collect(),
-                )
-            })
-            .collect(),
-    )
-}
-
-/// Filter predicate for aggregation functions. Preserves only aggregation functions that are
-/// relevant to any of the given scalar types.
-///
-/// This function is public to enable use in later versions that retain the same metadata types.
-fn filter_aggregate_functions(
-    scalar_types: &BTreeSet<metadata::ScalarType>,
-    aggregate_functions: metadata::AggregateFunctions,
-) -> metadata::AggregateFunctions {
-    metadata::AggregateFunctions(
-        aggregate_functions
-            .0
-            .into_iter()
-            .filter(|(typ, _)| scalar_types.contains(typ))
-            .collect(),
-    )
-}
-
-/// Filter predicate for type representations. Preserves only type representations that are
-/// relevant to any of the given scalar types.
-///
-/// This function is public to enable use in later versions that retain the same metadata types.
-fn filter_type_representations(
-    scalar_types: &BTreeSet<metadata::ScalarType>,
-    type_representations: metadata::TypeRepresentations,
-) -> metadata::TypeRepresentations {
-    metadata::TypeRepresentations(
-        type_representations
-            .0
-            .into_iter()
-            .filter(|(typ, _)| scalar_types.contains(typ))
-            .collect(),
-    )
-}
+// /// Filter predicate for type representations. Preserves only type representations that are
+// /// relevant to any of the given scalar types.
+// ///
+// /// This function is public to enable use in later versions that retain the same metadata types.
+// fn filter_type_representations(
+//     scalar_types: &BTreeSet<metadata::ScalarType>,
+//     type_representations: metadata::TypeRepresentations,
+// ) -> metadata::TypeRepresentations {
+//     metadata::TypeRepresentations(
+//         type_representations
+//             .0
+//             .into_iter()
+//             .filter(|(typ, _)| scalar_types.contains(typ))
+//             .collect(),
+//     )
+// }
 
 pub async fn parse_configuration(
     configuration_dir: impl AsRef<Path>,
@@ -541,71 +455,55 @@ pub async fn parse_configuration(
 
 // This function is used by tests as well
 pub fn convert_metadata(metadata: metadata::Metadata) -> query_engine_metadata::metadata::Metadata {
-    let (scalar_types, composite_types) = transitively_occurring_types(
-        occurring_scalar_types(
-            &metadata.tables,
-            &metadata.native_queries,
-            &metadata.aggregate_functions,
-        ),
-        &occurring_composite_types(&metadata.tables, &metadata.native_queries),
-        metadata.composite_types,
-    );
-
+    // let (scalar_types, composite_types) = transitively_occurring_types(
+    //     occurring_scalar_types(
+    //         &metadata.tables,
+    //         &metadata.native_queries,
+    //         &metadata.aggregate_functions,
+    //     ),
+    //     &occurring_composite_types(&metadata.tables, &metadata.native_queries),
+    //     metadata.composite_types,
+    // );
+    //
     query_engine_metadata::metadata::Metadata {
         tables: convert_tables(metadata.tables),
-        composite_types: convert_composite_types(composite_types),
+        composite_types: convert_composite_types(metadata.composite_types),
         native_queries: convert_native_queries(metadata.native_queries),
-        scalar_types: convert_scalar_types(
-            scalar_types,
-            metadata.aggregate_functions,
-            metadata.comparison_operators,
-            metadata.type_representations,
-        ),
+        scalar_types: convert_scalar_types(metadata.scalar_types),
     }
 }
 
 fn convert_scalar_types(
-    scalar_types: BTreeSet<metadata::ScalarType>,
-    aggregate_functions: metadata::AggregateFunctions,
-    comparison_operators: metadata::ComparisonOperators,
-    type_representations: metadata::TypeRepresentations,
+    scalar_types: metadata::ScalarTypes,
 ) -> query_engine_metadata::metadata::ScalarTypes {
-    let aggregates = convert_aggregate_functions(aggregate_functions);
-    let comparisons = convert_comparison_operators(comparison_operators);
-    let representations = convert_type_representations(type_representations);
+    // let aggregates = convert_aggregate_functions(aggregate_functions);
+    // let comparisons = convert_comparison_operators(comparison_operators);
+    // let representations = convert_type_representations(type_representations);
 
     query_engine_metadata::metadata::ScalarTypes(
         scalar_types
+            .0
             .into_iter()
-            .map(|t| {
+            .map(|(scalar_type_name, scalar_type)| {
                 (
-                    convert_scalar_type(t.clone()),
+                    convert_scalar_type_name(scalar_type_name.clone()),
                     query_engine_metadata::metadata::ScalarType {
-                        name: t.0.clone(),
-                        schema_name: None, // Version 3 does not capture the schema of scalar
-                        // types.
-                        description: None,
-                        aggregate_functions: aggregates
-                            .0
-                            .get(&query_engine_metadata::metadata::ScalarTypeName(
-                                t.0.clone(),
-                            ))
-                            .cloned()
-                            .unwrap_or(BTreeMap::new()),
-                        comparison_operators: comparisons
-                            .0
-                            .get(&query_engine_metadata::metadata::ScalarTypeName(
-                                t.0.clone(),
-                            ))
-                            .cloned()
-                            .unwrap_or(BTreeMap::new()),
-
-                        type_representation: representations
-                            .0
-                            .get(&query_engine_metadata::metadata::ScalarTypeName(
-                                t.0.clone(),
-                            ))
-                            .cloned(),
+                        type_name: scalar_type.type_name,
+                        schema_name: Some(scalar_type.schema_name),
+                        description: scalar_type.description,
+                        aggregate_functions: scalar_type
+                            .aggregate_functions
+                            .into_iter()
+                            .map(|(k, v)| (k, convert_aggregate_function(v)))
+                            .collect(),
+                        comparison_operators: scalar_type
+                            .comparison_operators
+                            .into_iter()
+                            .map(|(k, v)| (k, convert_comparison_operator(v)))
+                            .collect(),
+                        type_representation: scalar_type
+                            .type_representation
+                            .map(convert_type_representation),
                     },
                 )
             })
@@ -613,36 +511,17 @@ fn convert_scalar_types(
     )
 }
 
-fn convert_scalar_type(
-    scalar_type: metadata::ScalarType,
+fn convert_scalar_type_name(
+    scalar_type_name: metadata::ScalarTypeName,
 ) -> query_engine_metadata::metadata::ScalarTypeName {
-    query_engine_metadata::metadata::ScalarTypeName(scalar_type.0)
-}
-
-fn convert_aggregate_functions(
-    aggregate_functions: metadata::AggregateFunctions,
-) -> query_engine_metadata::metadata::AggregateFunctions {
-    let res = aggregate_functions
-        .0
-        .into_iter()
-        .map(|(k, v)| {
-            (
-                convert_scalar_type(k),
-                v.into_iter()
-                    .map(|(k, v)| (k, convert_aggregate_function(v)))
-                    .collect(),
-            )
-        })
-        .collect();
-
-    query_engine_metadata::metadata::AggregateFunctions(res)
+    query_engine_metadata::metadata::ScalarTypeName(scalar_type_name.0)
 }
 
 fn convert_aggregate_function(
     aggregate_function: metadata::AggregateFunction,
 ) -> query_engine_metadata::metadata::AggregateFunction {
     query_engine_metadata::metadata::AggregateFunction {
-        return_type: convert_scalar_type(aggregate_function.return_type),
+        return_type: convert_scalar_type_name(aggregate_function.return_type),
     }
 }
 
@@ -699,10 +578,10 @@ fn convert_nullable(nullable: &metadata::Nullable) -> query_engine_metadata::met
 fn convert_type(r#type: metadata::Type) -> query_engine_metadata::metadata::Type {
     match r#type {
         metadata::Type::ScalarType(t) => {
-            query_engine_metadata::metadata::Type::ScalarType(convert_scalar_type(t))
+            query_engine_metadata::metadata::Type::ScalarType(convert_scalar_type_name(t))
         }
         metadata::Type::CompositeType(t) => query_engine_metadata::metadata::Type::CompositeType(
-            query_engine_metadata::metadata::CompositeTypeName(t),
+            query_engine_metadata::metadata::CompositeTypeName(t.0),
         ),
         metadata::Type::ArrayType(t) => {
             query_engine_metadata::metadata::Type::ArrayType(Box::new(convert_type(*t)))
@@ -790,23 +669,6 @@ fn convert_native_query_part(
     }
 }
 
-fn convert_type_representations(
-    type_representations: metadata::TypeRepresentations,
-) -> query_engine_metadata::metadata::TypeRepresentations {
-    query_engine_metadata::metadata::TypeRepresentations(
-        type_representations
-            .0
-            .into_iter()
-            .map(|(k, type_representation)| {
-                (
-                    convert_scalar_type(k),
-                    convert_type_representation(type_representation),
-                )
-            })
-            .collect(),
-    )
-}
-
 fn convert_type_representation(
     type_representation: metadata::TypeRepresentation,
 ) -> query_engine_metadata::metadata::TypeRepresentation {
@@ -877,34 +739,13 @@ fn convert_type_representation(
     }
 }
 
-fn convert_comparison_operators(
-    comparison_operators: metadata::ComparisonOperators,
-) -> query_engine_metadata::metadata::ComparisonOperators {
-    query_engine_metadata::metadata::ComparisonOperators(
-        comparison_operators
-            .0
-            .into_iter()
-            .map(|(k, v)| {
-                (
-                    convert_scalar_type(k),
-                    v.into_iter()
-                        .map(|(k, comparison_operator)| {
-                            (k, convert_comparison_operator(comparison_operator))
-                        })
-                        .collect(),
-                )
-            })
-            .collect(),
-    )
-}
-
 fn convert_comparison_operator(
     comparison_operator: metadata::ComparisonOperator,
 ) -> query_engine_metadata::metadata::ComparisonOperator {
     query_engine_metadata::metadata::ComparisonOperator {
         operator_name: comparison_operator.operator_name,
         operator_kind: convert_operator_kind(&comparison_operator.operator_kind),
-        argument_type: convert_scalar_type(comparison_operator.argument_type),
+        argument_type: convert_scalar_type_name(comparison_operator.argument_type),
         is_infix: comparison_operator.is_infix,
     }
 }
@@ -940,8 +781,8 @@ fn convert_composite_type(
     composite_type: metadata::CompositeType,
 ) -> query_engine_metadata::metadata::CompositeType {
     query_engine_metadata::metadata::CompositeType {
-        name: composite_type.name,
-        schema_name: None, // Version3 does not capture the schema of a composite type
+        type_name: composite_type.type_name,
+        schema_name: Some(composite_type.schema_name),
         fields: composite_type
             .fields
             .into_iter()
@@ -955,7 +796,7 @@ fn convert_composite_type_field_info(
     field: metadata::FieldInfo,
 ) -> query_engine_metadata::metadata::FieldInfo {
     query_engine_metadata::metadata::FieldInfo {
-        name: field.name,
+        field_name: field.field_name,
         r#type: convert_type(field.r#type),
         description: field.description,
     }

--- a/crates/configuration/src/version4/options.rs
+++ b/crates/configuration/src/version4/options.rs
@@ -1,0 +1,211 @@
+//! The part of the configuration that dictates how the rest is generated.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::comparison::ComparisonOperatorMapping;
+
+/// Options which only influence how the configuration is updated.
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct IntrospectionOptions {
+    /// Schemas which are excluded from introspection. The default setting will exclude the
+    /// internal schemas of Postgres, Citus, Cockroach, and the PostGIS extension.
+    #[serde(default = "default_excluded_schemas")]
+    pub excluded_schemas: Vec<String>,
+    /// The names of Tables and Views in these schemas will be returned unqualified.
+    /// The default setting will set the `public` schema as unqualified.
+    #[serde(default = "default_unqualified_schemas_for_tables")]
+    pub unqualified_schemas_for_tables: Vec<String>,
+    /// The types and procedures in these schemas will be returned unqualified.
+    #[serde(default = "default_unqualified_schemas_for_types_and_procedures")]
+    pub unqualified_schemas_for_types_and_procedures: Vec<String>,
+    /// The mapping of comparison operator names to apply when updating the configuration
+    #[serde(default = "ComparisonOperatorMapping::default_mappings")]
+    pub comparison_operator_mapping: Vec<ComparisonOperatorMapping>,
+    /// Which prefix functions (i.e., non-infix operators) to generate introspection metadata for.
+    ///
+    /// This list will accept any boolean-returning function taking two concrete scalar types as
+    /// arguments.
+    ///
+    /// The default includes comparisons for various build-in types as well as those of PostGIS.
+    #[serde(default = "default_introspect_prefix_function_comparison_operators")]
+    pub introspect_prefix_function_comparison_operators: Vec<String>,
+}
+
+impl Default for IntrospectionOptions {
+    fn default() -> IntrospectionOptions {
+        IntrospectionOptions {
+            excluded_schemas: default_excluded_schemas(),
+            unqualified_schemas_for_tables: default_unqualified_schemas_for_tables(),
+            unqualified_schemas_for_types_and_procedures:
+                default_unqualified_schemas_for_types_and_procedures(),
+            comparison_operator_mapping: ComparisonOperatorMapping::default_mappings(),
+            introspect_prefix_function_comparison_operators:
+                default_introspect_prefix_function_comparison_operators(),
+        }
+    }
+}
+
+fn default_excluded_schemas() -> Vec<String> {
+    vec![
+        // From Postgres itself
+        "information_schema".to_string(),
+        "pg_catalog".to_string(),
+        // From PostGIS
+        "tiger".to_string(),
+        // From CockroachDB
+        "crdb_internal".to_string(),
+        // From Citus
+        "columnar".to_string(),
+        "columnar_internal".to_string(),
+    ]
+}
+
+/// Collection names of tables in these schemas will be appear as unqualified.
+fn default_unqualified_schemas_for_tables() -> Vec<String> {
+    vec!["public".to_string()]
+}
+
+/// Types, operators and procedures from these schemas will appear unqualified in the configuration.
+fn default_unqualified_schemas_for_types_and_procedures() -> Vec<String> {
+    vec![
+        "public".to_string(),
+        "pg_catalog".to_string(),
+        "tiger".to_string(),
+        // Supabase PG instances define types in these schemas
+        "auth".to_string(),
+        "pgsodium".to_string(),
+    ]
+}
+
+fn default_introspect_prefix_function_comparison_operators() -> Vec<String> {
+    vec![
+        "box_above".to_string(),
+        "box_below".to_string(),
+        "box_contain".to_string(),
+        "box_contain_pt".to_string(),
+        "box_contained".to_string(),
+        "box_left".to_string(),
+        "box_overabove".to_string(),
+        "box_overbelow".to_string(),
+        "box_overlap".to_string(),
+        "box_overleft".to_string(),
+        "box_overright".to_string(),
+        "box_right".to_string(),
+        "box_same".to_string(),
+        "circle_above".to_string(),
+        "circle_below".to_string(),
+        "circle_contain".to_string(),
+        "circle_contain_pt".to_string(),
+        "circle_contained".to_string(),
+        "circle_left".to_string(),
+        "circle_overabove".to_string(),
+        "circle_overbelow".to_string(),
+        "circle_overlap".to_string(),
+        "circle_overleft".to_string(),
+        "circle_overright".to_string(),
+        "circle_right".to_string(),
+        "circle_same".to_string(),
+        "contains_2d".to_string(),
+        "equals".to_string(),
+        "geography_overlaps".to_string(),
+        "geometry_above".to_string(),
+        "geometry_below".to_string(),
+        "geometry_contained_3d".to_string(),
+        "geometry_contains".to_string(),
+        "geometry_contains_3d".to_string(),
+        "geometry_contains_nd".to_string(),
+        "geometry_left".to_string(),
+        "geometry_overabove".to_string(),
+        "geometry_overbelow".to_string(),
+        "geometry_overlaps".to_string(),
+        "geometry_overlaps_3d".to_string(),
+        "geometry_overlaps_nd".to_string(),
+        "geometry_overleft".to_string(),
+        "geometry_overright".to_string(),
+        "geometry_right".to_string(),
+        "geometry_same".to_string(),
+        "geometry_same_3d".to_string(),
+        "geometry_same_nd".to_string(),
+        "geometry_within".to_string(),
+        "geometry_within_nd".to_string(),
+        "inet_same_family".to_string(),
+        "inter_lb".to_string(),
+        "inter_sb".to_string(),
+        "inter_sl".to_string(),
+        "is_contained_2d".to_string(),
+        "ishorizontal".to_string(),
+        "isparallel".to_string(),
+        "isperp".to_string(),
+        "isvertical".to_string(),
+        "jsonb_contained".to_string(),
+        "jsonb_contains".to_string(),
+        "jsonb_exists".to_string(),
+        "jsonb_path_exists_opr".to_string(),
+        "jsonb_path_match_opr".to_string(),
+        "line_intersect".to_string(),
+        "line_parallel".to_string(),
+        "line_perp".to_string(),
+        "lseg_intersect".to_string(),
+        "lseg_parallel".to_string(),
+        "lseg_perp".to_string(),
+        "network_overlap".to_string(),
+        "network_sub".to_string(),
+        "network_sup".to_string(),
+        "on_pb".to_string(),
+        "on_pl".to_string(),
+        "on_ppath".to_string(),
+        "on_ps".to_string(),
+        "on_sb".to_string(),
+        "on_sl".to_string(),
+        "overlaps_2d".to_string(),
+        "path_contain_pt".to_string(),
+        "path_inter".to_string(),
+        "point_above".to_string(),
+        "point_below".to_string(),
+        "point_horiz".to_string(),
+        "point_left".to_string(),
+        "point_right".to_string(),
+        "point_vert".to_string(),
+        "poly_above".to_string(),
+        "poly_below".to_string(),
+        "poly_contain".to_string(),
+        "poly_contain_pt".to_string(),
+        "poly_contained".to_string(),
+        "poly_left".to_string(),
+        "poly_overabove".to_string(),
+        "poly_overbelow".to_string(),
+        "poly_overlap".to_string(),
+        "poly_overleft".to_string(),
+        "poly_overright".to_string(),
+        "poly_right".to_string(),
+        "poly_same".to_string(),
+        "pt_contained_poly".to_string(),
+        "st_3dintersects".to_string(),
+        "st_contains".to_string(),
+        "st_containsproperly".to_string(),
+        "st_coveredby".to_string(),
+        "st_covers".to_string(),
+        "st_crosses".to_string(),
+        "st_disjoint".to_string(),
+        "st_equals".to_string(),
+        "st_intersects".to_string(),
+        "st_isvalid".to_string(),
+        "st_orderingequals".to_string(),
+        "st_overlaps".to_string(),
+        "st_relatematch".to_string(),
+        "st_touches".to_string(),
+        "st_within".to_string(),
+        "starts_with".to_string(),
+        "ts_match_qv".to_string(),
+        "ts_match_tq".to_string(),
+        "ts_match_tt".to_string(),
+        "ts_match_vq".to_string(),
+        "tsq_mcontained".to_string(),
+        "tsq_mcontains".to_string(),
+        "xmlexists".to_string(),
+        "xmlvalidate".to_string(),
+        "xpath_exists".to_string(),
+    ]
+}

--- a/crates/configuration/src/version4/options.rs
+++ b/crates/configuration/src/version4/options.rs
@@ -73,9 +73,6 @@ fn default_unqualified_schemas_for_types_and_procedures() -> Vec<String> {
         "public".to_string(),
         "pg_catalog".to_string(),
         "tiger".to_string(),
-        // Supabase PG instances define types in these schemas
-        "auth".to_string(),
-        "pgsodium".to_string(),
     ]
 }
 

--- a/crates/connectors/ndc-postgres/src/connector.rs
+++ b/crates/connectors/ndc-postgres/src/connector.rs
@@ -255,6 +255,10 @@ impl<Env: Environment + Send + Sync> ConnectorSetup for PostgresSetup<Env> {
                 configuration::Error::IoErrorButStringified(inner) => {
                     connector::ParseError::Other(inner.into())
                 }
+                configuration::Error::DidNotFindExpectedVersionTag(_)
+                | configuration::Error::UnableToParseAnyVersions(_) => {
+                    connector::ParseError::Other(Box::new(error))
+                }
             })
 
         // Note that we don't log validation errors, because they are part of the normal business

--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -31,11 +31,8 @@ pub fn get_schema(
                     .type_representation
                     .as_ref()
                     .map(map_type_representation),
-                aggregate_functions: metadata
+                aggregate_functions: scalar_type_info
                     .aggregate_functions
-                    .0
-                    .get(scalar_type_name)
-                    .unwrap_or(&BTreeMap::new())
                     .iter()
                     .map(|(function_name, function_definition)| {
                         (

--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -22,8 +22,9 @@ pub fn get_schema(
 ) -> Result<models::SchemaResponse, connector::SchemaError> {
     let metadata = &config.metadata;
     let mut scalar_types: BTreeMap<String, models::ScalarType> = metadata
-        .occurring_scalar_types
-        .iter()
+        .scalar_types
+        .0
+        .keys()
         .map(|scalar_type| {
             let result = models::ScalarType {
                 representation: metadata

--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -48,11 +48,8 @@ pub fn get_schema(
                         )
                     })
                     .collect(),
-                comparison_operators: metadata
+                comparison_operators: scalar_type_info
                     .comparison_operators
-                    .0
-                    .get(scalar_type_name)
-                    .unwrap_or(&BTreeMap::new())
                     .iter()
                     .map(|(op_name, op_def)| {
                         (

--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -24,18 +24,17 @@ pub fn get_schema(
     let mut scalar_types: BTreeMap<String, models::ScalarType> = metadata
         .scalar_types
         .0
-        .keys()
-        .map(|scalar_type| {
+        .iter()
+        .map(|(scalar_type_name, scalar_type_info)| {
             let result = models::ScalarType {
-                representation: metadata
-                    .type_representations
-                    .0
-                    .get(scalar_type)
+                representation: scalar_type_info
+                    .type_representation
+                    .as_ref()
                     .map(map_type_representation),
                 aggregate_functions: metadata
                     .aggregate_functions
                     .0
-                    .get(scalar_type)
+                    .get(scalar_type_name)
                     .unwrap_or(&BTreeMap::new())
                     .iter()
                     .map(|(function_name, function_definition)| {
@@ -52,7 +51,7 @@ pub fn get_schema(
                 comparison_operators: metadata
                     .comparison_operators
                     .0
-                    .get(scalar_type)
+                    .get(scalar_type_name)
                     .unwrap_or(&BTreeMap::new())
                     .iter()
                     .map(|(op_name, op_def)| {
@@ -77,7 +76,7 @@ pub fn get_schema(
                     })
                     .collect(),
             };
-            (scalar_type.0.clone(), result)
+            (scalar_type_name.0.clone(), result)
         })
         .collect();
 

--- a/crates/query-engine/metadata/src/metadata/database.rs
+++ b/crates/query-engine/metadata/src/metadata/database.rs
@@ -32,7 +32,7 @@ impl ScalarTypes {
 /// operations you can do on it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScalarType {
-    pub name: String,
+    pub type_name: String,
     pub schema_name: Option<String>,
     pub description: Option<String>,
     pub aggregate_functions: BTreeMap<String, AggregateFunction>,
@@ -54,7 +54,7 @@ impl CompositeTypes {
 /// difference that composite types do not support constraints (such as NOT NULL).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompositeType {
-    pub name: String,
+    pub type_name: String,
     pub schema_name: Option<String>,
     pub fields: BTreeMap<String, FieldInfo>,
     pub description: Option<String>,
@@ -63,22 +63,10 @@ pub struct CompositeType {
 /// Information about a composite type field.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FieldInfo {
-    pub name: String,
+    pub field_name: String,
     pub r#type: Type,
 
     pub description: Option<String>,
-}
-
-/// The complete list of supported binary operators for scalar types.
-/// Not all of these are supported for every type.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-
-pub struct ComparisonOperators(pub BTreeMap<ScalarTypeName, BTreeMap<String, ComparisonOperator>>);
-
-impl ComparisonOperators {
-    pub fn empty() -> Self {
-        ComparisonOperators(BTreeMap::new())
-    }
 }
 
 /// Represents a postgres binary comparison operator
@@ -204,17 +192,6 @@ pub struct ForeignRelation {
     pub foreign_schema: Option<String>,
     pub foreign_table: String,
     pub column_mapping: BTreeMap<String, String>,
-}
-
-/// All supported aggregate functions, grouped by type.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-
-pub struct AggregateFunctions(pub BTreeMap<ScalarTypeName, BTreeMap<String, AggregateFunction>>);
-
-impl AggregateFunctions {
-    pub fn empty() -> Self {
-        AggregateFunctions(BTreeMap::new())
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/query-engine/metadata/src/metadata/database.rs
+++ b/crates/query-engine/metadata/src/metadata/database.rs
@@ -18,6 +18,28 @@ pub enum Type {
     ArrayType(Box<Type>),
 }
 
+/// Map of all known/occurring scalar types.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ScalarTypes(pub BTreeMap<ScalarTypeName, ScalarType>);
+
+impl ScalarTypes {
+    pub fn empty() -> Self {
+        ScalarTypes(BTreeMap::new())
+    }
+}
+
+/// Information about a scalar type. A scalar type is completely characterized by its name and the
+/// operations you can do on it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScalarType {
+    pub name: String,
+    pub schema_name: Option<String>,
+    pub description: Option<String>,
+    pub aggregate_functions: BTreeMap<String, AggregateFunction>,
+    pub comparison_operators: BTreeMap<String, ComparisonOperator>,
+    pub type_representation: Option<TypeRepresentation>,
+}
+
 /// Map of all known composite types.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct CompositeTypes(pub BTreeMap<CompositeTypeName, CompositeType>);
@@ -31,7 +53,6 @@ impl CompositeTypes {
 /// Information about a composite type. These are very similar to tables, but with the crucial
 /// difference that composite types do not support constraints (such as NOT NULL).
 #[derive(Debug, Clone, PartialEq, Eq)]
-
 pub struct CompositeType {
     pub name: String,
     pub schema_name: Option<String>,
@@ -41,7 +62,6 @@ pub struct CompositeType {
 
 /// Information about a composite type field.
 #[derive(Debug, Clone, PartialEq, Eq)]
-
 pub struct FieldInfo {
     pub name: String,
     pub r#type: Type,

--- a/crates/query-engine/metadata/src/metadata/mod.rs
+++ b/crates/query-engine/metadata/src/metadata/mod.rs
@@ -16,7 +16,6 @@ pub struct Metadata {
     pub native_queries: NativeQueries,
     pub aggregate_functions: AggregateFunctions,
     pub comparison_operators: ComparisonOperators,
-    pub type_representations: TypeRepresentations,
     pub scalar_types: ScalarTypes,
 }
 
@@ -28,7 +27,6 @@ impl Metadata {
             native_queries: NativeQueries::empty(),
             aggregate_functions: AggregateFunctions::empty(),
             comparison_operators: ComparisonOperators::empty(),
-            type_representations: TypeRepresentations::empty(),
             scalar_types: ScalarTypes::empty(),
         }
     }

--- a/crates/query-engine/metadata/src/metadata/mod.rs
+++ b/crates/query-engine/metadata/src/metadata/mod.rs
@@ -15,7 +15,6 @@ pub struct Metadata {
     pub composite_types: CompositeTypes,
     pub native_queries: NativeQueries,
     pub aggregate_functions: AggregateFunctions,
-    pub comparison_operators: ComparisonOperators,
     pub scalar_types: ScalarTypes,
 }
 
@@ -26,7 +25,6 @@ impl Metadata {
             composite_types: CompositeTypes::empty(),
             native_queries: NativeQueries::empty(),
             aggregate_functions: AggregateFunctions::empty(),
-            comparison_operators: ComparisonOperators::empty(),
             scalar_types: ScalarTypes::empty(),
         }
     }

--- a/crates/query-engine/metadata/src/metadata/mod.rs
+++ b/crates/query-engine/metadata/src/metadata/mod.rs
@@ -4,8 +4,6 @@ pub mod database;
 pub mod mutations;
 pub mod native_queries;
 
-use std::collections::BTreeSet;
-
 // re-export without modules
 pub use database::*;
 pub use native_queries::*;
@@ -19,7 +17,6 @@ pub struct Metadata {
     pub aggregate_functions: AggregateFunctions,
     pub comparison_operators: ComparisonOperators,
     pub type_representations: TypeRepresentations,
-    pub occurring_scalar_types: BTreeSet<ScalarTypeName>,
     pub scalar_types: ScalarTypes,
 }
 
@@ -32,7 +29,6 @@ impl Metadata {
             aggregate_functions: AggregateFunctions::empty(),
             comparison_operators: ComparisonOperators::empty(),
             type_representations: TypeRepresentations::empty(),
-            occurring_scalar_types: BTreeSet::new(),
             scalar_types: ScalarTypes::empty(),
         }
     }

--- a/crates/query-engine/metadata/src/metadata/mod.rs
+++ b/crates/query-engine/metadata/src/metadata/mod.rs
@@ -14,7 +14,6 @@ pub struct Metadata {
     pub tables: TablesInfo,
     pub composite_types: CompositeTypes,
     pub native_queries: NativeQueries,
-    pub aggregate_functions: AggregateFunctions,
     pub scalar_types: ScalarTypes,
 }
 
@@ -24,7 +23,6 @@ impl Metadata {
             tables: TablesInfo::empty(),
             composite_types: CompositeTypes::empty(),
             native_queries: NativeQueries::empty(),
-            aggregate_functions: AggregateFunctions::empty(),
             scalar_types: ScalarTypes::empty(),
         }
     }

--- a/crates/query-engine/metadata/src/metadata/mod.rs
+++ b/crates/query-engine/metadata/src/metadata/mod.rs
@@ -20,6 +20,7 @@ pub struct Metadata {
     pub comparison_operators: ComparisonOperators,
     pub type_representations: TypeRepresentations,
     pub occurring_scalar_types: BTreeSet<ScalarTypeName>,
+    pub scalar_types: ScalarTypes,
 }
 
 impl Metadata {
@@ -32,6 +33,7 @@ impl Metadata {
             comparison_operators: ComparisonOperators::empty(),
             type_representations: TypeRepresentations::empty(),
             occurring_scalar_types: BTreeSet::new(),
+            scalar_types: ScalarTypes::empty(),
         }
     }
 }

--- a/crates/query-engine/translation/src/translation/error.rs
+++ b/crates/query-engine/translation/src/translation/error.rs
@@ -63,8 +63,8 @@ impl std::fmt::Display for Error {
             Error::CollectionNotFound(collection_name) => {
                 write!(f, "Collection '{collection_name}' not found.")
             }
-            Error::ScalarTypeNotFound(collection_name) => {
-                write!(f, "Scalar Type '{}' not found.", collection_name)
+            Error::ScalarTypeNotFound(scalar_type) => {
+                write!(f, "Scalar Type '{scalar_type}' not found.")
             }
             Error::ProcedureNotFound(procedure_name) => {
                 write!(f, "Procedure '{procedure_name}' not found.")

--- a/crates/query-engine/translation/src/translation/error.rs
+++ b/crates/query-engine/translation/src/translation/error.rs
@@ -6,6 +6,7 @@ use query_engine_metadata::metadata::{database, Type};
 #[derive(Debug, Clone)]
 pub enum Error {
     CollectionNotFound(String),
+    ScalarTypeNotFound(String),
     ProcedureNotFound(String),
     ColumnNotFoundInCollection(String, String),
     RelationshipNotFound(String),
@@ -60,6 +61,9 @@ impl std::fmt::Display for Error {
         match self {
             Error::CollectionNotFound(collection_name) => {
                 write!(f, "Collection '{}' not found.", collection_name)
+            }
+            Error::ScalarTypeNotFound(collection_name) => {
+                write!(f, "Scalar Type '{}' not found.", collection_name)
             }
             Error::ProcedureNotFound(procedure_name) => {
                 write!(f, "Procedure '{}' not found.", procedure_name)

--- a/crates/query-engine/translation/src/translation/helpers.rs
+++ b/crates/query-engine/translation/src/translation/helpers.rs
@@ -308,10 +308,10 @@ impl<'request> Env<'request> {
         name: &str,
     ) -> Result<&'request metadata::ComparisonOperator, Error> {
         self.metadata
-            .comparison_operators
+            .scalar_types
             .0
             .get(scalar_type)
-            .and_then(|ops| ops.get(name))
+            .and_then(|t| t.comparison_operators.get(name))
             .ok_or(Error::OperatorNotFound {
                 operator_name: name.to_string(),
                 type_name: scalar_type.clone(),

--- a/crates/query-engine/translation/src/translation/helpers.rs
+++ b/crates/query-engine/translation/src/translation/helpers.rs
@@ -202,7 +202,7 @@ impl<'request> Env<'request> {
                         .0
                         .get(&metadata::CompositeTypeName(type_name.to_string()))
                         .map(|t| FieldsInfo::CompositeType {
-                            name: &t.name,
+                            name: &t.type_name,
                             info: t,
                         })
                 })
@@ -244,7 +244,7 @@ impl<'request> Env<'request> {
             .or_else(|| {
                 self.metadata.composite_types.0.get(type_name).map(|t| {
                     CompositeTypeInfo::CompositeType {
-                        name: &t.name,
+                        name: &t.type_name,
                         info: t,
                     }
                 })
@@ -368,7 +368,7 @@ impl FieldsInfo<'_> {
                 .fields
                 .get(column_name)
                 .map(|field_info| ColumnInfo {
-                    name: sql::ast::ColumnName(field_info.name.clone()),
+                    name: sql::ast::ColumnName(field_info.field_name.clone()),
                     r#type: field_info.r#type.clone(),
                 })
                 .ok_or_else(|| {
@@ -406,7 +406,7 @@ impl CompositeTypeInfo<'_> {
             CompositeTypeInfo::CompositeType { name: _, info } => info
                 .fields
                 .iter()
-                .map(|(name, field)| (name, &field.name))
+                .map(|(name, field)| (name, &field.field_name))
                 .collect::<Vec<_>>(),
 
             CompositeTypeInfo::Table { name: _, info } => info

--- a/crates/query-engine/translation/src/translation/helpers.rs
+++ b/crates/query-engine/translation/src/translation/helpers.rs
@@ -323,7 +323,11 @@ impl<'request> Env<'request> {
         &self,
         scalar_type: &metadata::ScalarTypeName,
     ) -> Option<&metadata::TypeRepresentation> {
-        self.metadata.type_representations.0.get(scalar_type)
+        self.metadata
+            .scalar_types
+            .0
+            .get(scalar_type)
+            .and_then(|t| t.type_representation.as_ref())
     }
 
     /// Try to get the variables table reference. This will fail if no variables were passed

--- a/crates/query-engine/translation/src/translation/helpers.rs
+++ b/crates/query-engine/translation/src/translation/helpers.rs
@@ -338,6 +338,18 @@ impl<'request> Env<'request> {
             Some(t) => Ok(t.clone()),
         }
     }
+
+    /// Lookup a scalar type by its name in the ndc schema.
+    pub(crate) fn lookup_scalar_type(
+        &self,
+        t: &metadata::ScalarTypeName,
+    ) -> Result<&metadata::ScalarType, Error> {
+        self.metadata
+            .scalar_types
+            .0
+            .get(t)
+            .ok_or(Error::ScalarTypeNotFound(t.0.clone()))
+    }
 }
 
 impl FieldsInfo<'_> {

--- a/crates/query-engine/translation/src/translation/query/values.rs
+++ b/crates/query-engine/translation/src/translation/query/values.rs
@@ -66,9 +66,13 @@ fn type_to_ast_scalar_type(
             Ok(scalar_type)
         }
         query_engine_metadata::metadata::Type::ScalarType(t) => {
-            // TODO: When adding schema suppor to scalar types this will need access to a mapping
-            // between ndc-type names and db type names like we have for composite types.
-            Ok(sql::ast::ScalarTypeName::new_unqualified(&t.0))
+            let scalar_type: &query_engine_metadata::metadata::ScalarType =
+                env.lookup_scalar_type(t)?;
+            Ok(sql::ast::ScalarTypeName {
+                type_name: scalar_type.type_name.clone(),
+                schema_name: scalar_type.schema_name.clone().map(sql::ast::SchemaName),
+                is_array: false,
+            })
         }
         query_engine_metadata::metadata::Type::CompositeType(t) => {
             let type_info = env.lookup_composite_type(t)?;

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__get_configuration_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__get_configuration_schema.snap
@@ -329,6 +329,325 @@ expression: schema
           ]
         }
       }
+    },
+    {
+      "description": "Initial configuration, just enough to connect to a database and elaborate a full 'Configuration'.",
+      "type": "object",
+      "required": [
+        "connectionSettings",
+        "version"
+      ],
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "4"
+          ]
+        },
+        "$schema": {
+          "description": "Jsonschema of the configuration format.",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "connectionSettings": {
+          "description": "Database connection settings.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DatabaseConnectionSettings2"
+            }
+          ]
+        },
+        "metadata": {
+          "description": "Connector metadata.",
+          "default": {
+            "tables": {},
+            "scalarTypes": {},
+            "compositeTypes": {},
+            "nativeQueries": {}
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Metadata2"
+            }
+          ]
+        },
+        "introspectionOptions": {
+          "description": "Database introspection options.",
+          "default": {
+            "excludedSchemas": [
+              "information_schema",
+              "pg_catalog",
+              "tiger",
+              "crdb_internal",
+              "columnar",
+              "columnar_internal"
+            ],
+            "unqualifiedSchemasForTables": [
+              "public"
+            ],
+            "unqualifiedSchemasForTypesAndProcedures": [
+              "public",
+              "pg_catalog",
+              "tiger"
+            ],
+            "comparisonOperatorMapping": [
+              {
+                "operatorName": "=",
+                "exposedName": "_eq",
+                "operatorKind": "equal"
+              },
+              {
+                "operatorName": "<=",
+                "exposedName": "_lte",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": ">",
+                "exposedName": "_gt",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": ">=",
+                "exposedName": "_gte",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "<",
+                "exposedName": "_lt",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "!=",
+                "exposedName": "_neq",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "LIKE",
+                "exposedName": "_like",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "NOT LIKE",
+                "exposedName": "_nlike",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "ILIKE",
+                "exposedName": "_ilike",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "NOT ILIKE",
+                "exposedName": "_nilike",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "SIMILAR TO",
+                "exposedName": "_similar",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "NOT SIMILAR TO",
+                "exposedName": "_nsimilar",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "<>",
+                "exposedName": "_neq",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "~~",
+                "exposedName": "_like",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "!~~",
+                "exposedName": "_nlike",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "~~*",
+                "exposedName": "_ilike",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "!~~*",
+                "exposedName": "_nilike",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "~",
+                "exposedName": "_regex",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "!~",
+                "exposedName": "_nregex",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "~*",
+                "exposedName": "_iregex",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "!~*",
+                "exposedName": "_niregex",
+                "operatorKind": "custom"
+              }
+            ],
+            "introspectPrefixFunctionComparisonOperators": [
+              "box_above",
+              "box_below",
+              "box_contain",
+              "box_contain_pt",
+              "box_contained",
+              "box_left",
+              "box_overabove",
+              "box_overbelow",
+              "box_overlap",
+              "box_overleft",
+              "box_overright",
+              "box_right",
+              "box_same",
+              "circle_above",
+              "circle_below",
+              "circle_contain",
+              "circle_contain_pt",
+              "circle_contained",
+              "circle_left",
+              "circle_overabove",
+              "circle_overbelow",
+              "circle_overlap",
+              "circle_overleft",
+              "circle_overright",
+              "circle_right",
+              "circle_same",
+              "contains_2d",
+              "equals",
+              "geography_overlaps",
+              "geometry_above",
+              "geometry_below",
+              "geometry_contained_3d",
+              "geometry_contains",
+              "geometry_contains_3d",
+              "geometry_contains_nd",
+              "geometry_left",
+              "geometry_overabove",
+              "geometry_overbelow",
+              "geometry_overlaps",
+              "geometry_overlaps_3d",
+              "geometry_overlaps_nd",
+              "geometry_overleft",
+              "geometry_overright",
+              "geometry_right",
+              "geometry_same",
+              "geometry_same_3d",
+              "geometry_same_nd",
+              "geometry_within",
+              "geometry_within_nd",
+              "inet_same_family",
+              "inter_lb",
+              "inter_sb",
+              "inter_sl",
+              "is_contained_2d",
+              "ishorizontal",
+              "isparallel",
+              "isperp",
+              "isvertical",
+              "jsonb_contained",
+              "jsonb_contains",
+              "jsonb_exists",
+              "jsonb_path_exists_opr",
+              "jsonb_path_match_opr",
+              "line_intersect",
+              "line_parallel",
+              "line_perp",
+              "lseg_intersect",
+              "lseg_parallel",
+              "lseg_perp",
+              "network_overlap",
+              "network_sub",
+              "network_sup",
+              "on_pb",
+              "on_pl",
+              "on_ppath",
+              "on_ps",
+              "on_sb",
+              "on_sl",
+              "overlaps_2d",
+              "path_contain_pt",
+              "path_inter",
+              "point_above",
+              "point_below",
+              "point_horiz",
+              "point_left",
+              "point_right",
+              "point_vert",
+              "poly_above",
+              "poly_below",
+              "poly_contain",
+              "poly_contain_pt",
+              "poly_contained",
+              "poly_left",
+              "poly_overabove",
+              "poly_overbelow",
+              "poly_overlap",
+              "poly_overleft",
+              "poly_overright",
+              "poly_right",
+              "poly_same",
+              "pt_contained_poly",
+              "st_3dintersects",
+              "st_contains",
+              "st_containsproperly",
+              "st_coveredby",
+              "st_covers",
+              "st_crosses",
+              "st_disjoint",
+              "st_equals",
+              "st_intersects",
+              "st_isvalid",
+              "st_orderingequals",
+              "st_overlaps",
+              "st_relatematch",
+              "st_touches",
+              "st_within",
+              "starts_with",
+              "ts_match_qv",
+              "ts_match_tq",
+              "ts_match_tt",
+              "ts_match_vq",
+              "tsq_mcontained",
+              "tsq_mcontains",
+              "xmlexists",
+              "xmlvalidate",
+              "xpath_exists"
+            ]
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/IntrospectionOptions2"
+            }
+          ]
+        },
+        "mutationsVersion": {
+          "description": "Which version of the generated mutation procedures to include in the schema response",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MutationsVersion2"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
     }
   ],
   "definitions": {
@@ -1475,6 +1794,1040 @@ expression: schema
       }
     },
     "MutationsVersion": {
+      "description": "Which version of the generated mutations will be included in the schema",
+      "type": "string",
+      "enum": [
+        "v1",
+        "veryExperimentalWip"
+      ]
+    },
+    "DatabaseConnectionSettings2": {
+      "description": "Database connection settings.",
+      "type": "object",
+      "required": [
+        "connectionUri"
+      ],
+      "properties": {
+        "connectionUri": {
+          "description": "Connection string for a Postgres-compatible database.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConnectionUri"
+            }
+          ]
+        },
+        "poolSettings": {
+          "description": "Connection pool settings.",
+          "default": {
+            "maxConnections": 50,
+            "poolTimeout": 30,
+            "idleTimeout": 180,
+            "connectionLifetime": 600
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/PoolSettings"
+            }
+          ]
+        },
+        "isolationLevel": {
+          "description": "Query isolation level.",
+          "default": "ReadCommitted",
+          "allOf": [
+            {
+              "$ref": "#/definitions/IsolationLevel"
+            }
+          ]
+        }
+      }
+    },
+    "Metadata2": {
+      "description": "Metadata information.",
+      "type": "object",
+      "properties": {
+        "tables": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/TablesInfo2"
+            }
+          ]
+        },
+        "scalarTypes": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/ScalarTypes"
+            }
+          ]
+        },
+        "compositeTypes": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/CompositeTypes2"
+            }
+          ]
+        },
+        "nativeQueries": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/NativeQueries2"
+            }
+          ]
+        }
+      }
+    },
+    "TablesInfo2": {
+      "description": "Mapping from a \"table\" name to its information.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/TableInfo2"
+      }
+    },
+    "TableInfo2": {
+      "description": "Information about a database table (or any other kind of relation).",
+      "type": "object",
+      "required": [
+        "columns",
+        "schemaName",
+        "tableName"
+      ],
+      "properties": {
+        "schemaName": {
+          "type": "string"
+        },
+        "tableName": {
+          "type": "string"
+        },
+        "columns": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ColumnInfo2"
+          }
+        },
+        "uniquenessConstraints": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/UniquenessConstraints2"
+            }
+          ]
+        },
+        "foreignRelations": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/ForeignRelations2"
+            }
+          ]
+        },
+        "description": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "ColumnInfo2": {
+      "description": "Information about a database column.",
+      "type": "object",
+      "required": [
+        "name",
+        "type"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/Type2"
+        },
+        "nullable": {
+          "default": "nullable",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Nullable2"
+            }
+          ]
+        },
+        "hasDefault": {
+          "$ref": "#/definitions/HasDefault2"
+        },
+        "isIdentity": {
+          "$ref": "#/definitions/IsIdentity2"
+        },
+        "isGenerated": {
+          "$ref": "#/definitions/IsGenerated2"
+        },
+        "description": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "Type2": {
+      "description": "The type of values that a column, field, or argument may take.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "scalarType"
+          ],
+          "properties": {
+            "scalarType": {
+              "$ref": "#/definitions/ScalarTypeName"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "compositeType"
+          ],
+          "properties": {
+            "compositeType": {
+              "$ref": "#/definitions/CompositeTypeName"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "arrayType"
+          ],
+          "properties": {
+            "arrayType": {
+              "$ref": "#/definitions/Type2"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "ScalarTypeName": {
+      "description": "A name of a Scalar Type, as it appears in the NDC scheme.",
+      "type": "string"
+    },
+    "CompositeTypeName": {
+      "description": "The name of a Composite Type, as it appears in the NDC schema",
+      "type": "string"
+    },
+    "Nullable2": {
+      "description": "Can this column contain null values",
+      "type": "string",
+      "enum": [
+        "nullable",
+        "nonNullable"
+      ]
+    },
+    "HasDefault2": {
+      "description": "Does this column have a default value.",
+      "type": "string",
+      "enum": [
+        "noDefault",
+        "hasDefault"
+      ]
+    },
+    "IsIdentity2": {
+      "description": "Is this column an identity column.",
+      "type": "string",
+      "enum": [
+        "notIdentity",
+        "identityByDefault",
+        "identityAlways"
+      ]
+    },
+    "IsGenerated2": {
+      "description": "Is this column a generated column.",
+      "type": "string",
+      "enum": [
+        "notGenerated",
+        "stored"
+      ]
+    },
+    "UniquenessConstraints2": {
+      "description": "A mapping from the name of a unique constraint to its value.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/UniquenessConstraint2"
+      }
+    },
+    "UniquenessConstraint2": {
+      "description": "The set of columns that make up a uniqueness constraint.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "ForeignRelations2": {
+      "description": "A mapping from the name of a foreign key constraint to its value.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/ForeignRelation2"
+      }
+    },
+    "ForeignRelation2": {
+      "description": "A foreign key constraint.",
+      "type": "object",
+      "required": [
+        "columnMapping",
+        "foreignTable"
+      ],
+      "properties": {
+        "foreignSchema": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "foreignTable": {
+          "type": "string"
+        },
+        "columnMapping": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ScalarTypes": {
+      "description": "Map of all known/occurring scalar types.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/ScalarType2"
+      }
+    },
+    "ScalarType2": {
+      "description": "Information about a scalar type. A scalar type is completely characterized by its name and the operations you can do on it.",
+      "type": "object",
+      "required": [
+        "aggregateFunctions",
+        "comparisonOperators",
+        "schemaName",
+        "typeName"
+      ],
+      "properties": {
+        "typeName": {
+          "type": "string"
+        },
+        "schemaName": {
+          "type": "string"
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "aggregateFunctions": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/AggregateFunction2"
+          }
+        },
+        "comparisonOperators": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ComparisonOperator2"
+          }
+        },
+        "typeRepresentation": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TypeRepresentation2"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "AggregateFunction2": {
+      "type": "object",
+      "required": [
+        "returnType"
+      ],
+      "properties": {
+        "returnType": {
+          "$ref": "#/definitions/ScalarTypeName"
+        }
+      }
+    },
+    "ComparisonOperator2": {
+      "description": "Represents a postgres binary comparison operator",
+      "type": "object",
+      "required": [
+        "argumentType",
+        "operatorKind",
+        "operatorName"
+      ],
+      "properties": {
+        "operatorName": {
+          "type": "string"
+        },
+        "operatorKind": {
+          "$ref": "#/definitions/OperatorKind2"
+        },
+        "argumentType": {
+          "$ref": "#/definitions/ScalarTypeName"
+        },
+        "isInfix": {
+          "default": true,
+          "type": "boolean"
+        }
+      }
+    },
+    "OperatorKind2": {
+      "description": "Is it a built-in operator, or a custom operator.",
+      "type": "string",
+      "enum": [
+        "equal",
+        "in",
+        "custom"
+      ]
+    },
+    "TypeRepresentation2": {
+      "description": "Type representation of a scalar type.",
+      "oneOf": [
+        {
+          "description": "JSON booleans",
+          "type": "string",
+          "enum": [
+            "boolean"
+          ]
+        },
+        {
+          "description": "Any JSON string",
+          "type": "string",
+          "enum": [
+            "string"
+          ]
+        },
+        {
+          "description": "float4",
+          "type": "string",
+          "enum": [
+            "float32"
+          ]
+        },
+        {
+          "description": "float8",
+          "type": "string",
+          "enum": [
+            "float64"
+          ]
+        },
+        {
+          "description": "int2",
+          "type": "string",
+          "enum": [
+            "int16"
+          ]
+        },
+        {
+          "description": "int4",
+          "type": "string",
+          "enum": [
+            "int32"
+          ]
+        },
+        {
+          "description": "int8 as integer",
+          "type": "string",
+          "enum": [
+            "int64"
+          ]
+        },
+        {
+          "description": "int8 as string",
+          "type": "string",
+          "enum": [
+            "int64AsString"
+          ]
+        },
+        {
+          "description": "numeric",
+          "type": "string",
+          "enum": [
+            "bigDecimal"
+          ]
+        },
+        {
+          "description": "numeric as string",
+          "type": "string",
+          "enum": [
+            "bigDecimalAsString"
+          ]
+        },
+        {
+          "description": "timestamp",
+          "type": "string",
+          "enum": [
+            "timestamp"
+          ]
+        },
+        {
+          "description": "timestamp with timezone",
+          "type": "string",
+          "enum": [
+            "timestamptz"
+          ]
+        },
+        {
+          "description": "time",
+          "type": "string",
+          "enum": [
+            "time"
+          ]
+        },
+        {
+          "description": "time with timezone",
+          "type": "string",
+          "enum": [
+            "timetz"
+          ]
+        },
+        {
+          "description": "date",
+          "type": "string",
+          "enum": [
+            "date"
+          ]
+        },
+        {
+          "description": "uuid",
+          "type": "string",
+          "enum": [
+            "uUID"
+          ]
+        },
+        {
+          "description": "geography",
+          "type": "string",
+          "enum": [
+            "geography"
+          ]
+        },
+        {
+          "description": "geometry",
+          "type": "string",
+          "enum": [
+            "geometry"
+          ]
+        },
+        {
+          "description": "Any JSON number",
+          "type": "string",
+          "enum": [
+            "number"
+          ]
+        },
+        {
+          "description": "Any JSON number, with no decimal part",
+          "type": "string",
+          "enum": [
+            "integer"
+          ]
+        },
+        {
+          "description": "An arbitrary json.",
+          "type": "string",
+          "enum": [
+            "json"
+          ]
+        },
+        {
+          "description": "One of the specified string values",
+          "type": "object",
+          "required": [
+            "enum"
+          ],
+          "properties": {
+            "enum": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "CompositeTypes2": {
+      "description": "Map of all known composite types.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/CompositeType2"
+      }
+    },
+    "CompositeType2": {
+      "description": "Information about a composite type. These are very similar to tables, but with the crucial difference that composite types do not support constraints (such as NOT NULL).",
+      "type": "object",
+      "required": [
+        "fields",
+        "schemaName",
+        "typeName"
+      ],
+      "properties": {
+        "typeName": {
+          "type": "string"
+        },
+        "schemaName": {
+          "type": "string"
+        },
+        "fields": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/FieldInfo2"
+          }
+        },
+        "description": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "FieldInfo2": {
+      "description": "Information about a composite type field.",
+      "type": "object",
+      "required": [
+        "fieldName",
+        "type"
+      ],
+      "properties": {
+        "fieldName": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/Type2"
+        },
+        "description": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "NativeQueries2": {
+      "description": "Metadata information of native queries.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/NativeQueryInfo2"
+      }
+    },
+    "NativeQueryInfo2": {
+      "description": "Information about a Native Query",
+      "type": "object",
+      "required": [
+        "columns",
+        "sql"
+      ],
+      "properties": {
+        "sql": {
+          "description": "SQL expression to use for the Native Query. We can interpolate values using `{{variable_name}}` syntax, such as `SELECT * FROM authors WHERE name = {{author_name}}`",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NativeQuerySql"
+            }
+          ]
+        },
+        "columns": {
+          "description": "Columns returned by the Native Query",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ReadOnlyColumnInfo2"
+          }
+        },
+        "arguments": {
+          "description": "Names and types of arguments that can be passed to this Native Query",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ReadOnlyColumnInfo2"
+          }
+        },
+        "description": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "isProcedure": {
+          "description": "True if this native query mutates the database",
+          "type": "boolean"
+        }
+      }
+    },
+    "ReadOnlyColumnInfo2": {
+      "description": "Information about a native query column.",
+      "type": "object",
+      "required": [
+        "name",
+        "type"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/Type2"
+        },
+        "nullable": {
+          "default": "nullable",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Nullable2"
+            }
+          ]
+        },
+        "description": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "IntrospectionOptions2": {
+      "description": "Options which only influence how the configuration is updated.",
+      "type": "object",
+      "properties": {
+        "excludedSchemas": {
+          "description": "Schemas which are excluded from introspection. The default setting will exclude the internal schemas of Postgres, Citus, Cockroach, and the PostGIS extension.",
+          "default": [
+            "information_schema",
+            "pg_catalog",
+            "tiger",
+            "crdb_internal",
+            "columnar",
+            "columnar_internal"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "unqualifiedSchemasForTables": {
+          "description": "The names of Tables and Views in these schemas will be returned unqualified. The default setting will set the `public` schema as unqualified.",
+          "default": [
+            "public"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "unqualifiedSchemasForTypesAndProcedures": {
+          "description": "The types and procedures in these schemas will be returned unqualified.",
+          "default": [
+            "public",
+            "pg_catalog",
+            "tiger"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "comparisonOperatorMapping": {
+          "description": "The mapping of comparison operator names to apply when updating the configuration",
+          "default": [
+            {
+              "operatorName": "=",
+              "exposedName": "_eq",
+              "operatorKind": "equal"
+            },
+            {
+              "operatorName": "<=",
+              "exposedName": "_lte",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": ">",
+              "exposedName": "_gt",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": ">=",
+              "exposedName": "_gte",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "<",
+              "exposedName": "_lt",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "!=",
+              "exposedName": "_neq",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "LIKE",
+              "exposedName": "_like",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "NOT LIKE",
+              "exposedName": "_nlike",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "ILIKE",
+              "exposedName": "_ilike",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "NOT ILIKE",
+              "exposedName": "_nilike",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "SIMILAR TO",
+              "exposedName": "_similar",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "NOT SIMILAR TO",
+              "exposedName": "_nsimilar",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "<>",
+              "exposedName": "_neq",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "~~",
+              "exposedName": "_like",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "!~~",
+              "exposedName": "_nlike",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "~~*",
+              "exposedName": "_ilike",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "!~~*",
+              "exposedName": "_nilike",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "~",
+              "exposedName": "_regex",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "!~",
+              "exposedName": "_nregex",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "~*",
+              "exposedName": "_iregex",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "!~*",
+              "exposedName": "_niregex",
+              "operatorKind": "custom"
+            }
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ComparisonOperatorMapping2"
+          }
+        },
+        "introspectPrefixFunctionComparisonOperators": {
+          "description": "Which prefix functions (i.e., non-infix operators) to generate introspection metadata for.\n\nThis list will accept any boolean-returning function taking two concrete scalar types as arguments.\n\nThe default includes comparisons for various build-in types as well as those of PostGIS.",
+          "default": [
+            "box_above",
+            "box_below",
+            "box_contain",
+            "box_contain_pt",
+            "box_contained",
+            "box_left",
+            "box_overabove",
+            "box_overbelow",
+            "box_overlap",
+            "box_overleft",
+            "box_overright",
+            "box_right",
+            "box_same",
+            "circle_above",
+            "circle_below",
+            "circle_contain",
+            "circle_contain_pt",
+            "circle_contained",
+            "circle_left",
+            "circle_overabove",
+            "circle_overbelow",
+            "circle_overlap",
+            "circle_overleft",
+            "circle_overright",
+            "circle_right",
+            "circle_same",
+            "contains_2d",
+            "equals",
+            "geography_overlaps",
+            "geometry_above",
+            "geometry_below",
+            "geometry_contained_3d",
+            "geometry_contains",
+            "geometry_contains_3d",
+            "geometry_contains_nd",
+            "geometry_left",
+            "geometry_overabove",
+            "geometry_overbelow",
+            "geometry_overlaps",
+            "geometry_overlaps_3d",
+            "geometry_overlaps_nd",
+            "geometry_overleft",
+            "geometry_overright",
+            "geometry_right",
+            "geometry_same",
+            "geometry_same_3d",
+            "geometry_same_nd",
+            "geometry_within",
+            "geometry_within_nd",
+            "inet_same_family",
+            "inter_lb",
+            "inter_sb",
+            "inter_sl",
+            "is_contained_2d",
+            "ishorizontal",
+            "isparallel",
+            "isperp",
+            "isvertical",
+            "jsonb_contained",
+            "jsonb_contains",
+            "jsonb_exists",
+            "jsonb_path_exists_opr",
+            "jsonb_path_match_opr",
+            "line_intersect",
+            "line_parallel",
+            "line_perp",
+            "lseg_intersect",
+            "lseg_parallel",
+            "lseg_perp",
+            "network_overlap",
+            "network_sub",
+            "network_sup",
+            "on_pb",
+            "on_pl",
+            "on_ppath",
+            "on_ps",
+            "on_sb",
+            "on_sl",
+            "overlaps_2d",
+            "path_contain_pt",
+            "path_inter",
+            "point_above",
+            "point_below",
+            "point_horiz",
+            "point_left",
+            "point_right",
+            "point_vert",
+            "poly_above",
+            "poly_below",
+            "poly_contain",
+            "poly_contain_pt",
+            "poly_contained",
+            "poly_left",
+            "poly_overabove",
+            "poly_overbelow",
+            "poly_overlap",
+            "poly_overleft",
+            "poly_overright",
+            "poly_right",
+            "poly_same",
+            "pt_contained_poly",
+            "st_3dintersects",
+            "st_contains",
+            "st_containsproperly",
+            "st_coveredby",
+            "st_covers",
+            "st_crosses",
+            "st_disjoint",
+            "st_equals",
+            "st_intersects",
+            "st_isvalid",
+            "st_orderingequals",
+            "st_overlaps",
+            "st_relatematch",
+            "st_touches",
+            "st_within",
+            "starts_with",
+            "ts_match_qv",
+            "ts_match_tq",
+            "ts_match_tt",
+            "ts_match_vq",
+            "tsq_mcontained",
+            "tsq_mcontains",
+            "xmlexists",
+            "xmlvalidate",
+            "xpath_exists"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ComparisonOperatorMapping2": {
+      "description": "Define the names that comparison operators will be exposed as by the automatic introspection.",
+      "type": "object",
+      "required": [
+        "exposedName",
+        "operatorKind",
+        "operatorName"
+      ],
+      "properties": {
+        "operatorName": {
+          "description": "The name of the operator as defined by the database",
+          "type": "string"
+        },
+        "exposedName": {
+          "description": "The name the operator will appear under in the exposed API",
+          "type": "string"
+        },
+        "operatorKind": {
+          "description": "Equal, In or Custom.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OperatorKind2"
+            }
+          ]
+        }
+      }
+    },
+    "MutationsVersion2": {
       "description": "Which version of the generated mutations will be included in the schema",
       "type": "string",
       "enum": [

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__openapi_tests__openapi__up_to_date_generated_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__openapi_tests__openapi__up_to_date_generated_schema.snap
@@ -325,6 +325,321 @@ expression: generated_schema_json
           "nullable": true
         }
       }
+    },
+    {
+      "description": "Initial configuration, just enough to connect to a database and elaborate a full 'Configuration'.",
+      "type": "object",
+      "required": [
+        "connectionSettings",
+        "version"
+      ],
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "4"
+          ]
+        },
+        "$schema": {
+          "description": "Jsonschema of the configuration format.",
+          "default": null,
+          "type": "string",
+          "nullable": true
+        },
+        "connectionSettings": {
+          "description": "Database connection settings.",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/DatabaseConnectionSettings2"
+            }
+          ]
+        },
+        "metadata": {
+          "description": "Connector metadata.",
+          "default": {
+            "tables": {},
+            "scalarTypes": {},
+            "compositeTypes": {},
+            "nativeQueries": {}
+          },
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Metadata2"
+            }
+          ]
+        },
+        "introspectionOptions": {
+          "description": "Database introspection options.",
+          "default": {
+            "excludedSchemas": [
+              "information_schema",
+              "pg_catalog",
+              "tiger",
+              "crdb_internal",
+              "columnar",
+              "columnar_internal"
+            ],
+            "unqualifiedSchemasForTables": [
+              "public"
+            ],
+            "unqualifiedSchemasForTypesAndProcedures": [
+              "public",
+              "pg_catalog",
+              "tiger"
+            ],
+            "comparisonOperatorMapping": [
+              {
+                "operatorName": "=",
+                "exposedName": "_eq",
+                "operatorKind": "equal"
+              },
+              {
+                "operatorName": "<=",
+                "exposedName": "_lte",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": ">",
+                "exposedName": "_gt",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": ">=",
+                "exposedName": "_gte",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "<",
+                "exposedName": "_lt",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "!=",
+                "exposedName": "_neq",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "LIKE",
+                "exposedName": "_like",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "NOT LIKE",
+                "exposedName": "_nlike",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "ILIKE",
+                "exposedName": "_ilike",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "NOT ILIKE",
+                "exposedName": "_nilike",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "SIMILAR TO",
+                "exposedName": "_similar",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "NOT SIMILAR TO",
+                "exposedName": "_nsimilar",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "<>",
+                "exposedName": "_neq",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "~~",
+                "exposedName": "_like",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "!~~",
+                "exposedName": "_nlike",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "~~*",
+                "exposedName": "_ilike",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "!~~*",
+                "exposedName": "_nilike",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "~",
+                "exposedName": "_regex",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "!~",
+                "exposedName": "_nregex",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "~*",
+                "exposedName": "_iregex",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "!~*",
+                "exposedName": "_niregex",
+                "operatorKind": "custom"
+              }
+            ],
+            "introspectPrefixFunctionComparisonOperators": [
+              "box_above",
+              "box_below",
+              "box_contain",
+              "box_contain_pt",
+              "box_contained",
+              "box_left",
+              "box_overabove",
+              "box_overbelow",
+              "box_overlap",
+              "box_overleft",
+              "box_overright",
+              "box_right",
+              "box_same",
+              "circle_above",
+              "circle_below",
+              "circle_contain",
+              "circle_contain_pt",
+              "circle_contained",
+              "circle_left",
+              "circle_overabove",
+              "circle_overbelow",
+              "circle_overlap",
+              "circle_overleft",
+              "circle_overright",
+              "circle_right",
+              "circle_same",
+              "contains_2d",
+              "equals",
+              "geography_overlaps",
+              "geometry_above",
+              "geometry_below",
+              "geometry_contained_3d",
+              "geometry_contains",
+              "geometry_contains_3d",
+              "geometry_contains_nd",
+              "geometry_left",
+              "geometry_overabove",
+              "geometry_overbelow",
+              "geometry_overlaps",
+              "geometry_overlaps_3d",
+              "geometry_overlaps_nd",
+              "geometry_overleft",
+              "geometry_overright",
+              "geometry_right",
+              "geometry_same",
+              "geometry_same_3d",
+              "geometry_same_nd",
+              "geometry_within",
+              "geometry_within_nd",
+              "inet_same_family",
+              "inter_lb",
+              "inter_sb",
+              "inter_sl",
+              "is_contained_2d",
+              "ishorizontal",
+              "isparallel",
+              "isperp",
+              "isvertical",
+              "jsonb_contained",
+              "jsonb_contains",
+              "jsonb_exists",
+              "jsonb_path_exists_opr",
+              "jsonb_path_match_opr",
+              "line_intersect",
+              "line_parallel",
+              "line_perp",
+              "lseg_intersect",
+              "lseg_parallel",
+              "lseg_perp",
+              "network_overlap",
+              "network_sub",
+              "network_sup",
+              "on_pb",
+              "on_pl",
+              "on_ppath",
+              "on_ps",
+              "on_sb",
+              "on_sl",
+              "overlaps_2d",
+              "path_contain_pt",
+              "path_inter",
+              "point_above",
+              "point_below",
+              "point_horiz",
+              "point_left",
+              "point_right",
+              "point_vert",
+              "poly_above",
+              "poly_below",
+              "poly_contain",
+              "poly_contain_pt",
+              "poly_contained",
+              "poly_left",
+              "poly_overabove",
+              "poly_overbelow",
+              "poly_overlap",
+              "poly_overleft",
+              "poly_overright",
+              "poly_right",
+              "poly_same",
+              "pt_contained_poly",
+              "st_3dintersects",
+              "st_contains",
+              "st_containsproperly",
+              "st_coveredby",
+              "st_covers",
+              "st_crosses",
+              "st_disjoint",
+              "st_equals",
+              "st_intersects",
+              "st_isvalid",
+              "st_orderingequals",
+              "st_overlaps",
+              "st_relatematch",
+              "st_touches",
+              "st_within",
+              "starts_with",
+              "ts_match_qv",
+              "ts_match_tq",
+              "ts_match_tt",
+              "ts_match_vq",
+              "tsq_mcontained",
+              "tsq_mcontains",
+              "xmlexists",
+              "xmlvalidate",
+              "xpath_exists"
+            ]
+          },
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/IntrospectionOptions2"
+            }
+          ]
+        },
+        "mutationsVersion": {
+          "description": "Which version of the generated mutation procedures to include in the schema response",
+          "default": null,
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/MutationsVersion2"
+            }
+          ],
+          "nullable": true
+        }
+      }
     }
   ],
   "definitions": {
@@ -1453,6 +1768,1022 @@ expression: generated_schema_json
       }
     },
     "MutationsVersion": {
+      "description": "Which version of the generated mutations will be included in the schema",
+      "type": "string",
+      "enum": [
+        "v1",
+        "veryExperimentalWip"
+      ]
+    },
+    "DatabaseConnectionSettings2": {
+      "description": "Database connection settings.",
+      "type": "object",
+      "required": [
+        "connectionUri"
+      ],
+      "properties": {
+        "connectionUri": {
+          "description": "Connection string for a Postgres-compatible database.",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/ConnectionUri"
+            }
+          ]
+        },
+        "poolSettings": {
+          "description": "Connection pool settings.",
+          "default": {
+            "maxConnections": 50,
+            "poolTimeout": 30,
+            "idleTimeout": 180,
+            "connectionLifetime": 600
+          },
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/PoolSettings"
+            }
+          ]
+        },
+        "isolationLevel": {
+          "description": "Query isolation level.",
+          "default": "ReadCommitted",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/IsolationLevel"
+            }
+          ]
+        }
+      }
+    },
+    "Metadata2": {
+      "description": "Metadata information.",
+      "type": "object",
+      "properties": {
+        "tables": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/TablesInfo2"
+            }
+          ]
+        },
+        "scalarTypes": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/ScalarTypes"
+            }
+          ]
+        },
+        "compositeTypes": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/CompositeTypes2"
+            }
+          ]
+        },
+        "nativeQueries": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/NativeQueries2"
+            }
+          ]
+        }
+      }
+    },
+    "TablesInfo2": {
+      "description": "Mapping from a \"table\" name to its information.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/components/schemas/TableInfo2"
+      }
+    },
+    "TableInfo2": {
+      "description": "Information about a database table (or any other kind of relation).",
+      "type": "object",
+      "required": [
+        "columns",
+        "schemaName",
+        "tableName"
+      ],
+      "properties": {
+        "schemaName": {
+          "type": "string"
+        },
+        "tableName": {
+          "type": "string"
+        },
+        "columns": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/components/schemas/ColumnInfo2"
+          }
+        },
+        "uniquenessConstraints": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/UniquenessConstraints2"
+            }
+          ]
+        },
+        "foreignRelations": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/ForeignRelations2"
+            }
+          ]
+        },
+        "description": {
+          "default": null,
+          "type": "string",
+          "nullable": true
+        }
+      }
+    },
+    "ColumnInfo2": {
+      "description": "Information about a database column.",
+      "type": "object",
+      "required": [
+        "name",
+        "type"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/components/schemas/Type2"
+        },
+        "nullable": {
+          "default": "nullable",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Nullable2"
+            }
+          ]
+        },
+        "hasDefault": {
+          "$ref": "#/components/schemas/HasDefault2"
+        },
+        "isIdentity": {
+          "$ref": "#/components/schemas/IsIdentity2"
+        },
+        "isGenerated": {
+          "$ref": "#/components/schemas/IsGenerated2"
+        },
+        "description": {
+          "default": null,
+          "type": "string",
+          "nullable": true
+        }
+      }
+    },
+    "Type2": {
+      "description": "The type of values that a column, field, or argument may take.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "scalarType"
+          ],
+          "properties": {
+            "scalarType": {
+              "$ref": "#/components/schemas/ScalarTypeName"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "compositeType"
+          ],
+          "properties": {
+            "compositeType": {
+              "$ref": "#/components/schemas/CompositeTypeName"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "arrayType"
+          ],
+          "properties": {
+            "arrayType": {
+              "$ref": "#/components/schemas/Type2"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "ScalarTypeName": {
+      "description": "A name of a Scalar Type, as it appears in the NDC scheme.",
+      "type": "string"
+    },
+    "CompositeTypeName": {
+      "description": "The name of a Composite Type, as it appears in the NDC schema",
+      "type": "string"
+    },
+    "Nullable2": {
+      "description": "Can this column contain null values",
+      "type": "string",
+      "enum": [
+        "nullable",
+        "nonNullable"
+      ]
+    },
+    "HasDefault2": {
+      "description": "Does this column have a default value.",
+      "type": "string",
+      "enum": [
+        "noDefault",
+        "hasDefault"
+      ]
+    },
+    "IsIdentity2": {
+      "description": "Is this column an identity column.",
+      "type": "string",
+      "enum": [
+        "notIdentity",
+        "identityByDefault",
+        "identityAlways"
+      ]
+    },
+    "IsGenerated2": {
+      "description": "Is this column a generated column.",
+      "type": "string",
+      "enum": [
+        "notGenerated",
+        "stored"
+      ]
+    },
+    "UniquenessConstraints2": {
+      "description": "A mapping from the name of a unique constraint to its value.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/components/schemas/UniquenessConstraint2"
+      }
+    },
+    "UniquenessConstraint2": {
+      "description": "The set of columns that make up a uniqueness constraint.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "ForeignRelations2": {
+      "description": "A mapping from the name of a foreign key constraint to its value.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/components/schemas/ForeignRelation2"
+      }
+    },
+    "ForeignRelation2": {
+      "description": "A foreign key constraint.",
+      "type": "object",
+      "required": [
+        "columnMapping",
+        "foreignTable"
+      ],
+      "properties": {
+        "foreignSchema": {
+          "type": "string",
+          "nullable": true
+        },
+        "foreignTable": {
+          "type": "string"
+        },
+        "columnMapping": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ScalarTypes": {
+      "description": "Map of all known/occurring scalar types.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/components/schemas/ScalarType2"
+      }
+    },
+    "ScalarType2": {
+      "description": "Information about a scalar type. A scalar type is completely characterized by its name and the operations you can do on it.",
+      "type": "object",
+      "required": [
+        "aggregateFunctions",
+        "comparisonOperators",
+        "schemaName",
+        "typeName"
+      ],
+      "properties": {
+        "typeName": {
+          "type": "string"
+        },
+        "schemaName": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string",
+          "nullable": true
+        },
+        "aggregateFunctions": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/components/schemas/AggregateFunction2"
+          }
+        },
+        "comparisonOperators": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/components/schemas/ComparisonOperator2"
+          }
+        },
+        "typeRepresentation": {
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/TypeRepresentation2"
+            }
+          ],
+          "nullable": true
+        }
+      }
+    },
+    "AggregateFunction2": {
+      "type": "object",
+      "required": [
+        "returnType"
+      ],
+      "properties": {
+        "returnType": {
+          "$ref": "#/components/schemas/ScalarTypeName"
+        }
+      }
+    },
+    "ComparisonOperator2": {
+      "description": "Represents a postgres binary comparison operator",
+      "type": "object",
+      "required": [
+        "argumentType",
+        "operatorKind",
+        "operatorName"
+      ],
+      "properties": {
+        "operatorName": {
+          "type": "string"
+        },
+        "operatorKind": {
+          "$ref": "#/components/schemas/OperatorKind2"
+        },
+        "argumentType": {
+          "$ref": "#/components/schemas/ScalarTypeName"
+        },
+        "isInfix": {
+          "default": true,
+          "type": "boolean"
+        }
+      }
+    },
+    "OperatorKind2": {
+      "description": "Is it a built-in operator, or a custom operator.",
+      "type": "string",
+      "enum": [
+        "equal",
+        "in",
+        "custom"
+      ]
+    },
+    "TypeRepresentation2": {
+      "description": "Type representation of a scalar type.",
+      "oneOf": [
+        {
+          "description": "JSON booleans",
+          "type": "string",
+          "enum": [
+            "boolean"
+          ]
+        },
+        {
+          "description": "Any JSON string",
+          "type": "string",
+          "enum": [
+            "string"
+          ]
+        },
+        {
+          "description": "float4",
+          "type": "string",
+          "enum": [
+            "float32"
+          ]
+        },
+        {
+          "description": "float8",
+          "type": "string",
+          "enum": [
+            "float64"
+          ]
+        },
+        {
+          "description": "int2",
+          "type": "string",
+          "enum": [
+            "int16"
+          ]
+        },
+        {
+          "description": "int4",
+          "type": "string",
+          "enum": [
+            "int32"
+          ]
+        },
+        {
+          "description": "int8 as integer",
+          "type": "string",
+          "enum": [
+            "int64"
+          ]
+        },
+        {
+          "description": "int8 as string",
+          "type": "string",
+          "enum": [
+            "int64AsString"
+          ]
+        },
+        {
+          "description": "numeric",
+          "type": "string",
+          "enum": [
+            "bigDecimal"
+          ]
+        },
+        {
+          "description": "numeric as string",
+          "type": "string",
+          "enum": [
+            "bigDecimalAsString"
+          ]
+        },
+        {
+          "description": "timestamp",
+          "type": "string",
+          "enum": [
+            "timestamp"
+          ]
+        },
+        {
+          "description": "timestamp with timezone",
+          "type": "string",
+          "enum": [
+            "timestamptz"
+          ]
+        },
+        {
+          "description": "time",
+          "type": "string",
+          "enum": [
+            "time"
+          ]
+        },
+        {
+          "description": "time with timezone",
+          "type": "string",
+          "enum": [
+            "timetz"
+          ]
+        },
+        {
+          "description": "date",
+          "type": "string",
+          "enum": [
+            "date"
+          ]
+        },
+        {
+          "description": "uuid",
+          "type": "string",
+          "enum": [
+            "uUID"
+          ]
+        },
+        {
+          "description": "geography",
+          "type": "string",
+          "enum": [
+            "geography"
+          ]
+        },
+        {
+          "description": "geometry",
+          "type": "string",
+          "enum": [
+            "geometry"
+          ]
+        },
+        {
+          "description": "Any JSON number",
+          "type": "string",
+          "enum": [
+            "number"
+          ]
+        },
+        {
+          "description": "Any JSON number, with no decimal part",
+          "type": "string",
+          "enum": [
+            "integer"
+          ]
+        },
+        {
+          "description": "An arbitrary json.",
+          "type": "string",
+          "enum": [
+            "json"
+          ]
+        },
+        {
+          "description": "One of the specified string values",
+          "type": "object",
+          "required": [
+            "enum"
+          ],
+          "properties": {
+            "enum": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "CompositeTypes2": {
+      "description": "Map of all known composite types.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/components/schemas/CompositeType2"
+      }
+    },
+    "CompositeType2": {
+      "description": "Information about a composite type. These are very similar to tables, but with the crucial difference that composite types do not support constraints (such as NOT NULL).",
+      "type": "object",
+      "required": [
+        "fields",
+        "schemaName",
+        "typeName"
+      ],
+      "properties": {
+        "typeName": {
+          "type": "string"
+        },
+        "schemaName": {
+          "type": "string"
+        },
+        "fields": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/components/schemas/FieldInfo2"
+          }
+        },
+        "description": {
+          "default": null,
+          "type": "string",
+          "nullable": true
+        }
+      }
+    },
+    "FieldInfo2": {
+      "description": "Information about a composite type field.",
+      "type": "object",
+      "required": [
+        "fieldName",
+        "type"
+      ],
+      "properties": {
+        "fieldName": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/components/schemas/Type2"
+        },
+        "description": {
+          "default": null,
+          "type": "string",
+          "nullable": true
+        }
+      }
+    },
+    "NativeQueries2": {
+      "description": "Metadata information of native queries.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/components/schemas/NativeQueryInfo2"
+      }
+    },
+    "NativeQueryInfo2": {
+      "description": "Information about a Native Query",
+      "type": "object",
+      "required": [
+        "columns",
+        "sql"
+      ],
+      "properties": {
+        "sql": {
+          "description": "SQL expression to use for the Native Query. We can interpolate values using `{{variable_name}}` syntax, such as `SELECT * FROM authors WHERE name = {{author_name}}`",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/NativeQuerySql"
+            }
+          ]
+        },
+        "columns": {
+          "description": "Columns returned by the Native Query",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/components/schemas/ReadOnlyColumnInfo2"
+          }
+        },
+        "arguments": {
+          "description": "Names and types of arguments that can be passed to this Native Query",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/components/schemas/ReadOnlyColumnInfo2"
+          }
+        },
+        "description": {
+          "default": null,
+          "type": "string",
+          "nullable": true
+        },
+        "isProcedure": {
+          "description": "True if this native query mutates the database",
+          "type": "boolean"
+        }
+      }
+    },
+    "ReadOnlyColumnInfo2": {
+      "description": "Information about a native query column.",
+      "type": "object",
+      "required": [
+        "name",
+        "type"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/components/schemas/Type2"
+        },
+        "nullable": {
+          "default": "nullable",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Nullable2"
+            }
+          ]
+        },
+        "description": {
+          "default": null,
+          "type": "string",
+          "nullable": true
+        }
+      }
+    },
+    "IntrospectionOptions2": {
+      "description": "Options which only influence how the configuration is updated.",
+      "type": "object",
+      "properties": {
+        "excludedSchemas": {
+          "description": "Schemas which are excluded from introspection. The default setting will exclude the internal schemas of Postgres, Citus, Cockroach, and the PostGIS extension.",
+          "default": [
+            "information_schema",
+            "pg_catalog",
+            "tiger",
+            "crdb_internal",
+            "columnar",
+            "columnar_internal"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "unqualifiedSchemasForTables": {
+          "description": "The names of Tables and Views in these schemas will be returned unqualified. The default setting will set the `public` schema as unqualified.",
+          "default": [
+            "public"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "unqualifiedSchemasForTypesAndProcedures": {
+          "description": "The types and procedures in these schemas will be returned unqualified.",
+          "default": [
+            "public",
+            "pg_catalog",
+            "tiger"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "comparisonOperatorMapping": {
+          "description": "The mapping of comparison operator names to apply when updating the configuration",
+          "default": [
+            {
+              "operatorName": "=",
+              "exposedName": "_eq",
+              "operatorKind": "equal"
+            },
+            {
+              "operatorName": "<=",
+              "exposedName": "_lte",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": ">",
+              "exposedName": "_gt",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": ">=",
+              "exposedName": "_gte",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "<",
+              "exposedName": "_lt",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "!=",
+              "exposedName": "_neq",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "LIKE",
+              "exposedName": "_like",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "NOT LIKE",
+              "exposedName": "_nlike",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "ILIKE",
+              "exposedName": "_ilike",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "NOT ILIKE",
+              "exposedName": "_nilike",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "SIMILAR TO",
+              "exposedName": "_similar",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "NOT SIMILAR TO",
+              "exposedName": "_nsimilar",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "<>",
+              "exposedName": "_neq",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "~~",
+              "exposedName": "_like",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "!~~",
+              "exposedName": "_nlike",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "~~*",
+              "exposedName": "_ilike",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "!~~*",
+              "exposedName": "_nilike",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "~",
+              "exposedName": "_regex",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "!~",
+              "exposedName": "_nregex",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "~*",
+              "exposedName": "_iregex",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "!~*",
+              "exposedName": "_niregex",
+              "operatorKind": "custom"
+            }
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/ComparisonOperatorMapping2"
+          }
+        },
+        "introspectPrefixFunctionComparisonOperators": {
+          "description": "Which prefix functions (i.e., non-infix operators) to generate introspection metadata for.\n\nThis list will accept any boolean-returning function taking two concrete scalar types as arguments.\n\nThe default includes comparisons for various build-in types as well as those of PostGIS.",
+          "default": [
+            "box_above",
+            "box_below",
+            "box_contain",
+            "box_contain_pt",
+            "box_contained",
+            "box_left",
+            "box_overabove",
+            "box_overbelow",
+            "box_overlap",
+            "box_overleft",
+            "box_overright",
+            "box_right",
+            "box_same",
+            "circle_above",
+            "circle_below",
+            "circle_contain",
+            "circle_contain_pt",
+            "circle_contained",
+            "circle_left",
+            "circle_overabove",
+            "circle_overbelow",
+            "circle_overlap",
+            "circle_overleft",
+            "circle_overright",
+            "circle_right",
+            "circle_same",
+            "contains_2d",
+            "equals",
+            "geography_overlaps",
+            "geometry_above",
+            "geometry_below",
+            "geometry_contained_3d",
+            "geometry_contains",
+            "geometry_contains_3d",
+            "geometry_contains_nd",
+            "geometry_left",
+            "geometry_overabove",
+            "geometry_overbelow",
+            "geometry_overlaps",
+            "geometry_overlaps_3d",
+            "geometry_overlaps_nd",
+            "geometry_overleft",
+            "geometry_overright",
+            "geometry_right",
+            "geometry_same",
+            "geometry_same_3d",
+            "geometry_same_nd",
+            "geometry_within",
+            "geometry_within_nd",
+            "inet_same_family",
+            "inter_lb",
+            "inter_sb",
+            "inter_sl",
+            "is_contained_2d",
+            "ishorizontal",
+            "isparallel",
+            "isperp",
+            "isvertical",
+            "jsonb_contained",
+            "jsonb_contains",
+            "jsonb_exists",
+            "jsonb_path_exists_opr",
+            "jsonb_path_match_opr",
+            "line_intersect",
+            "line_parallel",
+            "line_perp",
+            "lseg_intersect",
+            "lseg_parallel",
+            "lseg_perp",
+            "network_overlap",
+            "network_sub",
+            "network_sup",
+            "on_pb",
+            "on_pl",
+            "on_ppath",
+            "on_ps",
+            "on_sb",
+            "on_sl",
+            "overlaps_2d",
+            "path_contain_pt",
+            "path_inter",
+            "point_above",
+            "point_below",
+            "point_horiz",
+            "point_left",
+            "point_right",
+            "point_vert",
+            "poly_above",
+            "poly_below",
+            "poly_contain",
+            "poly_contain_pt",
+            "poly_contained",
+            "poly_left",
+            "poly_overabove",
+            "poly_overbelow",
+            "poly_overlap",
+            "poly_overleft",
+            "poly_overright",
+            "poly_right",
+            "poly_same",
+            "pt_contained_poly",
+            "st_3dintersects",
+            "st_contains",
+            "st_containsproperly",
+            "st_coveredby",
+            "st_covers",
+            "st_crosses",
+            "st_disjoint",
+            "st_equals",
+            "st_intersects",
+            "st_isvalid",
+            "st_orderingequals",
+            "st_overlaps",
+            "st_relatematch",
+            "st_touches",
+            "st_within",
+            "starts_with",
+            "ts_match_qv",
+            "ts_match_tq",
+            "ts_match_tt",
+            "ts_match_vq",
+            "tsq_mcontained",
+            "tsq_mcontains",
+            "xmlexists",
+            "xmlvalidate",
+            "xpath_exists"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ComparisonOperatorMapping2": {
+      "description": "Define the names that comparison operators will be exposed as by the automatic introspection.",
+      "type": "object",
+      "required": [
+        "exposedName",
+        "operatorKind",
+        "operatorName"
+      ],
+      "properties": {
+        "operatorName": {
+          "description": "The name of the operator as defined by the database",
+          "type": "string"
+        },
+        "exposedName": {
+          "description": "The name the operator will appear under in the exposed API",
+          "type": "string"
+        },
+        "operatorKind": {
+          "description": "Equal, In or Custom.",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/OperatorKind2"
+            }
+          ]
+        }
+      }
+    },
+    "MutationsVersion2": {
       "description": "Which version of the generated mutations will be included in the schema",
       "type": "string",
       "enum": [

--- a/crates/tests/tests-common/src/ndc_metadata/configuration.rs
+++ b/crates/tests/tests-common/src/ndc_metadata/configuration.rs
@@ -86,5 +86,9 @@ fn set_connection_uri(input: RawConfiguration, connection_uri: String) -> RawCon
             config.connection_settings.connection_uri = connection_uri.into();
             RawConfiguration::Version3(config)
         }
+        RawConfiguration::Version4(mut config) => {
+            config.connection_settings.connection_uri = connection_uri.into();
+            RawConfiguration::Version4(config)
+        }
     }
 }

--- a/static/schema.json
+++ b/static/schema.json
@@ -315,6 +315,315 @@
           ]
         }
       }
+    },
+    {
+      "description": "Initial configuration, just enough to connect to a database and elaborate a full 'Configuration'.",
+      "type": "object",
+      "required": ["connectionSettings", "version"],
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": ["4"]
+        },
+        "$schema": {
+          "description": "Jsonschema of the configuration format.",
+          "default": null,
+          "type": ["string", "null"]
+        },
+        "connectionSettings": {
+          "description": "Database connection settings.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DatabaseConnectionSettings2"
+            }
+          ]
+        },
+        "metadata": {
+          "description": "Connector metadata.",
+          "default": {
+            "tables": {},
+            "scalarTypes": {},
+            "compositeTypes": {},
+            "nativeQueries": {}
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Metadata2"
+            }
+          ]
+        },
+        "introspectionOptions": {
+          "description": "Database introspection options.",
+          "default": {
+            "excludedSchemas": [
+              "information_schema",
+              "pg_catalog",
+              "tiger",
+              "crdb_internal",
+              "columnar",
+              "columnar_internal"
+            ],
+            "unqualifiedSchemasForTables": ["public"],
+            "unqualifiedSchemasForTypesAndProcedures": [
+              "public",
+              "pg_catalog",
+              "tiger"
+            ],
+            "comparisonOperatorMapping": [
+              {
+                "operatorName": "=",
+                "exposedName": "_eq",
+                "operatorKind": "equal"
+              },
+              {
+                "operatorName": "<=",
+                "exposedName": "_lte",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": ">",
+                "exposedName": "_gt",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": ">=",
+                "exposedName": "_gte",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "<",
+                "exposedName": "_lt",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "!=",
+                "exposedName": "_neq",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "LIKE",
+                "exposedName": "_like",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "NOT LIKE",
+                "exposedName": "_nlike",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "ILIKE",
+                "exposedName": "_ilike",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "NOT ILIKE",
+                "exposedName": "_nilike",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "SIMILAR TO",
+                "exposedName": "_similar",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "NOT SIMILAR TO",
+                "exposedName": "_nsimilar",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "<>",
+                "exposedName": "_neq",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "~~",
+                "exposedName": "_like",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "!~~",
+                "exposedName": "_nlike",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "~~*",
+                "exposedName": "_ilike",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "!~~*",
+                "exposedName": "_nilike",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "~",
+                "exposedName": "_regex",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "!~",
+                "exposedName": "_nregex",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "~*",
+                "exposedName": "_iregex",
+                "operatorKind": "custom"
+              },
+              {
+                "operatorName": "!~*",
+                "exposedName": "_niregex",
+                "operatorKind": "custom"
+              }
+            ],
+            "introspectPrefixFunctionComparisonOperators": [
+              "box_above",
+              "box_below",
+              "box_contain",
+              "box_contain_pt",
+              "box_contained",
+              "box_left",
+              "box_overabove",
+              "box_overbelow",
+              "box_overlap",
+              "box_overleft",
+              "box_overright",
+              "box_right",
+              "box_same",
+              "circle_above",
+              "circle_below",
+              "circle_contain",
+              "circle_contain_pt",
+              "circle_contained",
+              "circle_left",
+              "circle_overabove",
+              "circle_overbelow",
+              "circle_overlap",
+              "circle_overleft",
+              "circle_overright",
+              "circle_right",
+              "circle_same",
+              "contains_2d",
+              "equals",
+              "geography_overlaps",
+              "geometry_above",
+              "geometry_below",
+              "geometry_contained_3d",
+              "geometry_contains",
+              "geometry_contains_3d",
+              "geometry_contains_nd",
+              "geometry_left",
+              "geometry_overabove",
+              "geometry_overbelow",
+              "geometry_overlaps",
+              "geometry_overlaps_3d",
+              "geometry_overlaps_nd",
+              "geometry_overleft",
+              "geometry_overright",
+              "geometry_right",
+              "geometry_same",
+              "geometry_same_3d",
+              "geometry_same_nd",
+              "geometry_within",
+              "geometry_within_nd",
+              "inet_same_family",
+              "inter_lb",
+              "inter_sb",
+              "inter_sl",
+              "is_contained_2d",
+              "ishorizontal",
+              "isparallel",
+              "isperp",
+              "isvertical",
+              "jsonb_contained",
+              "jsonb_contains",
+              "jsonb_exists",
+              "jsonb_path_exists_opr",
+              "jsonb_path_match_opr",
+              "line_intersect",
+              "line_parallel",
+              "line_perp",
+              "lseg_intersect",
+              "lseg_parallel",
+              "lseg_perp",
+              "network_overlap",
+              "network_sub",
+              "network_sup",
+              "on_pb",
+              "on_pl",
+              "on_ppath",
+              "on_ps",
+              "on_sb",
+              "on_sl",
+              "overlaps_2d",
+              "path_contain_pt",
+              "path_inter",
+              "point_above",
+              "point_below",
+              "point_horiz",
+              "point_left",
+              "point_right",
+              "point_vert",
+              "poly_above",
+              "poly_below",
+              "poly_contain",
+              "poly_contain_pt",
+              "poly_contained",
+              "poly_left",
+              "poly_overabove",
+              "poly_overbelow",
+              "poly_overlap",
+              "poly_overleft",
+              "poly_overright",
+              "poly_right",
+              "poly_same",
+              "pt_contained_poly",
+              "st_3dintersects",
+              "st_contains",
+              "st_containsproperly",
+              "st_coveredby",
+              "st_covers",
+              "st_crosses",
+              "st_disjoint",
+              "st_equals",
+              "st_intersects",
+              "st_isvalid",
+              "st_orderingequals",
+              "st_overlaps",
+              "st_relatematch",
+              "st_touches",
+              "st_within",
+              "starts_with",
+              "ts_match_qv",
+              "ts_match_tq",
+              "ts_match_tt",
+              "ts_match_vq",
+              "tsq_mcontained",
+              "tsq_mcontains",
+              "xmlexists",
+              "xmlvalidate",
+              "xpath_exists"
+            ]
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/IntrospectionOptions2"
+            }
+          ]
+        },
+        "mutationsVersion": {
+          "description": "Which version of the generated mutation procedures to include in the schema response",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MutationsVersion2"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
     }
   ],
   "definitions": {
@@ -1313,6 +1622,905 @@
       }
     },
     "MutationsVersion": {
+      "description": "Which version of the generated mutations will be included in the schema",
+      "type": "string",
+      "enum": ["v1", "veryExperimentalWip"]
+    },
+    "DatabaseConnectionSettings2": {
+      "description": "Database connection settings.",
+      "type": "object",
+      "required": ["connectionUri"],
+      "properties": {
+        "connectionUri": {
+          "description": "Connection string for a Postgres-compatible database.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConnectionUri"
+            }
+          ]
+        },
+        "poolSettings": {
+          "description": "Connection pool settings.",
+          "default": {
+            "maxConnections": 50,
+            "poolTimeout": 30,
+            "idleTimeout": 180,
+            "connectionLifetime": 600
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/PoolSettings"
+            }
+          ]
+        },
+        "isolationLevel": {
+          "description": "Query isolation level.",
+          "default": "ReadCommitted",
+          "allOf": [
+            {
+              "$ref": "#/definitions/IsolationLevel"
+            }
+          ]
+        }
+      }
+    },
+    "Metadata2": {
+      "description": "Metadata information.",
+      "type": "object",
+      "properties": {
+        "tables": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/TablesInfo2"
+            }
+          ]
+        },
+        "scalarTypes": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/ScalarTypes"
+            }
+          ]
+        },
+        "compositeTypes": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/CompositeTypes2"
+            }
+          ]
+        },
+        "nativeQueries": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/NativeQueries2"
+            }
+          ]
+        }
+      }
+    },
+    "TablesInfo2": {
+      "description": "Mapping from a \"table\" name to its information.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/TableInfo2"
+      }
+    },
+    "TableInfo2": {
+      "description": "Information about a database table (or any other kind of relation).",
+      "type": "object",
+      "required": ["columns", "schemaName", "tableName"],
+      "properties": {
+        "schemaName": {
+          "type": "string"
+        },
+        "tableName": {
+          "type": "string"
+        },
+        "columns": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ColumnInfo2"
+          }
+        },
+        "uniquenessConstraints": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/UniquenessConstraints2"
+            }
+          ]
+        },
+        "foreignRelations": {
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/ForeignRelations2"
+            }
+          ]
+        },
+        "description": {
+          "default": null,
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "ColumnInfo2": {
+      "description": "Information about a database column.",
+      "type": "object",
+      "required": ["name", "type"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/Type2"
+        },
+        "nullable": {
+          "default": "nullable",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Nullable2"
+            }
+          ]
+        },
+        "hasDefault": {
+          "$ref": "#/definitions/HasDefault2"
+        },
+        "isIdentity": {
+          "$ref": "#/definitions/IsIdentity2"
+        },
+        "isGenerated": {
+          "$ref": "#/definitions/IsGenerated2"
+        },
+        "description": {
+          "default": null,
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "Type2": {
+      "description": "The type of values that a column, field, or argument may take.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["scalarType"],
+          "properties": {
+            "scalarType": {
+              "$ref": "#/definitions/ScalarTypeName"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": ["compositeType"],
+          "properties": {
+            "compositeType": {
+              "$ref": "#/definitions/CompositeTypeName"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": ["arrayType"],
+          "properties": {
+            "arrayType": {
+              "$ref": "#/definitions/Type2"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "ScalarTypeName": {
+      "description": "A name of a Scalar Type, as it appears in the NDC scheme.",
+      "type": "string"
+    },
+    "CompositeTypeName": {
+      "description": "The name of a Composite Type, as it appears in the NDC schema",
+      "type": "string"
+    },
+    "Nullable2": {
+      "description": "Can this column contain null values",
+      "type": "string",
+      "enum": ["nullable", "nonNullable"]
+    },
+    "HasDefault2": {
+      "description": "Does this column have a default value.",
+      "type": "string",
+      "enum": ["noDefault", "hasDefault"]
+    },
+    "IsIdentity2": {
+      "description": "Is this column an identity column.",
+      "type": "string",
+      "enum": ["notIdentity", "identityByDefault", "identityAlways"]
+    },
+    "IsGenerated2": {
+      "description": "Is this column a generated column.",
+      "type": "string",
+      "enum": ["notGenerated", "stored"]
+    },
+    "UniquenessConstraints2": {
+      "description": "A mapping from the name of a unique constraint to its value.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/UniquenessConstraint2"
+      }
+    },
+    "UniquenessConstraint2": {
+      "description": "The set of columns that make up a uniqueness constraint.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "ForeignRelations2": {
+      "description": "A mapping from the name of a foreign key constraint to its value.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/ForeignRelation2"
+      }
+    },
+    "ForeignRelation2": {
+      "description": "A foreign key constraint.",
+      "type": "object",
+      "required": ["columnMapping", "foreignTable"],
+      "properties": {
+        "foreignSchema": {
+          "type": ["string", "null"]
+        },
+        "foreignTable": {
+          "type": "string"
+        },
+        "columnMapping": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ScalarTypes": {
+      "description": "Map of all known/occurring scalar types.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/ScalarType2"
+      }
+    },
+    "ScalarType2": {
+      "description": "Information about a scalar type. A scalar type is completely characterized by its name and the operations you can do on it.",
+      "type": "object",
+      "required": [
+        "aggregateFunctions",
+        "comparisonOperators",
+        "schemaName",
+        "typeName"
+      ],
+      "properties": {
+        "typeName": {
+          "type": "string"
+        },
+        "schemaName": {
+          "type": "string"
+        },
+        "description": {
+          "type": ["string", "null"]
+        },
+        "aggregateFunctions": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/AggregateFunction2"
+          }
+        },
+        "comparisonOperators": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ComparisonOperator2"
+          }
+        },
+        "typeRepresentation": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TypeRepresentation2"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "AggregateFunction2": {
+      "type": "object",
+      "required": ["returnType"],
+      "properties": {
+        "returnType": {
+          "$ref": "#/definitions/ScalarTypeName"
+        }
+      }
+    },
+    "ComparisonOperator2": {
+      "description": "Represents a postgres binary comparison operator",
+      "type": "object",
+      "required": ["argumentType", "operatorKind", "operatorName"],
+      "properties": {
+        "operatorName": {
+          "type": "string"
+        },
+        "operatorKind": {
+          "$ref": "#/definitions/OperatorKind2"
+        },
+        "argumentType": {
+          "$ref": "#/definitions/ScalarTypeName"
+        },
+        "isInfix": {
+          "default": true,
+          "type": "boolean"
+        }
+      }
+    },
+    "OperatorKind2": {
+      "description": "Is it a built-in operator, or a custom operator.",
+      "type": "string",
+      "enum": ["equal", "in", "custom"]
+    },
+    "TypeRepresentation2": {
+      "description": "Type representation of a scalar type.",
+      "oneOf": [
+        {
+          "description": "JSON booleans",
+          "type": "string",
+          "enum": ["boolean"]
+        },
+        {
+          "description": "Any JSON string",
+          "type": "string",
+          "enum": ["string"]
+        },
+        {
+          "description": "float4",
+          "type": "string",
+          "enum": ["float32"]
+        },
+        {
+          "description": "float8",
+          "type": "string",
+          "enum": ["float64"]
+        },
+        {
+          "description": "int2",
+          "type": "string",
+          "enum": ["int16"]
+        },
+        {
+          "description": "int4",
+          "type": "string",
+          "enum": ["int32"]
+        },
+        {
+          "description": "int8 as integer",
+          "type": "string",
+          "enum": ["int64"]
+        },
+        {
+          "description": "int8 as string",
+          "type": "string",
+          "enum": ["int64AsString"]
+        },
+        {
+          "description": "numeric",
+          "type": "string",
+          "enum": ["bigDecimal"]
+        },
+        {
+          "description": "numeric as string",
+          "type": "string",
+          "enum": ["bigDecimalAsString"]
+        },
+        {
+          "description": "timestamp",
+          "type": "string",
+          "enum": ["timestamp"]
+        },
+        {
+          "description": "timestamp with timezone",
+          "type": "string",
+          "enum": ["timestamptz"]
+        },
+        {
+          "description": "time",
+          "type": "string",
+          "enum": ["time"]
+        },
+        {
+          "description": "time with timezone",
+          "type": "string",
+          "enum": ["timetz"]
+        },
+        {
+          "description": "date",
+          "type": "string",
+          "enum": ["date"]
+        },
+        {
+          "description": "uuid",
+          "type": "string",
+          "enum": ["uUID"]
+        },
+        {
+          "description": "geography",
+          "type": "string",
+          "enum": ["geography"]
+        },
+        {
+          "description": "geometry",
+          "type": "string",
+          "enum": ["geometry"]
+        },
+        {
+          "description": "Any JSON number",
+          "type": "string",
+          "enum": ["number"]
+        },
+        {
+          "description": "Any JSON number, with no decimal part",
+          "type": "string",
+          "enum": ["integer"]
+        },
+        {
+          "description": "An arbitrary json.",
+          "type": "string",
+          "enum": ["json"]
+        },
+        {
+          "description": "One of the specified string values",
+          "type": "object",
+          "required": ["enum"],
+          "properties": {
+            "enum": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "CompositeTypes2": {
+      "description": "Map of all known composite types.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/CompositeType2"
+      }
+    },
+    "CompositeType2": {
+      "description": "Information about a composite type. These are very similar to tables, but with the crucial difference that composite types do not support constraints (such as NOT NULL).",
+      "type": "object",
+      "required": ["fields", "schemaName", "typeName"],
+      "properties": {
+        "typeName": {
+          "type": "string"
+        },
+        "schemaName": {
+          "type": "string"
+        },
+        "fields": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/FieldInfo2"
+          }
+        },
+        "description": {
+          "default": null,
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "FieldInfo2": {
+      "description": "Information about a composite type field.",
+      "type": "object",
+      "required": ["fieldName", "type"],
+      "properties": {
+        "fieldName": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/Type2"
+        },
+        "description": {
+          "default": null,
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "NativeQueries2": {
+      "description": "Metadata information of native queries.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/NativeQueryInfo2"
+      }
+    },
+    "NativeQueryInfo2": {
+      "description": "Information about a Native Query",
+      "type": "object",
+      "required": ["columns", "sql"],
+      "properties": {
+        "sql": {
+          "description": "SQL expression to use for the Native Query. We can interpolate values using `{{variable_name}}` syntax, such as `SELECT * FROM authors WHERE name = {{author_name}}`",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NativeQuerySql"
+            }
+          ]
+        },
+        "columns": {
+          "description": "Columns returned by the Native Query",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ReadOnlyColumnInfo2"
+          }
+        },
+        "arguments": {
+          "description": "Names and types of arguments that can be passed to this Native Query",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ReadOnlyColumnInfo2"
+          }
+        },
+        "description": {
+          "default": null,
+          "type": ["string", "null"]
+        },
+        "isProcedure": {
+          "description": "True if this native query mutates the database",
+          "type": "boolean"
+        }
+      }
+    },
+    "ReadOnlyColumnInfo2": {
+      "description": "Information about a native query column.",
+      "type": "object",
+      "required": ["name", "type"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/Type2"
+        },
+        "nullable": {
+          "default": "nullable",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Nullable2"
+            }
+          ]
+        },
+        "description": {
+          "default": null,
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "IntrospectionOptions2": {
+      "description": "Options which only influence how the configuration is updated.",
+      "type": "object",
+      "properties": {
+        "excludedSchemas": {
+          "description": "Schemas which are excluded from introspection. The default setting will exclude the internal schemas of Postgres, Citus, Cockroach, and the PostGIS extension.",
+          "default": [
+            "information_schema",
+            "pg_catalog",
+            "tiger",
+            "crdb_internal",
+            "columnar",
+            "columnar_internal"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "unqualifiedSchemasForTables": {
+          "description": "The names of Tables and Views in these schemas will be returned unqualified. The default setting will set the `public` schema as unqualified.",
+          "default": ["public"],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "unqualifiedSchemasForTypesAndProcedures": {
+          "description": "The types and procedures in these schemas will be returned unqualified.",
+          "default": ["public", "pg_catalog", "tiger"],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "comparisonOperatorMapping": {
+          "description": "The mapping of comparison operator names to apply when updating the configuration",
+          "default": [
+            {
+              "operatorName": "=",
+              "exposedName": "_eq",
+              "operatorKind": "equal"
+            },
+            {
+              "operatorName": "<=",
+              "exposedName": "_lte",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": ">",
+              "exposedName": "_gt",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": ">=",
+              "exposedName": "_gte",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "<",
+              "exposedName": "_lt",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "!=",
+              "exposedName": "_neq",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "LIKE",
+              "exposedName": "_like",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "NOT LIKE",
+              "exposedName": "_nlike",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "ILIKE",
+              "exposedName": "_ilike",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "NOT ILIKE",
+              "exposedName": "_nilike",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "SIMILAR TO",
+              "exposedName": "_similar",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "NOT SIMILAR TO",
+              "exposedName": "_nsimilar",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "<>",
+              "exposedName": "_neq",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "~~",
+              "exposedName": "_like",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "!~~",
+              "exposedName": "_nlike",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "~~*",
+              "exposedName": "_ilike",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "!~~*",
+              "exposedName": "_nilike",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "~",
+              "exposedName": "_regex",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "!~",
+              "exposedName": "_nregex",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "~*",
+              "exposedName": "_iregex",
+              "operatorKind": "custom"
+            },
+            {
+              "operatorName": "!~*",
+              "exposedName": "_niregex",
+              "operatorKind": "custom"
+            }
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ComparisonOperatorMapping2"
+          }
+        },
+        "introspectPrefixFunctionComparisonOperators": {
+          "description": "Which prefix functions (i.e., non-infix operators) to generate introspection metadata for.\n\nThis list will accept any boolean-returning function taking two concrete scalar types as arguments.\n\nThe default includes comparisons for various build-in types as well as those of PostGIS.",
+          "default": [
+            "box_above",
+            "box_below",
+            "box_contain",
+            "box_contain_pt",
+            "box_contained",
+            "box_left",
+            "box_overabove",
+            "box_overbelow",
+            "box_overlap",
+            "box_overleft",
+            "box_overright",
+            "box_right",
+            "box_same",
+            "circle_above",
+            "circle_below",
+            "circle_contain",
+            "circle_contain_pt",
+            "circle_contained",
+            "circle_left",
+            "circle_overabove",
+            "circle_overbelow",
+            "circle_overlap",
+            "circle_overleft",
+            "circle_overright",
+            "circle_right",
+            "circle_same",
+            "contains_2d",
+            "equals",
+            "geography_overlaps",
+            "geometry_above",
+            "geometry_below",
+            "geometry_contained_3d",
+            "geometry_contains",
+            "geometry_contains_3d",
+            "geometry_contains_nd",
+            "geometry_left",
+            "geometry_overabove",
+            "geometry_overbelow",
+            "geometry_overlaps",
+            "geometry_overlaps_3d",
+            "geometry_overlaps_nd",
+            "geometry_overleft",
+            "geometry_overright",
+            "geometry_right",
+            "geometry_same",
+            "geometry_same_3d",
+            "geometry_same_nd",
+            "geometry_within",
+            "geometry_within_nd",
+            "inet_same_family",
+            "inter_lb",
+            "inter_sb",
+            "inter_sl",
+            "is_contained_2d",
+            "ishorizontal",
+            "isparallel",
+            "isperp",
+            "isvertical",
+            "jsonb_contained",
+            "jsonb_contains",
+            "jsonb_exists",
+            "jsonb_path_exists_opr",
+            "jsonb_path_match_opr",
+            "line_intersect",
+            "line_parallel",
+            "line_perp",
+            "lseg_intersect",
+            "lseg_parallel",
+            "lseg_perp",
+            "network_overlap",
+            "network_sub",
+            "network_sup",
+            "on_pb",
+            "on_pl",
+            "on_ppath",
+            "on_ps",
+            "on_sb",
+            "on_sl",
+            "overlaps_2d",
+            "path_contain_pt",
+            "path_inter",
+            "point_above",
+            "point_below",
+            "point_horiz",
+            "point_left",
+            "point_right",
+            "point_vert",
+            "poly_above",
+            "poly_below",
+            "poly_contain",
+            "poly_contain_pt",
+            "poly_contained",
+            "poly_left",
+            "poly_overabove",
+            "poly_overbelow",
+            "poly_overlap",
+            "poly_overleft",
+            "poly_overright",
+            "poly_right",
+            "poly_same",
+            "pt_contained_poly",
+            "st_3dintersects",
+            "st_contains",
+            "st_containsproperly",
+            "st_coveredby",
+            "st_covers",
+            "st_crosses",
+            "st_disjoint",
+            "st_equals",
+            "st_intersects",
+            "st_isvalid",
+            "st_orderingequals",
+            "st_overlaps",
+            "st_relatematch",
+            "st_touches",
+            "st_within",
+            "starts_with",
+            "ts_match_qv",
+            "ts_match_tq",
+            "ts_match_tt",
+            "ts_match_vq",
+            "tsq_mcontained",
+            "tsq_mcontains",
+            "xmlexists",
+            "xmlvalidate",
+            "xpath_exists"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ComparisonOperatorMapping2": {
+      "description": "Define the names that comparison operators will be exposed as by the automatic introspection.",
+      "type": "object",
+      "required": ["exposedName", "operatorKind", "operatorName"],
+      "properties": {
+        "operatorName": {
+          "description": "The name of the operator as defined by the database",
+          "type": "string"
+        },
+        "exposedName": {
+          "description": "The name the operator will appear under in the exposed API",
+          "type": "string"
+        },
+        "operatorKind": {
+          "description": "Equal, In or Custom.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OperatorKind2"
+            }
+          ]
+        }
+      }
+    },
+    "MutationsVersion2": {
       "description": "Which version of the generated mutations will be included in the schema",
       "type": "string",
       "enum": ["v1", "veryExperimentalWip"]


### PR DESCRIPTION
### What

This PR introduces the ability to refer to scalar types and complex types by a separate name in the ndc schema. This name is formed taking into account the schema the type is defined in, in the same manner as we treat tables.

The implementation is limited so far as it only includes the parsing of this format and not its construction (though doing so for testing is as simple as changing the default empty RawConfiguration value).

The reason for this is that this is already a sizable PR, so it would be good to review and integrate before it includes CLI support and upgrading of tests.
 
### How

While this sounds innocuous it actually introduces an extra level of indirection. We used to only refer to scalar types by their unqualified name in both SQL generation and NDC schema. Now we record the defined name and schema of a type and derive a new name based off these which we use to refer to the type everywhere in the generated schema.

A knock-on effect of this is that it is now more appropriate to produce a dedicated "ScalarTypes" object in introspection that includes both name data and aggregation functions and comparison operators for scalar types in nested objects. This actually simplifies the business logic of the dataconnecter itself somewhat as well, since this new structure has the same shape as the schema-response.