### PR TITLE
Bump release version v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "databases-tests"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "axum",
  "insta",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-postgres"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "ndc-postgres-configuration",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-postgres-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "build-data",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-postgres-configuration"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -1686,7 +1686,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openapi-generator"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "ndc-postgres-configuration",
  "serde_json",
@@ -2078,7 +2078,7 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "query-engine-execution"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "prometheus",
@@ -2092,11 +2092,11 @@ dependencies = [
 
 [[package]]
 name = "query-engine-metadata"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "query-engine-sql"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "schemars",
  "serde",
@@ -2105,7 +2105,7 @@ dependencies = [
 
 [[package]]
 name = "query-engine-translation"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3046,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "tests-common"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 
-package.version = "0.6.0"
+package.version = "0.7.0"
 package.edition = "2021"
 package.license = "Apache-2.0"
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,14 @@
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [v0.7.0] - 2024-05-22
+
+### Added
+
 - Support for qualifying scalar types by their schema. This updates the
   metadata configuration format version number from `"3"` to `"4"`.
   ([#471](https://github.com/hasura/ndc-postgres/pull/471))
@@ -225,7 +233,8 @@ Initial release.
 
 <!-- end -->
 
-[Unreleased]: https://github.com/hasura/ndc-postgres/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/hasura/ndc-postgres/compare/v0.7.0...HEAD
+[v0.7.0]: https://github.com/hasura/ndc-postgres/releases/tag/v0.7.0
 [v0.6.0]: https://github.com/hasura/ndc-postgres/releases/tag/v0.6.0
 [v0.5.2]: https://github.com/hasura/ndc-postgres/releases/tag/v0.5.2
 [v0.5.1]: https://github.com/hasura/ndc-postgres/releases/tag/v0.5.1


### PR DESCRIPTION
### What

This PR marks the release of ndc-postgres v0.7.0
