### PR TITLE
Test that the version produced by `ndc-postgres-cli initialize` is stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,6 +1456,7 @@ dependencies = [
  "insta",
  "ndc-postgres-configuration",
  "serde",
+ "serde_json",
  "serde_yaml",
  "tempfile",
  "thiserror",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0.201", features = ["derive"] }
 serde_yaml = "0.9.34"
 thiserror = "1.0.59"
 tokio = { version = "1.37.0", features = ["full"] }
+serde_json = "1.0.117"
 
 [build-dependencies]
 build-data = "0.2.1"

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_version_is_unchanged.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_version_is_unchanged.snap
@@ -1,0 +1,5 @@
+---
+source: crates/cli/tests/initialize_tests.rs
+expression: version
+---
+"4"


### PR DESCRIPTION
### What

This PR adds a test that asserts that the configuration version produced by the cli `initialize` command hasn't changed.

### How

The test runs the initialize command and asserts on the value of the `version` key in `configuration.json`. This is a somewhat simplified model of version checking, but it holds for the ones we have currently.