### PR TITLE
bugfix: duplicate results when filtering, over-filtering on lack of rows

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@
 
 ### Fixed
 
-- Return at most a single instance of a root table row when filtering, empty rows of a column relationship should not necessarily filter a row. 
+- Return at most a single instance of a root table row when filtering, empty rows of a column relationship should not necessarily filter a row.
   ([#463](https://github.com/hasura/ndc-postgres/pull/463))
 
 ## [v0.6.0] - 2024-04-16

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,9 @@
 
 ### Fixed
 
+- Return at most a single instance of a root table row when filtering, empty rows of a column relationship should not necessarily filter a row. 
+  ([#463](https://github.com/hasura/ndc-postgres/pull/463))
+
 ## [v0.6.0] - 2024-04-16
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@
 
 ### Changed
 
+- When acquiring a connection, ping the db only if it has been idle.
+  ([#450](https://github.com/hasura/ndc-postgres/pull/450))
+
 ### Fixed
 
 - Return at most a single instance of a root table row when filtering, empty rows of a column relationship should not necessarily filter a row. 

--- a/crates/query-engine/sql/src/sql/ast.rs
+++ b/crates/query-engine/sql/src/sql/ast.rs
@@ -82,7 +82,9 @@ pub enum Returning {
 pub enum SelectList {
     SelectList(Vec<(ColumnAlias, Expression)>),
     SelectStar,
+    SelectStarFrom(TableReference),
     SelectStarComposite(Expression),
+    Select1,
 }
 
 /// A FROM clause
@@ -124,10 +126,25 @@ pub enum Join {
     LeftOuterJoinLateral(LeftOuterJoinLateral),
     /// INNER JOIN LATERAL
     InnerJoinLateral(InnerJoinLateral),
+    /// FULL OUTER JOIN LATERAL
+    FullOuterJoinLateral(FullOuterJoinLateral),
     /// CROSS JOIN LATERAL
     CrossJoinLateral(CrossJoin),
     /// CROSS JOIN
     CrossJoin(CrossJoin),
+}
+
+impl Join {
+    /// Get the select expression and table alias regardless of the join type.
+    pub fn get_select_and_alias(self) -> (Box<Select>, TableAlias) {
+        match self {
+            Join::CrossJoin(CrossJoin { select, alias })
+            | Join::CrossJoinLateral(CrossJoin { select, alias })
+            | Join::LeftOuterJoinLateral(LeftOuterJoinLateral { select, alias })
+            | Join::InnerJoinLateral(InnerJoinLateral { select, alias })
+            | Join::FullOuterJoinLateral(FullOuterJoinLateral { select, alias }) => (select, alias),
+        }
+    }
 }
 
 /// A CROSS JOIN clause
@@ -147,6 +164,13 @@ pub struct LeftOuterJoinLateral {
 /// An INNER JOIN LATERAL clause
 #[derive(Debug, Clone, PartialEq)]
 pub struct InnerJoinLateral {
+    pub select: Box<Select>,
+    pub alias: TableAlias,
+}
+
+/// A FULL OUTER JOIN LATERAL clause
+#[derive(Debug, Clone, PartialEq)]
+pub struct FullOuterJoinLateral {
     pub select: Box<Select>,
     pub alias: TableAlias,
 }

--- a/crates/query-engine/sql/src/sql/convert.rs
+++ b/crates/query-engine/sql/src/sql/convert.rs
@@ -95,10 +95,17 @@ impl SelectList {
             SelectList::SelectStar => {
                 sql.append_syntax("*");
             }
+            SelectList::SelectStarFrom(table_reference) => {
+                table_reference.to_sql(sql);
+                sql.append_syntax(".*");
+            }
             SelectList::SelectStarComposite(expr) => {
                 sql.append_syntax("(");
                 expr.to_sql(sql);
                 sql.append_syntax(").*");
+            }
+            SelectList::Select1 => {
+                sql.append_syntax("1");
             }
         }
     }
@@ -278,6 +285,15 @@ impl Join {
             }
             Join::InnerJoinLateral(join) => {
                 sql.append_syntax(" INNER JOIN LATERAL ");
+                sql.append_syntax("(");
+                join.select.to_sql(sql);
+                sql.append_syntax(")");
+                sql.append_syntax(" AS ");
+                join.alias.to_sql(sql);
+                sql.append_syntax(" ON ('true') ");
+            }
+            Join::FullOuterJoinLateral(join) => {
+                sql.append_syntax(" FULL OUTER JOIN LATERAL ");
                 sql.append_syntax("(");
                 join.select.to_sql(sql);
                 sql.append_syntax(")");

--- a/crates/query-engine/sql/src/sql/helpers.rs
+++ b/crates/query-engine/sql/src/sql/helpers.rs
@@ -122,6 +122,22 @@ pub fn star_select(from: From) -> Select {
     }
 }
 
+/// Generate an EXISTS where expression.
+pub fn where_exists_select(from: From, joins: Vec<Join>, where_: Where) -> Expression {
+    Expression::Exists {
+        select: Box::new(Select {
+            with: empty_with(),
+            select_list: SelectList::Select1,
+            from: Some(from),
+            joins,
+            where_,
+            group_by: empty_group_by(),
+            order_by: empty_order_by(),
+            limit: empty_limit(),
+        }),
+    }
+}
+
 /// Do we want to aggregate results or return a single row?
 #[derive(Clone, Copy)]
 pub enum ResultsKind {

--- a/crates/query-engine/sql/src/sql/rewrites/constant_folding.rs
+++ b/crates/query-engine/sql/src/sql/rewrites/constant_folding.rs
@@ -16,6 +16,8 @@ pub fn normalize_select(mut select: Select) -> Select {
     // select list
     select.select_list = match select.select_list {
         SelectList::SelectStar => SelectList::SelectStar,
+        SelectList::SelectStarFrom(table) => SelectList::SelectStarFrom(table),
+        SelectList::Select1 => SelectList::Select1,
         SelectList::SelectStarComposite(exp) => {
             SelectList::SelectStarComposite(normalize_expr(exp))
         }
@@ -58,6 +60,12 @@ pub fn normalize_join(join: Join) -> Join {
         }
         Join::InnerJoinLateral(InnerJoinLateral { select, alias }) => {
             Join::InnerJoinLateral(InnerJoinLateral {
+                select: Box::new(normalize_select(*select)),
+                alias,
+            })
+        }
+        Join::FullOuterJoinLateral(FullOuterJoinLateral { select, alias }) => {
+            Join::FullOuterJoinLateral(FullOuterJoinLateral {
                 select: Box::new(normalize_select(*select)),
                 alias,
             })

--- a/crates/query-engine/translation/src/translation/query/filtering.rs
+++ b/crates/query-engine/translation/src/translation/query/filtering.rs
@@ -25,7 +25,7 @@ pub fn translate_expression(
     root_and_current_tables: &RootAndCurrentTables,
     predicate: &models::Expression,
 ) -> Result<sql::ast::Expression, Error> {
-    // Fetch the filter expression and the relevant joins
+    // Fetch the filter expression and the relevant joins.
     let (filter_expression, joins) =
         translate_expression_with_joins(env, state, root_and_current_tables, predicate)?;
 
@@ -267,34 +267,35 @@ pub fn translate_expression_with_joins(
 /// Given a vector of PathElements and the table alias for the table the
 /// expression is over, we return a join in the form of:
 ///
-///   LEFT JOIN LATERAL
-///   (
-///     SELECT *
-///     FROM
-///       <table of path[0]> AS <fresh name>
-///     WHERE
-///       <table 0 join condition>
-///       AND <predicate of path[0]>
-///     AS <fresh name>
-///   )
-///   LEFT JOIN LATERAL
-///   (
-///     SELECT *
-///     FROM
-///        <table of path[1]> AS <fresh name>
-///     WHERE
-///        <table 1 join condition on table 0>
-///        AND <predicate of path[1]>
-///   ) AS <fresh name>
-///   ...
-///   LEFT JOIN LATERAL
-///   (
+///   SELECT <LAST-FRESH-NAME>.* FROM (
+///     (
 ///       SELECT *
 ///       FROM
-///          <table of path[m]> AS <fresh name>
+///         <table of path[0]> AS <fresh name>
 ///       WHERE
-///          <table m join condition on table m-1>
-///          AND <predicate of path[m]>
+///         <table 0 join condition>
+///         AND <predicate of path[0]>
+///       AS <fresh name>
+///     )
+///     INNER JOIN LATERAL
+///     (
+///       SELECT *
+///       FROM
+///          <table of path[1]> AS <fresh name>
+///       WHERE
+///          <table 1 join condition on table 0>
+///          AND <predicate of path[1]>
+///     ) AS <fresh name>
+///     ...
+///     INNER JOIN LATERAL
+///     (
+///         SELECT *
+///         FROM
+///            <table of path[m]> AS <fresh name>
+///         WHERE
+///            <table m join condition on table m-1>
+///            AND <predicate of path[m]>
+///     ) AS <LAST-FRESH-NAME>
 ///   ) AS <fresh name>
 ///
 /// and the aliased table name under which the sought colum can be found, i.e.

--- a/crates/query-engine/translation/src/translation/query/filtering.rs
+++ b/crates/query-engine/translation/src/translation/query/filtering.rs
@@ -415,7 +415,10 @@ fn translate_comparison_pathelements(
                     reference,
                     name: final_ref.name.clone(),
                 },
-                // create a join from the select
+                // create a join from the select.
+                // We use a full outer join so even if one of the sides does not contain rows,
+                // We can still select values.
+                // See a more elaborated explanation: https://github.com/hasura/ndc-postgres/pull/463#discussion_r1601884534
                 vec![sql::ast::Join::FullOuterJoinLateral(
                     sql::ast::FullOuterJoinLateral {
                         select: Box::new(outer_select),

--- a/crates/query-engine/translation/src/translation/query/root.rs
+++ b/crates/query-engine/translation/src/translation/query/root.rs
@@ -141,8 +141,8 @@ fn translate_query_part(
     select.joins.extend(order_by_joins);
 
     // translate where
-    let (filter, filter_joins) = match &query.predicate {
-        None => Ok((sql::helpers::true_expr(), vec![])),
+    let filter = match &query.predicate {
+        None => Ok(sql::helpers::true_expr()),
         Some(predicate) => {
             filtering::translate_expression(env, state, &root_and_current_tables, predicate)
         }
@@ -159,8 +159,6 @@ fn translate_query_part(
     )?;
 
     select.joins.extend(relationship_joins);
-
-    select.joins.extend(filter_joins);
 
     select.order_by = order_by;
 

--- a/crates/query-engine/translation/src/translation/query/sorting.rs
+++ b/crates/query-engine/translation/src/translation/query/sorting.rs
@@ -718,7 +718,7 @@ fn select_for_path_element(
                 root_table: root_and_current_tables.root_table.clone(),
                 current_table: join_table,
             };
-            let (predicate_expr, predicate_joins) =
+            let predicate_expr =
                 filtering::translate_expression(env, state, &predicate_tables, predicate)?;
 
             // generate a condition for this join.
@@ -735,7 +735,6 @@ fn select_for_path_element(
                 right: Box::new(predicate_expr),
             });
 
-            select.joins = predicate_joins;
             Ok(select)
         }
     }

--- a/crates/query-engine/translation/tests/snapshots/tests__select_where_album_id_equals_self_nested_object_relationship.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_where_album_id_equals_self_nested_object_relationship.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%12_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%14_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,7 +11,7 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%13_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%15_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
@@ -30,17 +30,17 @@ FROM
                     FROM
                       (
                         SELECT
-                          coalesce(json_agg(row_to_json("%10_rows")), '[]') AS "rows"
+                          coalesce(json_agg(row_to_json("%12_rows")), '[]') AS "rows"
                         FROM
                           (
                             SELECT
-                              "%5_Album"."Title" AS "album",
-                              "%6_RELATIONSHIP_Artist"."Artist" AS "Artist"
+                              "%7_Album"."Title" AS "album",
+                              "%8_RELATIONSHIP_Artist"."Artist" AS "Artist"
                             FROM
-                              "public"."Album" AS "%5_Album"
+                              "public"."Album" AS "%7_Album"
                               LEFT OUTER JOIN LATERAL (
                                 SELECT
-                                  row_to_json("%6_RELATIONSHIP_Artist") AS "Artist"
+                                  row_to_json("%8_RELATIONSHIP_Artist") AS "Artist"
                                 FROM
                                   (
                                     SELECT
@@ -48,82 +48,98 @@ FROM
                                     FROM
                                       (
                                         SELECT
-                                          coalesce(json_agg(row_to_json("%8_rows")), '[]') AS "rows"
+                                          coalesce(json_agg(row_to_json("%10_rows")), '[]') AS "rows"
                                         FROM
                                           (
                                             SELECT
-                                              "%7_Artist"."Name" AS "artist",
-                                              "%7_Artist"."ArtistId" AS "ArtistId"
+                                              "%9_Artist"."Name" AS "artist",
+                                              "%9_Artist"."ArtistId" AS "ArtistId"
                                             FROM
-                                              "public"."Artist" AS "%7_Artist"
+                                              "public"."Artist" AS "%9_Artist"
                                             WHERE
-                                              ("%5_Album"."ArtistId" = "%7_Artist"."ArtistId")
-                                          ) AS "%8_rows"
-                                      ) AS "%8_rows"
-                                  ) AS "%6_RELATIONSHIP_Artist"
-                              ) AS "%6_RELATIONSHIP_Artist" ON ('true')
+                                              ("%7_Album"."ArtistId" = "%9_Artist"."ArtistId")
+                                          ) AS "%10_rows"
+                                      ) AS "%10_rows"
+                                  ) AS "%8_RELATIONSHIP_Artist"
+                              ) AS "%8_RELATIONSHIP_Artist" ON ('true')
                             WHERE
-                              ("%0_Track"."AlbumId" = "%5_Album"."AlbumId")
-                          ) AS "%10_rows"
-                      ) AS "%10_rows"
+                              ("%0_Track"."AlbumId" = "%7_Album"."AlbumId")
+                          ) AS "%12_rows"
+                      ) AS "%12_rows"
                   ) AS "%1_RELATIONSHIP_Album"
               ) AS "%1_RELATIONSHIP_Album" ON ('true')
-              INNER JOIN LATERAL (
-                SELECT
-                  *
-                FROM
-                  "public"."Album" AS "%2_BOOLEXP_Album"
-                WHERE
-                  (
-                    (
-                      "%2_BOOLEXP_Album"."Title" = cast($1 as "pg_catalog"."varchar")
-                    )
-                    AND (
-                      "%0_Track"."AlbumId" = "%2_BOOLEXP_Album"."AlbumId"
-                    )
-                  )
-              ) AS "%2_BOOLEXP_Album" ON ('true')
-              INNER JOIN LATERAL (
-                SELECT
-                  *
-                FROM
-                  "public"."Album" AS "%3_BOOLEXP_Album"
-                WHERE
-                  (
-                    (
-                      "%3_BOOLEXP_Album"."Title" = cast($2 as "pg_catalog"."varchar")
-                    )
-                    AND (
-                      "%0_Track"."AlbumId" = "%3_BOOLEXP_Album"."AlbumId"
-                    )
-                  )
-              ) AS "%3_BOOLEXP_Album" ON ('true')
-              INNER JOIN LATERAL (
-                SELECT
-                  *
-                FROM
-                  "public"."Artist" AS "%4_BOOLEXP_Artist"
-                WHERE
-                  (
-                    (
-                      "%4_BOOLEXP_Artist"."Name" = cast($3 as "pg_catalog"."varchar")
-                    )
-                    AND (
-                      "%3_BOOLEXP_Album"."ArtistId" = "%4_BOOLEXP_Artist"."ArtistId"
-                    )
-                  )
-              ) AS "%4_BOOLEXP_Artist" ON ('true')
             WHERE
-              (
-                "%2_BOOLEXP_Album"."AlbumId" > "%4_BOOLEXP_Artist"."ArtistId"
+              EXISTS (
+                SELECT
+                  1
+                FROM
+                  (
+                    SELECT
+                      "%2_BOOLEXP_Album".*
+                    FROM
+                      (
+                        SELECT
+                          *
+                        FROM
+                          "public"."Album" AS "%2_BOOLEXP_Album"
+                        WHERE
+                          (
+                            (
+                              "%2_BOOLEXP_Album"."Title" = cast($1 as "pg_catalog"."varchar")
+                            )
+                            AND (
+                              "%0_Track"."AlbumId" = "%2_BOOLEXP_Album"."AlbumId"
+                            )
+                          )
+                      ) AS "%2_BOOLEXP_Album"
+                  ) AS "%3_BOOLEXP_Album" FULL
+                  OUTER JOIN LATERAL (
+                    SELECT
+                      "%5_BOOLEXP_Artist".*
+                    FROM
+                      (
+                        SELECT
+                          *
+                        FROM
+                          "public"."Album" AS "%4_BOOLEXP_Album"
+                        WHERE
+                          (
+                            (
+                              "%4_BOOLEXP_Album"."Title" = cast($2 as "pg_catalog"."varchar")
+                            )
+                            AND (
+                              "%0_Track"."AlbumId" = "%4_BOOLEXP_Album"."AlbumId"
+                            )
+                          )
+                      ) AS "%4_BOOLEXP_Album"
+                      INNER JOIN LATERAL (
+                        SELECT
+                          *
+                        FROM
+                          "public"."Artist" AS "%5_BOOLEXP_Artist"
+                        WHERE
+                          (
+                            (
+                              "%5_BOOLEXP_Artist"."Name" = cast($3 as "pg_catalog"."varchar")
+                            )
+                            AND (
+                              "%4_BOOLEXP_Album"."ArtistId" = "%5_BOOLEXP_Artist"."ArtistId"
+                            )
+                          )
+                      ) AS "%5_BOOLEXP_Artist" ON ('true')
+                  ) AS "%6_BOOLEXP_Artist" ON ('true')
+                WHERE
+                  (
+                    "%3_BOOLEXP_Album"."AlbumId" > "%6_BOOLEXP_Artist"."ArtistId"
+                  )
               )
             ORDER BY
               "%0_Track"."TrackId" ASC
             LIMIT
               5
-          ) AS "%13_rows"
-      ) AS "%13_rows"
-  ) AS "%12_universe";
+          ) AS "%15_rows"
+      ) AS "%15_rows"
+  ) AS "%14_universe";
 
 {
     1: String(

--- a/crates/query-engine/translation/tests/snapshots/tests__select_where_array_relationship.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_where_array_relationship.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%6_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%7_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,7 +11,7 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%7_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%8_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
@@ -29,40 +29,51 @@ FROM
                     FROM
                       (
                         SELECT
-                          coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
+                          coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
                         FROM
                           (
                             SELECT
-                              "%3_Album"."Title" AS "title"
+                              "%4_Album"."Title" AS "title"
                             FROM
-                              "public"."Album" AS "%3_Album"
+                              "public"."Album" AS "%4_Album"
                             WHERE
-                              ("%0_Artist"."ArtistId" = "%3_Album"."ArtistId")
+                              ("%0_Artist"."ArtistId" = "%4_Album"."ArtistId")
                             ORDER BY
-                              "%3_Album"."AlbumId" ASC
-                          ) AS "%4_rows"
-                      ) AS "%4_rows"
+                              "%4_Album"."AlbumId" ASC
+                          ) AS "%5_rows"
+                      ) AS "%5_rows"
                   ) AS "%1_RELATIONSHIP_albums"
               ) AS "%1_RELATIONSHIP_albums" ON ('true')
-              INNER JOIN LATERAL (
+            WHERE
+              EXISTS (
                 SELECT
-                  *
+                  1
                 FROM
-                  "public"."Album" AS "%2_BOOLEXP_Album"
+                  (
+                    SELECT
+                      "%2_BOOLEXP_Album".*
+                    FROM
+                      (
+                        SELECT
+                          *
+                        FROM
+                          "public"."Album" AS "%2_BOOLEXP_Album"
+                        WHERE
+                          (
+                            "%0_Artist"."ArtistId" = "%2_BOOLEXP_Album"."ArtistId"
+                          )
+                      ) AS "%2_BOOLEXP_Album"
+                  ) AS "%3_BOOLEXP_Album"
                 WHERE
                   (
-                    "%0_Artist"."ArtistId" = "%2_BOOLEXP_Album"."ArtistId"
+                    "%3_BOOLEXP_Album"."Title" LIKE cast($1 as "pg_catalog"."varchar")
                   )
-              ) AS "%2_BOOLEXP_Album" ON ('true')
-            WHERE
-              (
-                "%2_BOOLEXP_Album"."Title" LIKE cast($1 as "pg_catalog"."varchar")
               )
             ORDER BY
               "%0_Artist"."ArtistId" ASC
-          ) AS "%7_rows"
-      ) AS "%7_rows"
-  ) AS "%6_universe";
+          ) AS "%8_rows"
+      ) AS "%8_rows"
+  ) AS "%7_universe";
 
 {
     1: String(

--- a/crates/tests/databases-tests/src/postgres/explain_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/explain_tests.rs
@@ -32,6 +32,35 @@ mod query {
         insta::assert_snapshot!(result.details.query);
     }
 
+    #[tokio::test]
+    async fn duplicate_filter_results() {
+        let result = run_query_explain(create_router().await, "duplicate_filter_results").await;
+        let keywords = &[
+            "Aggregate",
+            "Subquery Scan",
+            "Limit",
+            "Index Scan",
+            "Filter",
+        ];
+        is_contained_in_lines(keywords, &result.details.plan);
+        insta::assert_snapshot!(result.details.query);
+    }
+
+    #[tokio::test]
+    async fn duplicate_filter_results_nested() {
+        let result =
+            run_query_explain(create_router().await, "duplicate_filter_results_nested").await;
+        let keywords = &[
+            "Aggregate",
+            "Subquery Scan",
+            "Limit",
+            "Index Scan",
+            "Filter",
+        ];
+        is_contained_in_lines(keywords, &result.details.plan);
+        insta::assert_snapshot!(result.details.query);
+    }
+
     mod native_queries {
         use super::super::super::common::create_router;
         use tests_common::assert::is_contained_in_lines;
@@ -64,7 +93,7 @@ mod mutation {
     async fn delete_playlist_track() {
         let result = run_mutation_explain(create_router().await, "delete_playlist_track").await;
         is_contained_in_lines(
-            &["Delete", "Recheck Cond", "Index Cond", "CTE Scan"],
+            &["Delete", "Index Cond", "CTE Scan"],
             result
                 .details
                 .get("delete_playlist_track Execution Plan")

--- a/crates/tests/databases-tests/src/postgres/query_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/query_tests.rs
@@ -296,6 +296,18 @@ mod predicates {
         let result = run_query(create_router().await, "select_where_array_relationship").await;
         insta::assert_json_snapshot!(result);
     }
+
+    #[tokio::test]
+    async fn duplicate_filter_results() {
+        let result = run_query(create_router().await, "duplicate_filter_results").await;
+        insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test]
+    async fn duplicate_filter_results_nested() {
+        let result = run_query(create_router().await, "duplicate_filter_results_nested").await;
+        insta::assert_json_snapshot!(result);
+    }
 }
 
 #[cfg(test)]

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__delete_invoice_line.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__delete_invoice_line.snap
@@ -6,25 +6,34 @@ EXPLAIN WITH "%0_generated_mutation" AS (
   DELETE FROM
     "public"."InvoiceLine" AS "%2_InvoiceLine"
   WHERE
-    EXISTS (
-      SELECT
-        *
-      FROM
-        "public"."Track" AS "%3_BOOLEXP_Track"
-      WHERE
-        (
+    (
+      ("%2_InvoiceLine"."InvoiceLineId" = 90)
+      AND EXISTS (
+        SELECT
+          1
+        FROM
           (
-            "%2_InvoiceLine"."TrackId" = "%3_BOOLEXP_Track"."TrackId"
-          )
-          AND (
-            ("%2_InvoiceLine"."InvoiceLineId" = 90)
-            AND ("%3_BOOLEXP_Track"."TrackId" = 512)
-          )
-        )
+            SELECT
+              "%3_BOOLEXP_Track".*
+            FROM
+              (
+                SELECT
+                  *
+                FROM
+                  "public"."Track" AS "%3_BOOLEXP_Track"
+                WHERE
+                  (
+                    "%2_InvoiceLine"."TrackId" = "%3_BOOLEXP_Track"."TrackId"
+                  )
+              ) AS "%3_BOOLEXP_Track"
+          ) AS "%4_BOOLEXP_Track"
+        WHERE
+          ("%4_BOOLEXP_Track"."TrackId" = 512)
+      )
     ) RETURNING *
 )
 SELECT
-  json_build_object('result', row_to_json("%4_universe"), 'type', $1) AS "universe"
+  json_build_object('result', row_to_json("%5_universe"), 'type', $1) AS "universe"
 FROM
   (
     SELECT
@@ -32,7 +41,7 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%5_returning")), '[]') AS "returning"
+          coalesce(json_agg(row_to_json("%6_returning")), '[]') AS "returning"
         FROM
           (
             SELECT
@@ -40,12 +49,12 @@ FROM
               "%1_experimental_delete_InvoiceLine_by_InvoiceLineId"."Quantity" AS "quantity"
             FROM
               "%0_generated_mutation" AS "%1_experimental_delete_InvoiceLine_by_InvoiceLineId"
-          ) AS "%5_returning"
-      ) AS "%5_returning"
+          ) AS "%6_returning"
+      ) AS "%6_returning"
       CROSS JOIN (
         SELECT
           COUNT(*) AS "affected_rows"
         FROM
           "%0_generated_mutation" AS "%1_experimental_delete_InvoiceLine_by_InvoiceLineId"
-      ) AS "%6_aggregates"
-  ) AS "%4_universe"
+      ) AS "%7_aggregates"
+  ) AS "%5_universe"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__duplicate_filter_results.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__duplicate_filter_results.snap
@@ -1,0 +1,53 @@
+---
+source: crates/tests/databases-tests/src/postgres/explain_tests.rs
+expression: result.details.query
+---
+EXPLAIN
+SELECT
+  coalesce(json_agg(row_to_json("%3_universe")), '[]') AS "universe"
+FROM
+  (
+    SELECT
+      *
+    FROM
+      (
+        SELECT
+          coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
+        FROM
+          (
+            SELECT
+              "%0_Artist"."Name" AS "Name"
+            FROM
+              "public"."Artist" AS "%0_Artist"
+            WHERE
+              EXISTS (
+                SELECT
+                  1
+                FROM
+                  (
+                    SELECT
+                      "%1_BOOLEXP_Album".*
+                    FROM
+                      (
+                        SELECT
+                          *
+                        FROM
+                          "public"."Album" AS "%1_BOOLEXP_Album"
+                        WHERE
+                          (
+                            "%0_Artist"."ArtistId" = "%1_BOOLEXP_Album"."ArtistId"
+                          )
+                      ) AS "%1_BOOLEXP_Album"
+                  ) AS "%2_BOOLEXP_Album"
+                WHERE
+                  (
+                    "%2_BOOLEXP_Album"."Title" ~~ cast($1 as "pg_catalog"."varchar")
+                  )
+              )
+            ORDER BY
+              "%0_Artist"."ArtistId" ASC
+            LIMIT
+              5
+          ) AS "%4_rows"
+      ) AS "%4_rows"
+  ) AS "%3_universe"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__duplicate_filter_results_nested.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__duplicate_filter_results_nested.snap
@@ -1,0 +1,83 @@
+---
+source: crates/tests/databases-tests/src/postgres/explain_tests.rs
+expression: result.details.query
+---
+EXPLAIN
+SELECT
+  coalesce(json_agg(row_to_json("%6_universe")), '[]') AS "universe"
+FROM
+  (
+    SELECT
+      *
+    FROM
+      (
+        SELECT
+          coalesce(json_agg(row_to_json("%7_rows")), '[]') AS "rows"
+        FROM
+          (
+            SELECT
+              "%0_Artist"."Name" AS "Name"
+            FROM
+              "public"."Artist" AS "%0_Artist"
+            WHERE
+              EXISTS (
+                SELECT
+                  1
+                FROM
+                  (
+                    SELECT
+                      "%2_BOOLEXP_Track".*
+                    FROM
+                      (
+                        SELECT
+                          *
+                        FROM
+                          "public"."Album" AS "%1_BOOLEXP_Album"
+                        WHERE
+                          (
+                            "%0_Artist"."ArtistId" = "%1_BOOLEXP_Album"."ArtistId"
+                          )
+                      ) AS "%1_BOOLEXP_Album"
+                      INNER JOIN LATERAL (
+                        SELECT
+                          *
+                        FROM
+                          "public"."Track" AS "%2_BOOLEXP_Track"
+                        WHERE
+                          (
+                            "%1_BOOLEXP_Album"."AlbumId" = "%2_BOOLEXP_Track"."AlbumId"
+                          )
+                      ) AS "%2_BOOLEXP_Track" ON ('true')
+                  ) AS "%3_BOOLEXP_Track" FULL
+                  OUTER JOIN LATERAL (
+                    SELECT
+                      "%4_BOOLEXP_Album".*
+                    FROM
+                      (
+                        SELECT
+                          *
+                        FROM
+                          "public"."Album" AS "%4_BOOLEXP_Album"
+                        WHERE
+                          (
+                            "%0_Artist"."ArtistId" = "%4_BOOLEXP_Album"."ArtistId"
+                          )
+                      ) AS "%4_BOOLEXP_Album"
+                  ) AS "%5_BOOLEXP_Album" ON ('true')
+                WHERE
+                  (
+                    (
+                      "%3_BOOLEXP_Track"."Name" ~~ cast($1 as "pg_catalog"."varchar")
+                    )
+                    OR (
+                      "%5_BOOLEXP_Album"."Title" ~~ cast($2 as "pg_catalog"."varchar")
+                    )
+                  )
+              )
+            ORDER BY
+              "%0_Artist"."ArtistId" ASC
+            LIMIT
+              5
+          ) AS "%7_rows"
+      ) AS "%7_rows"
+  ) AS "%6_universe"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__predicates__duplicate_filter_results.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__predicates__duplicate_filter_results.snap
@@ -1,0 +1,25 @@
+---
+source: crates/tests/databases-tests/src/postgres/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": [
+      {
+        "Name": "AC/DC"
+      },
+      {
+        "Name": "Accept"
+      },
+      {
+        "Name": "Aerosmith"
+      },
+      {
+        "Name": "Alanis Morissette"
+      },
+      {
+        "Name": "Alice In Chains"
+      }
+    ]
+  }
+]

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__predicates__duplicate_filter_results_nested.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__predicates__duplicate_filter_results_nested.snap
@@ -1,0 +1,25 @@
+---
+source: crates/tests/databases-tests/src/postgres/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": [
+      {
+        "Name": "AC/DC"
+      },
+      {
+        "Name": "Accept"
+      },
+      {
+        "Name": "Aerosmith"
+      },
+      {
+        "Name": "Alanis Morissette"
+      },
+      {
+        "Name": "Alice In Chains"
+      }
+    ]
+  }
+]

--- a/crates/tests/tests-common/goldenfiles/duplicate_filter_results.json
+++ b/crates/tests/tests-common/goldenfiles/duplicate_filter_results.json
@@ -1,0 +1,58 @@
+{
+  "collection": "Artist",
+  "query": {
+    "fields": {
+      "Name": {
+        "type": "column",
+        "column": "Name",
+        "arguments": {}
+      }
+    },
+    "predicate": {
+      "type": "binary_comparison_operator",
+      "column": {
+        "type": "column",
+        "name": "Title",
+        "path": [
+          {
+            "relationship": "Artist_Albums",
+            "arguments": {},
+            "predicate": {
+              "type": "and",
+              "expressions": []
+            }
+          }
+        ]
+      },
+      "operator": "_like",
+      "value": {
+        "type": "scalar",
+        "value": "%e%"
+      }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "ArtistId",
+            "path": []
+          }
+        }
+      ]
+    },
+    "limit": 5
+  },
+  "arguments": {},
+  "collection_relationships": {
+    "Artist_Albums": {
+      "arguments": {},
+      "column_mapping": {
+        "ArtistId": "ArtistId"
+      },
+      "relationship_type": "array",
+      "target_collection": "Album"
+    }
+  }
+}

--- a/crates/tests/tests-common/goldenfiles/duplicate_filter_results_nested.json
+++ b/crates/tests/tests-common/goldenfiles/duplicate_filter_results_nested.json
@@ -1,0 +1,101 @@
+{
+  "collection": "Artist",
+  "query": {
+    "fields": {
+      "Name": {
+        "type": "column",
+        "column": "Name",
+        "arguments": {}
+      }
+    },
+    "predicate": {
+      "type": "or",
+      "expressions": [
+        {
+          "type": "binary_comparison_operator",
+          "column": {
+            "type": "column",
+            "name": "Name",
+            "path": [
+              {
+                "relationship": "Artist_Albums",
+                "arguments": {},
+                "predicate": {
+                  "type": "and",
+                  "expressions": []
+                }
+              },
+              {
+                "relationship": "Albums_Tracks",
+                "arguments": {},
+                "predicate": {
+                  "type": "and",
+                  "expressions": []
+                }
+              }
+            ]
+          },
+          "operator": "_like",
+          "value": {
+            "type": "scalar",
+            "value": "%e%"
+          }
+        },
+        {
+          "type": "binary_comparison_operator",
+          "column": {
+            "type": "column",
+            "name": "Title",
+            "path": [
+              {
+                "relationship": "Artist_Albums",
+                "arguments": {},
+                "predicate": {
+                  "type": "and",
+                  "expressions": []
+                }
+              }
+            ]
+          },
+          "operator": "_like",
+          "value": {
+            "type": "scalar",
+            "value": "%e%"
+          }
+        }
+      ]
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "type": "column",
+            "name": "ArtistId",
+            "path": []
+          }
+        }
+      ]
+    },
+    "limit": 5
+  },
+  "arguments": {},
+  "collection_relationships": {
+    "Artist_Albums": {
+      "arguments": {},
+      "column_mapping": {
+        "ArtistId": "ArtistId"
+      },
+      "relationship_type": "array",
+      "target_collection": "Album"
+    },
+    "Albums_Tracks": {
+      "arguments": {},
+      "column_mapping": {
+        "AlbumId": "AlbumId"
+      },
+      "relationship_type": "array",
+      "target_collection": "Track"
+    }
+  }
+}

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ set shell := ["bash", "-c"]
 # This allows us to handle quoted arguments.
 set positional-arguments
 
-HGE_V3_DIR := env_var_or_default('HGE_V3_DIRECTORY', '../v4-engine')
+HGE_V3_DIR := env_var_or_default('HGE_V3_DIRECTORY', '../v3-engine')
 
 CONNECTOR_IMAGE_NAME := "ghcr.io/hasura/ndc-postgres"
 CONNECTOR_IMAGE_TAG := "dev"


### PR DESCRIPTION
### What

We are fixing two bugs:

1. Fix returning duplicate results when filtering https://github.com/hasura/graphql-engine/issues/10238
2. Fix over-filtering when a related table contains no results (due to the use of inner join)

<!-- Consider: do we need to add a changelog entry? -->

### How

In order to filter by a nested relationship column, we first query that nesting to fetch the relevant column, and then build our filter.

Before, we fetched the tables at the top-level using an inner join, then added a where clause.

In this PR we change this generation scheme to use `WHERE EXISTS (SELECT 1 ...)` instead.
The fetching of columns will appear inside the `WHERE` clause, each path element will have it's own select (where the nesting are combined using inner joins) and separate path elements are combined with a FULL OUTER JOIN instead of inner join.

The `EXISTS` part helps us avoid duplicates - while inner joins at the top-level can create additional rows, an EXISTS cannot. It will just inform if a particular row matches the predicate.

The `FULL OUTER JOIN` part helps us avoid over-eager filtering. See the [note here](https://github.com/hasura/ndc-postgres/pull/463#discussion_r1601884534).
