### PR TITLE
Enable configuration v4 by default.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Support for qualifying scalar types by their schema. This updates the
+  metadata configuration format version number from `"3"` to `"4"`.
+
 ### Changed
 
 - When acquiring a connection, ping the db only if it has been idle.

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 - Support for qualifying scalar types by their schema. This updates the
   metadata configuration format version number from `"3"` to `"4"`.
+  ([#471](https://github.com/hasura/ndc-postgres/pull/471))
 
 ### Changed
 

--- a/crates/configuration/src/configuration.rs
+++ b/crates/configuration/src/configuration.rs
@@ -42,7 +42,7 @@ pub enum ParsedConfiguration {
 
 impl ParsedConfiguration {
     pub fn initial() -> Self {
-        ParsedConfiguration::Version3(version3::RawConfiguration::empty())
+        ParsedConfiguration::Version4(version4::ParsedConfiguration::empty())
     }
 }
 


### PR DESCRIPTION
### What

This PR makes the CLI plugin produce version-4 configuration metadata when initializing a project.

### How

Simply changing the `initial()` trait function on `ParsedConfiguration` to produce the `Version4` case instead of the `Version3` case.
