### PR TITLE
ScalarTypeName ast: use enums instead of flags

### DIFF
--- a/crates/query-engine/sql/src/sql/ast.rs
+++ b/crates/query-engine/sql/src/sql/ast.rs
@@ -103,7 +103,7 @@ pub enum From {
     JsonbToRecordset {
         expression: Expression,
         alias: TableAlias,
-        columns: Vec<(ColumnAlias, ScalarTypeName)>,
+        columns: Vec<(ColumnAlias, ScalarType)>,
     },
     JsonbArrayElements {
         expression: Expression,
@@ -241,7 +241,7 @@ pub enum Expression {
     Value(Value),
     Cast {
         expression: Box<Expression>,
-        r#type: ScalarTypeName,
+        r#type: ScalarType,
     },
     /// A COUNT clause
     Count(CountType),
@@ -305,28 +305,28 @@ pub enum Value {
 /// This has a few quirks:
 ///
 /// * Array types need to be quoted as `"type name"[]` and _not_ `"type name[]"`. Therefore we
-/// track whether a scalar type is supposed to be an array with the separate field `is_array`.
+/// track whether a scalar type is supposed to be an array.
 ///
 /// * Quoting of type name identifiers is only supported for the actual type names recorded in
 /// `pg_type`, and _not_ the SQL standard type names. This means that `character varying` is an
 /// acceptable type name, but `"character varying"` is _not_ (Unless of course you do `CREATE TYPE
 /// "character varying" AS (..)`. Spicy).
-///
 #[derive(Debug, Clone, PartialEq)]
-pub struct ScalarTypeName {
-    pub type_name: String,
-    pub schema_name: Option<SchemaName>,
-    pub is_array: bool,
+pub enum ScalarType {
+    BaseType(ScalarTypeName),
+    ArrayType(ScalarTypeName),
 }
 
-impl ScalarTypeName {
-    pub fn new_unqualified(type_name: &str) -> Self {
-        ScalarTypeName {
-            schema_name: None,
-            type_name: type_name.to_string(),
-            is_array: false,
-        }
-    }
+/// Scalar type name. This will always be output as a quoted identifier.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ScalarTypeName {
+    /// A type name referencing a schema.
+    Qualified {
+        schema_name: SchemaName,
+        type_name: String,
+    },
+    /// A type name without a schema.
+    Unqualified(String),
 }
 
 /// A database schema name

--- a/crates/query-engine/sql/src/sql/convert.rs
+++ b/crates/query-engine/sql/src/sql/convert.rs
@@ -530,19 +530,35 @@ impl Value {
     }
 }
 
+impl ScalarType {
+    pub fn to_sql(&self, sql: &mut SQL) {
+        match &self {
+            ScalarType::BaseType(scalar_type_name) => {
+                scalar_type_name.to_sql(sql);
+            }
+            ScalarType::ArrayType(scalar_type_name) => {
+                scalar_type_name.to_sql(sql);
+                sql.append_syntax("[]");
+            }
+        };
+    }
+}
+
 impl ScalarTypeName {
     pub fn to_sql(&self, sql: &mut SQL) {
-        match &self.schema_name {
-            Some(schema_name) => {
+        match &self {
+            ScalarTypeName::Qualified {
+                schema_name,
+                type_name,
+            } => {
                 sql.append_identifier(&schema_name.0);
                 sql.append_syntax(".");
+                sql.append_identifier(type_name);
             }
-            None => (),
+            ScalarTypeName::Unqualified(type_name) => {
+                sql.append_identifier(type_name);
+            }
         };
-        sql.append_identifier(&self.type_name);
-        if self.is_array {
-            sql.append_syntax("[]");
-        }
     }
 }
 

--- a/crates/query-engine/sql/src/sql/helpers.rs
+++ b/crates/query-engine/sql/src/sql/helpers.rs
@@ -624,15 +624,12 @@ pub fn select_row_as_json_with_default(
 /// ```
 pub fn from_variables(alias: TableAlias) -> From {
     let expression = Expression::Value(Value::Variable(VARIABLES_OBJECT_PLACEHOLDER.to_string()));
-    let columns: Vec<(ColumnAlias, ScalarTypeName)> = vec![
+    let columns: Vec<(ColumnAlias, ScalarType)> = vec![
         (
             make_column_alias(VARIABLE_ORDER_FIELD.to_string()),
-            ScalarTypeName::new_unqualified("int4"),
+            int4_type(),
         ),
-        (
-            make_column_alias(VARIABLES_FIELD.to_string()),
-            ScalarTypeName::new_unqualified("jsonb"),
-        ),
+        (make_column_alias(VARIABLES_FIELD.to_string()), jsonb_type()),
     ];
 
     From::JsonbToRecordset {
@@ -693,4 +690,21 @@ pub fn transaction_rollback() -> string::Statement {
     let mut sql = string::SQL::new();
     transaction::Rollback {}.to_sql(&mut sql);
     string::Statement(sql)
+}
+
+// Types //
+
+/// An unqualified scalar type representing int4.
+pub fn int4_type() -> ScalarType {
+    ScalarType::BaseType(ScalarTypeName::Unqualified("int4".to_string()))
+}
+
+/// An unqualified scalar type representing jsonb.
+pub fn jsonb_type() -> ScalarType {
+    ScalarType::BaseType(ScalarTypeName::Unqualified("jsonb".to_string()))
+}
+
+/// An unqualified scalar type name representing text.
+pub fn text_type_name() -> ScalarTypeName {
+    ScalarTypeName::Unqualified("text".to_string())
 }

--- a/crates/query-engine/translation/src/translation/error.rs
+++ b/crates/query-engine/translation/src/translation/error.rs
@@ -31,6 +31,7 @@ pub enum Error {
     NoProcedureResultFieldsRequested,
     UnexpectedStructure(String),
     InternalError(String),
+    NestedArrayTypesNotSupported,
     NestedArraysNotSupported {
         field_name: String,
     },
@@ -135,6 +136,9 @@ impl std::fmt::Display for Error {
             }
             Error::NonScalarTypeUsedInOperator { r#type } => {
                 write!(f, "Non-scalar-type used in operator: {type:?}")
+            }
+            Error::NestedArrayTypesNotSupported => {
+                write!(f, "Encountered a nested array type.")
             }
             Error::NestedArraysNotSupported { field_name } => {
                 write!(f, "Nested field '{field_name}' requested as nested array.")

--- a/crates/query-engine/translation/src/translation/query/fields.rs
+++ b/crates/query-engine/translation/src/translation/query/fields.rs
@@ -433,12 +433,11 @@ fn wrap_array_in_type_representation(
     match column_type_representation {
         None => expression,
         Some(type_rep) => {
-            if let Some(mut cast_type) = get_type_representation_cast_type(type_rep) {
-                cast_type.is_array = true;
+            if let Some(cast_type) = get_type_representation_cast_type(type_rep) {
                 sql::ast::Expression::Cast {
                     expression: Box::new(expression),
                     // make it an array of cast type
-                    r#type: cast_type,
+                    r#type: sql::ast::ScalarType::ArrayType(cast_type),
                 }
             } else {
                 expression
@@ -460,7 +459,7 @@ fn wrap_in_type_representation(
             if let Some(cast_type) = get_type_representation_cast_type(type_rep) {
                 sql::ast::Expression::Cast {
                     expression: Box::new(expression),
-                    r#type: cast_type,
+                    r#type: sql::ast::ScalarType::BaseType(cast_type),
                 }
             } else {
                 expression
@@ -477,7 +476,7 @@ fn get_type_representation_cast_type(
         // In these situations, we expect to cast the expression according
         // to the type representation.
         TypeRepresentation::Int64AsString | TypeRepresentation::BigDecimalAsString => {
-            Some(sql::ast::ScalarTypeName::new_unqualified("text"))
+            Some(sql::helpers::text_type_name())
         }
 
         // In these situations the type representation should be the same as

--- a/crates/query-engine/translation/src/translation/query/values.rs
+++ b/crates/query-engine/translation/src/translation/query/values.rs
@@ -45,39 +45,50 @@ pub fn translate_json_value(
         _ => Ok(sql::ast::Expression::Cast {
             expression: Box::new(sql::ast::Expression::Cast {
                 expression: Box::new(Expression::Value(Value::JsonValue(value.clone()))),
-                r#type: sql::ast::ScalarTypeName::new_unqualified("jsonb"),
+                r#type: sql::helpers::jsonb_type(),
             }),
             r#type: type_to_ast_scalar_type(env, r#type)?,
         }),
     }
 }
 
+/// Translate a NDC 'Type' to an SQL scalar type.
+fn type_to_ast_scalar_type(env: &Env, typ: &database::Type) -> Result<sql::ast::ScalarType, Error> {
+    match typ {
+        query_engine_metadata::metadata::Type::ArrayType(t) => {
+            let scalar_type_name = type_to_ast_scalar_type_name(env, t)?;
+            Ok(sql::ast::ScalarType::ArrayType(scalar_type_name))
+        }
+        _ => Ok(sql::ast::ScalarType::BaseType(
+            type_to_ast_scalar_type_name(env, typ)?,
+        )),
+    }
+}
+
 /// Translate a NDC 'Type' to an SQL type name.
-fn type_to_ast_scalar_type(
+fn type_to_ast_scalar_type_name(
     env: &Env,
     typ: &database::Type,
 ) -> Result<sql::ast::ScalarTypeName, Error> {
     match typ {
-        query_engine_metadata::metadata::Type::ArrayType(t) => {
-            // This will collapse nested arrays. This is fine since it matches the behavior of
-            // Postgres where these are unsupported anyway.
-            let mut scalar_type = type_to_ast_scalar_type(env, t)?;
-            scalar_type.is_array = true;
-            Ok(scalar_type)
+        query_engine_metadata::metadata::Type::ArrayType(_) => {
+            Err(Error::NestedArrayTypesNotSupported)
         }
         query_engine_metadata::metadata::Type::ScalarType(t) => {
-            // TODO: When adding schema suppor to scalar types this will need access to a mapping
+            // TODO: When adding schema support to scalar types this will need access to a mapping
             // between ndc-type names and db type names like we have for composite types.
-            Ok(sql::ast::ScalarTypeName::new_unqualified(&t.0))
+            Ok(sql::ast::ScalarTypeName::Unqualified(t.0.clone()))
         }
         query_engine_metadata::metadata::Type::CompositeType(t) => {
             let type_info = env.lookup_composite_type(t)?;
-            Ok(sql::ast::ScalarTypeName {
-                type_name: type_info.type_name().to_string(),
-                schema_name: type_info
-                    .schema_name()
-                    .map(|s| sql::ast::SchemaName(s.clone())),
-                is_array: false,
+            let type_name = type_info.type_name().to_string();
+            Ok(if let Some(schema_name) = type_info.schema_name() {
+                sql::ast::ScalarTypeName::Qualified {
+                    type_name,
+                    schema_name: sql::ast::SchemaName(schema_name.to_string()),
+                }
+            } else {
+                sql::ast::ScalarTypeName::Unqualified(type_name)
             })
         }
     }
@@ -185,11 +196,7 @@ pub fn translate_projected_variable(
                     expression: Box::new(sql::ast::Expression::Value(sql::ast::Value::Array(
                         vec![],
                     ))),
-                    r#type: {
-                        let mut text_arr = sql::ast::ScalarTypeName::new_unqualified("text");
-                        text_arr.is_array = true;
-                        text_arr
-                    },
+                    r#type: sql::ast::ScalarType::ArrayType(sql::helpers::text_type_name()),
                 }),
             }),
             r#type: type_to_ast_scalar_type(env, r#type)?,


### PR DESCRIPTION
### What

Followup to the review suggestion: https://github.com/hasura/ndc-postgres/pull/431#discussion_r1571231393

Makes the AST for ScalarType a bit more structured.
Using enums instead of flags makes things more explicit, so if we make a mistake it would not be one of "I forgot to set the flag" but rather "I explicitly chose the wrong variant".

### How

Use the following representation:

```rust
pub enum ScalarType {
    BaseType(ScalarTypeName),
    ArrayType(ScalarTypeName),
}

pub enum ScalarTypeName {
    Qualified {
        schema_name: SchemaName,
        type_name: String,
    },
    Unqualified(String),
}
```

Instead of the previous:

```rust
pub struct ScalarTypeName {
    pub type_name: String,
    pub schema_name: Option<SchemaName>,
    pub is_array: bool,
}
```