### PR TITLE
Insert multiple objects instead of a single object

### DIFF
--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -532,9 +532,11 @@ fn experimental_insert_to_procedure(
     object_types.insert(object_name.clone(), object_type);
 
     arguments.insert(
-        "_object".to_string(),
+        "_objects".to_string(),
         models::ArgumentInfo {
-            argument_type: models::Type::Named { name: object_name },
+            argument_type: models::Type::Array {
+                element_type: Box::new(models::Type::Named { name: object_name }),
+            },
             description: None,
         },
     );

--- a/crates/query-engine/sql/src/sql/ast.rs
+++ b/crates/query-engine/sql/src/sql/ast.rs
@@ -59,8 +59,15 @@ pub struct Insert {
     pub schema: SchemaName,
     pub table: TableName,
     pub columns: Vec<ColumnName>,
-    pub values: Vec<Expression>,
+    pub values: Vec<Vec<InsertExpression>>,
     pub returning: Returning,
+}
+
+/// An expression inside an INSERT VALUES clause
+#[derive(Debug, Clone, PartialEq)]
+pub enum InsertExpression {
+    Default,
+    Expression(Expression),
 }
 
 /// A DELETE clause
@@ -377,7 +384,7 @@ pub enum TableReference {
 }
 
 /// A database table's column name
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ColumnName(pub String);
 
 /// A reference to a column. Used when we want to query it,

--- a/crates/query-engine/sql/src/sql/convert.rs
+++ b/crates/query-engine/sql/src/sql/convert.rs
@@ -160,14 +160,21 @@ impl Insert {
         sql.append_syntax(")");
 
         sql.append_syntax(" VALUES ");
-        sql.append_syntax("(");
-        for (index, value) in self.values.iter().enumerate() {
-            value.to_sql(sql);
+
+        for (index, object) in self.values.iter().enumerate() {
+            sql.append_syntax("(");
+            for (index, value) in object.iter().enumerate() {
+                value.to_sql(sql);
+                if index < (object.len() - 1) {
+                    sql.append_syntax(", ");
+                }
+            }
+            sql.append_syntax(")");
+
             if index < (self.values.len() - 1) {
                 sql.append_syntax(", ");
             }
         }
-        sql.append_syntax(")");
 
         sql.append_syntax(" ");
 
@@ -551,6 +558,15 @@ impl Value {
                 }
                 sql.append_syntax("]");
             }
+        }
+    }
+}
+
+impl InsertExpression {
+    pub fn to_sql(&self, sql: &mut SQL) {
+        match &self {
+            InsertExpression::Expression(expression) => expression.to_sql(sql),
+            InsertExpression::Default => sql.append_syntax("DEFAULT"),
         }
     }
 }

--- a/crates/query-engine/sql/src/sql/rewrites/constant_folding.rs
+++ b/crates/query-engine/sql/src/sql/rewrites/constant_folding.rs
@@ -137,7 +137,21 @@ fn normalize_delete(mut delete: Delete) -> Delete {
 
 /// Normalize everything in an Insert
 fn normalize_insert(mut insert: Insert) -> Insert {
-    insert.values = insert.values.into_iter().map(normalize_expr).collect();
+    insert.values = insert
+        .values
+        .into_iter()
+        .map(|values| {
+            values
+                .into_iter()
+                .map(|value| match value {
+                    InsertExpression::Expression(expression) => {
+                        InsertExpression::Expression(normalize_expr(expression))
+                    }
+                    InsertExpression::Default => InsertExpression::Default,
+                })
+                .collect()
+        })
+        .collect();
     insert
 }
 

--- a/crates/query-engine/translation/src/translation/mutation/experimental/insert.rs
+++ b/crates/query-engine/translation/src/translation/mutation/experimental/insert.rs
@@ -8,7 +8,7 @@ use ndc_sdk::models;
 use query_engine_metadata::metadata;
 use query_engine_metadata::metadata::database;
 use query_engine_sql::sql;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// A representation of an auto-generated insert mutation.
 ///
@@ -56,21 +56,17 @@ pub fn generate(
     (name, insert_mutation)
 }
 
-/// Given the description of an insert mutation (ie, `InsertMutation`),
-/// and the arguments, output the SQL AST.
-pub fn translate(
+/// Translate a single insert object into a mapping from column names to values.
+fn translate_object_into_columns_and_values(
     env: &crate::translation::helpers::Env,
     state: &mut crate::translation::helpers::State,
     mutation: &InsertMutation,
-    arguments: &BTreeMap<String, serde_json::Value>,
-) -> Result<(sql::ast::Insert, sql::ast::ColumnAlias), Error> {
-    let mut columns = vec![];
-    let mut values = vec![];
-    let object = arguments
-        .get("_object")
-        .ok_or(Error::ArgumentNotFound("_object".to_string()))?;
+    object: &serde_json::Value,
+) -> Result<BTreeMap<sql::ast::ColumnName, sql::ast::InsertExpression>, Error> {
+    let mut columns_to_values = BTreeMap::new();
     match object {
         serde_json::Value::Object(object) => {
+            // For each field, look up the column name in the table and insert it and the value into the map.
             for (name, value) in object {
                 let column_info =
                     mutation
@@ -81,19 +77,119 @@ pub fn translate(
                             mutation.collection_name.clone(),
                         ))?;
 
-                columns.push(sql::ast::ColumnName(column_info.name.clone()));
-                values.push(translate_json_value(
-                    env,
-                    state,
-                    value,
-                    &column_info.r#type,
+                columns_to_values.insert(
+                    sql::ast::ColumnName(column_info.name.clone()),
+                    sql::ast::InsertExpression::Expression(translate_json_value(
+                        env,
+                        state,
+                        value,
+                        &column_info.r#type,
+                    )?),
+                );
+            }
+            Ok(())
+        }
+        serde_json::Value::Array(_) => Err(Error::UnexpectedStructure(
+            "array of arrays structure in insert _objects argument. Expecting an array of objects."
+                .to_string(),
+        )),
+        _ => Err(Error::UnexpectedStructure(
+            "array of values structure in insert _objects argument. Expecting an array of objects."
+                .to_string(),
+        )),
+    }?;
+    Ok(columns_to_values)
+}
+
+/// We parse the objects that the user sent to us and we translate them to a list of columns
+/// to insert and a vector of vector of values, each vector of values represents an object/row.
+fn translate_objects_to_columns_and_values(
+    env: &crate::translation::helpers::Env,
+    state: &mut crate::translation::helpers::State,
+    mutation: &InsertMutation,
+    value: &serde_json::Value,
+) -> Result<
+    (
+        Vec<sql::ast::ColumnName>,
+        Vec<Vec<sql::ast::InsertExpression>>,
+    ),
+    Error,
+> {
+    match value {
+        serde_json::Value::Array(array) => {
+            let mut all_columns_and_values: Vec<
+                BTreeMap<sql::ast::ColumnName, sql::ast::InsertExpression>,
+            > = vec![];
+            // We fetch the column names and values for each user specified object in the _objects array.
+            for object in array {
+                all_columns_and_values.push(translate_object_into_columns_and_values(
+                    env, state, mutation, object,
                 )?);
             }
-        }
-        _ => todo!(),
-    };
 
-    check_columns(&mutation.columns, &columns, &mutation.collection_name)?;
+            // Some objects might have missing columns, which indicate that they want the default value to be inserted.
+            // To handle this, we take the union of column names in all objects, and then traverse each object
+            // to check if it is missing a column. If it does, we add the column to its mapping with a DEFAULT expression.
+
+            // Here we get the union of the column names.
+            let union_of_columns: BTreeSet<sql::ast::ColumnName> = all_columns_and_values
+                .iter()
+                .map(|cols_and_vals| cols_and_vals.keys().cloned().collect::<BTreeSet<_>>())
+                .fold(BTreeSet::new(), |acc, cols| {
+                    acc.union(&cols).cloned().collect()
+                });
+
+            // Here we add missing column names with DEFAULT.
+            for columns_and_values in &mut all_columns_and_values {
+                for column_name in &union_of_columns {
+                    if !columns_and_values.contains_key(column_name) {
+                        columns_and_values
+                            .insert(column_name.clone(), sql::ast::InsertExpression::Default);
+                    }
+                }
+
+                // Finally, check that the final form of the object is fine according to the schema.
+                check_columns(
+                    &mutation.columns,
+                    columns_and_values,
+                    &mutation.collection_name,
+                )?;
+            }
+
+            Ok((
+                // We return an ordered vector of column names
+                union_of_columns.into_iter().collect(),
+                // and a vector of rows
+                all_columns_and_values
+                    .into_iter()
+                    .map(|columns_and_values| columns_and_values.into_values().collect())
+                    .collect(),
+            ))
+        }
+        serde_json::Value::Object(_) => Err(Error::UnexpectedStructure(
+            "object structure in insert _objects argument. Expecting an array of objects."
+                .to_string(),
+        )),
+        _ => Err(Error::UnexpectedStructure(
+            "value structure in insert _objects argument. Expecting an array of objects."
+                .to_string(),
+        )),
+    }
+}
+
+/// Given the description of an insert mutation (ie, `InsertMutation`),
+/// and the arguments, output the SQL AST.
+pub fn translate(
+    env: &crate::translation::helpers::Env,
+    state: &mut crate::translation::helpers::State,
+    mutation: &InsertMutation,
+    arguments: &BTreeMap<String, serde_json::Value>,
+) -> Result<(sql::ast::Insert, sql::ast::ColumnAlias), Error> {
+    let object = arguments
+        .get("_objects")
+        .ok_or(Error::ArgumentNotFound("_objects".to_string()))?;
+
+    let (columns, values) = translate_objects_to_columns_and_values(env, state, mutation, object)?;
 
     let table_name_and_reference = TableNameAndReference {
         name: mutation.collection_name.clone(),
@@ -145,10 +241,10 @@ pub fn translate(
 }
 
 /// Check that no columns are missing, and that columns cannot be inserted to
-/// are not insertred.
+/// are not inserted.
 fn check_columns(
     columns: &BTreeMap<String, database::ColumnInfo>,
-    inserted_columns: &[sql::ast::ColumnName],
+    inserted_columns: &BTreeMap<sql::ast::ColumnName, sql::ast::InsertExpression>,
     insert_name: &str,
 ) -> Result<(), Error> {
     for (name, column) in columns {
@@ -171,10 +267,12 @@ fn check_columns(
                 is_generated: database::IsGenerated::Stored,
                 ..
             } => {
-                if inserted_columns.contains(&sql::ast::ColumnName(column.name.clone())) {
-                    Err(Error::ColumnIsGenerated(name.clone()))
-                } else {
-                    Ok(())
+                let value = inserted_columns.get(&sql::ast::ColumnName(column.name.clone()));
+                match value {
+                    Some(expr) if *expr != sql::ast::InsertExpression::Default => {
+                        Err(Error::ColumnIsGenerated(name.clone()))
+                    }
+                    _ => Ok(()),
                 }
             }
             // identity always columns must not be inserted into.
@@ -182,23 +280,22 @@ fn check_columns(
                 is_identity: database::IsIdentity::IdentityAlways,
                 ..
             } => {
-                if inserted_columns.contains(&sql::ast::ColumnName(column.name.clone())) {
-                    {
+                let value = inserted_columns.get(&sql::ast::ColumnName(column.name.clone()));
+                match value {
+                    Some(expr) if *expr != sql::ast::InsertExpression::Default => {
                         Err(Error::ColumnIsIdentityAlways(name.clone()))
                     }
-                } else {
-                    Ok(())
+                    _ => Ok(()),
                 }
             }
             // regular columns must be inserted into.
             _ => {
-                if inserted_columns.contains(&sql::ast::ColumnName(column.name.clone())) {
-                    Ok(())
-                } else {
-                    Err(Error::MissingColumnInInsert(
-                        name.clone(),
-                        insert_name.to_owned(),
-                    ))
+                let value = inserted_columns.get(&sql::ast::ColumnName(column.name.clone()));
+                match value {
+                    Some(sql::ast::InsertExpression::Expression(_)) => Ok(()),
+                    Some(sql::ast::InsertExpression::Default) | None => Err(
+                        Error::MissingColumnInInsert(name.clone(), insert_name.to_owned()),
+                    ),
                 }
             }
         }?;

--- a/crates/query-engine/translation/src/translation/mutation/v1/insert.rs
+++ b/crates/query-engine/translation/src/translation/mutation/v1/insert.rs
@@ -65,12 +65,9 @@ pub fn translate(
                         ))?;
 
                 columns.push(sql::ast::ColumnName(column_info.name.clone()));
-                values.push(translate_json_value(
-                    env,
-                    state,
-                    value,
-                    &column_info.r#type,
-                )?);
+                values.push(sql::ast::InsertExpression::Expression(
+                    translate_json_value(env, state, value, &column_info.r#type)?,
+                ));
             }
         }
         _ => todo!(),
@@ -87,7 +84,7 @@ pub fn translate(
         schema: mutation.schema_name.clone(),
         table: mutation.table_name.clone(),
         columns,
-        values,
+        values: vec![values],
         // RETURNING *, true
         returning: sql::ast::Returning::Returning(sql::ast::SelectList::SelectListComposite(
             Box::new(sql::ast::SelectList::SelectStar),

--- a/crates/query-engine/translation/tests/common/mod.rs
+++ b/crates/query-engine/translation/tests/common/mod.rs
@@ -93,7 +93,7 @@ pub async fn test_mutation_translation(
                 &metadata,
                 operation,
                 request.collection_relationships.clone(),
-                Some(query_engine_metadata::metadata::mutations::MutationsVersion::V1),
+                Some(query_engine_metadata::metadata::mutations::MutationsVersion::VeryExperimentalWip),
             )
         })
         .collect::<Result<Vec<_>, translation::error::Error>>()?;

--- a/crates/query-engine/translation/tests/goldenfiles/mutations/experimental_insert/configuration.json
+++ b/crates/query-engine/translation/tests/goldenfiles/mutations/experimental_insert/configuration.json
@@ -49,5 +49,5 @@
     "compositeTypes": {},
     "nativeQueries": {}
   },
-  "mutationsVersion": null
+  "mutationsVersion": "veryExperimentalWip"
 }

--- a/crates/query-engine/translation/tests/goldenfiles/mutations/experimental_insert/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/mutations/experimental_insert/request.json
@@ -2,11 +2,20 @@
   "operations": [
     {
       "type": "procedure",
-      "name": "v1_insert_Artist",
+      "name": "experimental_insert_Artist",
       "arguments": {
-        "_object": {
-          "id": 276,
-          "name": "Olympians"
+        "_objects": [
+          {
+            "name": "Olympians",
+            "id": 276
+          },
+          {
+            "name": "The Other Band"
+          }
+        ],
+        "constraint": {
+          "type": "or",
+          "expressions": []
         }
       },
       "fields": {

--- a/crates/query-engine/translation/tests/snapshots/tests__mutations__experimental_insert.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__mutations__experimental_insert.snap
@@ -9,13 +9,14 @@ WITH "%0_generated_mutation" AS (
   INSERT INTO
     "public"."Artist"("ArtistId", "Name")
   VALUES
-    (276, cast($1 as "pg_catalog"."varchar")) RETURNING *,
-    true AS "%check__constraint"
+    (276, cast($1 as "pg_catalog"."varchar")),
+    (DEFAULT, cast($2 as "pg_catalog"."varchar")) RETURNING *,
+    false AS "%check__constraint"
 )
 SELECT
   (
     SELECT
-      json_build_object('result', row_to_json("%2_universe"), 'type', $2) AS "universe"
+      json_build_object('result', row_to_json("%2_universe"), 'type', $3) AS "universe"
     FROM
       (
         SELECT
@@ -27,30 +28,32 @@ SELECT
             FROM
               (
                 SELECT
-                  "%1_v1_insert_Artist"."ArtistId" AS "artist_id",
-                  "%1_v1_insert_Artist"."Name" AS "name"
+                  "%1_experimental_insert_Artist"."ArtistId" AS "artist_id",
+                  "%1_experimental_insert_Artist"."Name" AS "name"
                 FROM
-                  "%0_generated_mutation" AS "%1_v1_insert_Artist"
+                  "%0_generated_mutation" AS "%1_experimental_insert_Artist"
               ) AS "%3_returning"
           ) AS "%3_returning"
           CROSS JOIN (
             SELECT
               COUNT(*) AS "affected_rows"
             FROM
-              "%0_generated_mutation" AS "%1_v1_insert_Artist"
+              "%0_generated_mutation" AS "%1_experimental_insert_Artist"
           ) AS "%4_aggregates"
       ) AS "%2_universe"
   ) AS "%results",
   (
     SELECT
       coalesce(
-        bool_and("%5_v1_insert_Artist"."%check__constraint"),
+        bool_and(
+          "%5_experimental_insert_Artist"."%check__constraint"
+        ),
         true
       ) AS "%check__constraint"
     FROM
-      "%0_generated_mutation" AS "%5_v1_insert_Artist"
+      "%0_generated_mutation" AS "%5_experimental_insert_Artist"
   ) AS "%check__constraint";
 
 COMMIT;
 
-[[(1, String("Olympians")), (2, String("procedure"))]]
+[[(1, String("Olympians")), (2, String("The Other Band")), (3, String("procedure"))]]

--- a/crates/tests/databases-tests/src/postgres/mutation_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/mutation_tests.rs
@@ -221,4 +221,29 @@ mod negative {
 
         insta::assert_json_snapshot!(result);
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn experimental_insert_artist_missing_column() {
+        let ndc_metadata =
+            FreshDeployment::create(common::CONNECTION_URI, common::CHINOOK_NDC_METADATA_PATH)
+                .await
+                .unwrap();
+
+        let router = tests_common::router::create_router(
+            &ndc_metadata.ndc_metadata_path,
+            &ndc_metadata.connection_uri,
+        )
+        .await;
+
+        let mutation_result = run_mutation_fail(
+            router.clone(),
+            "experimental_insert_Artist_missing_column",
+            StatusCode::BAD_REQUEST,
+        )
+        .await;
+
+        let result = mutation_result;
+
+        insta::assert_json_snapshot!(result);
+    }
 }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__experimental_insert_custom_dog.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__experimental_insert_custom_dog.snap
@@ -4,21 +4,28 @@ expression: "result.details.get(\"0 experimental_insert_custom_dog SQL Mutation\
 ---
 EXPLAIN WITH "%0_generated_mutation" AS (
   INSERT INTO
-    "custom"."dog"("name", "height_cm", "adopter_name")
+    "custom"."dog"("adopter_name", "birthday", "height_cm", "name")
   VALUES
     (
       cast($1 as "pg_catalog"."text"),
+      cast($2 as "pg_catalog"."date"),
       160,
-      cast($2 as "pg_catalog"."text")
+      cast($3 as "pg_catalog"."text")
+    ),
+    (
+      cast($4 as "pg_catalog"."text"),
+      DEFAULT,
+      160,
+      cast($5 as "pg_catalog"."text")
     ) RETURNING *,
     (
-      "custom"."dog"."adopter_name" = cast($3 as "pg_catalog"."text")
+      "custom"."dog"."adopter_name" = cast($6 as "pg_catalog"."text")
     ) AS "%check__constraint"
 )
 SELECT
   (
     SELECT
-      json_build_object('result', row_to_json("%2_universe"), 'type', $4) AS "universe"
+      json_build_object('result', row_to_json("%2_universe"), 'type', $7) AS "universe"
     FROM
       (
         SELECT

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__experimental_insert_custom_dog.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__experimental_insert_custom_dog.snap
@@ -11,13 +11,21 @@ expression: result
           {
             "id": "1",
             "name": "Cremebo",
+            "birthday": "2020-02-02",
+            "height_cm": "160",
+            "height_inch": "62.9921259842519685",
+            "adopter_name": "Strauss"
+          },
+          {
+            "id": "2",
+            "name": "Krembo",
             "birthday": "2024-01-17",
             "height_cm": "160",
             "height_inch": "62.9921259842519685",
             "adopter_name": "Strauss"
           }
         ],
-        "affected_rows": 1
+        "affected_rows": 2
       }
     },
     {

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__negative__experimental_insert_artist_missing_column.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__negative__experimental_insert_artist_missing_column.snap
@@ -1,0 +1,10 @@
+---
+source: crates/tests/databases-tests/src/postgres/mutation_tests.rs
+expression: result
+---
+{
+  "message": "Invalid request",
+  "details": {
+    "detail": "Unable to insert into 'Artist'. Column 'ArtistId' is missing."
+  }
+}

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
@@ -6102,10 +6102,13 @@ expression: result
       "name": "experimental_insert_Album",
       "description": "Insert into the Album table",
       "arguments": {
-        "_object": {
+        "_objects": {
           "type": {
-            "type": "named",
-            "name": "experimental_insert_Album_object"
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "experimental_insert_Album_object"
+            }
           }
         },
         "constraint": {
@@ -6125,10 +6128,13 @@ expression: result
       "name": "experimental_insert_Artist",
       "description": "Insert into the Artist table",
       "arguments": {
-        "_object": {
+        "_objects": {
           "type": {
-            "type": "named",
-            "name": "experimental_insert_Artist_object"
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "experimental_insert_Artist_object"
+            }
           }
         },
         "constraint": {
@@ -6148,10 +6154,13 @@ expression: result
       "name": "experimental_insert_Customer",
       "description": "Insert into the Customer table",
       "arguments": {
-        "_object": {
+        "_objects": {
           "type": {
-            "type": "named",
-            "name": "experimental_insert_Customer_object"
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "experimental_insert_Customer_object"
+            }
           }
         },
         "constraint": {
@@ -6171,10 +6180,13 @@ expression: result
       "name": "experimental_insert_Employee",
       "description": "Insert into the Employee table",
       "arguments": {
-        "_object": {
+        "_objects": {
           "type": {
-            "type": "named",
-            "name": "experimental_insert_Employee_object"
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "experimental_insert_Employee_object"
+            }
           }
         },
         "constraint": {
@@ -6194,10 +6206,13 @@ expression: result
       "name": "experimental_insert_Genre",
       "description": "Insert into the Genre table",
       "arguments": {
-        "_object": {
+        "_objects": {
           "type": {
-            "type": "named",
-            "name": "experimental_insert_Genre_object"
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "experimental_insert_Genre_object"
+            }
           }
         },
         "constraint": {
@@ -6217,10 +6232,13 @@ expression: result
       "name": "experimental_insert_Invoice",
       "description": "Insert into the Invoice table",
       "arguments": {
-        "_object": {
+        "_objects": {
           "type": {
-            "type": "named",
-            "name": "experimental_insert_Invoice_object"
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "experimental_insert_Invoice_object"
+            }
           }
         },
         "constraint": {
@@ -6240,10 +6258,13 @@ expression: result
       "name": "experimental_insert_InvoiceLine",
       "description": "Insert into the InvoiceLine table",
       "arguments": {
-        "_object": {
+        "_objects": {
           "type": {
-            "type": "named",
-            "name": "experimental_insert_InvoiceLine_object"
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "experimental_insert_InvoiceLine_object"
+            }
           }
         },
         "constraint": {
@@ -6263,10 +6284,13 @@ expression: result
       "name": "experimental_insert_MediaType",
       "description": "Insert into the MediaType table",
       "arguments": {
-        "_object": {
+        "_objects": {
           "type": {
-            "type": "named",
-            "name": "experimental_insert_MediaType_object"
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "experimental_insert_MediaType_object"
+            }
           }
         },
         "constraint": {
@@ -6286,10 +6310,13 @@ expression: result
       "name": "experimental_insert_Playlist",
       "description": "Insert into the Playlist table",
       "arguments": {
-        "_object": {
+        "_objects": {
           "type": {
-            "type": "named",
-            "name": "experimental_insert_Playlist_object"
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "experimental_insert_Playlist_object"
+            }
           }
         },
         "constraint": {
@@ -6309,10 +6336,13 @@ expression: result
       "name": "experimental_insert_PlaylistTrack",
       "description": "Insert into the PlaylistTrack table",
       "arguments": {
-        "_object": {
+        "_objects": {
           "type": {
-            "type": "named",
-            "name": "experimental_insert_PlaylistTrack_object"
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "experimental_insert_PlaylistTrack_object"
+            }
           }
         },
         "constraint": {
@@ -6332,10 +6362,13 @@ expression: result
       "name": "experimental_insert_Track",
       "description": "Insert into the Track table",
       "arguments": {
-        "_object": {
+        "_objects": {
           "type": {
-            "type": "named",
-            "name": "experimental_insert_Track_object"
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "experimental_insert_Track_object"
+            }
           }
         },
         "constraint": {
@@ -6355,10 +6388,13 @@ expression: result
       "name": "experimental_insert_custom_dog",
       "description": "Insert into the custom_dog table",
       "arguments": {
-        "_object": {
+        "_objects": {
           "type": {
-            "type": "named",
-            "name": "experimental_insert_custom_dog_object"
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "experimental_insert_custom_dog_object"
+            }
           }
         },
         "constraint": {
@@ -6378,10 +6414,13 @@ expression: result
       "name": "experimental_insert_deck_of_cards",
       "description": "Insert into the deck_of_cards table",
       "arguments": {
-        "_object": {
+        "_objects": {
           "type": {
-            "type": "named",
-            "name": "experimental_insert_deck_of_cards_object"
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "experimental_insert_deck_of_cards_object"
+            }
           }
         },
         "constraint": {
@@ -6401,10 +6440,13 @@ expression: result
       "name": "experimental_insert_discoverable_types_root_occurrence",
       "description": "Insert into the discoverable_types_root_occurrence table",
       "arguments": {
-        "_object": {
+        "_objects": {
           "type": {
-            "type": "named",
-            "name": "experimental_insert_discoverable_types_root_occurrence_object"
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "experimental_insert_discoverable_types_root_occurrence_object"
+            }
           }
         },
         "constraint": {
@@ -6424,10 +6466,13 @@ expression: result
       "name": "experimental_insert_even_numbers",
       "description": "Insert into the even_numbers table",
       "arguments": {
-        "_object": {
+        "_objects": {
           "type": {
-            "type": "named",
-            "name": "experimental_insert_even_numbers_object"
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "experimental_insert_even_numbers_object"
+            }
           }
         },
         "constraint": {
@@ -6447,10 +6492,13 @@ expression: result
       "name": "experimental_insert_group_leader",
       "description": "Insert into the group_leader table",
       "arguments": {
-        "_object": {
+        "_objects": {
           "type": {
-            "type": "named",
-            "name": "experimental_insert_group_leader_object"
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "experimental_insert_group_leader_object"
+            }
           }
         },
         "constraint": {
@@ -6470,10 +6518,13 @@ expression: result
       "name": "experimental_insert_phone_numbers",
       "description": "Insert into the phone_numbers table",
       "arguments": {
-        "_object": {
+        "_objects": {
           "type": {
-            "type": "named",
-            "name": "experimental_insert_phone_numbers_object"
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "experimental_insert_phone_numbers_object"
+            }
           }
         },
         "constraint": {
@@ -6493,10 +6544,13 @@ expression: result
       "name": "experimental_insert_spatial_ref_sys",
       "description": "Insert into the spatial_ref_sys table",
       "arguments": {
-        "_object": {
+        "_objects": {
           "type": {
-            "type": "named",
-            "name": "experimental_insert_spatial_ref_sys_object"
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "experimental_insert_spatial_ref_sys_object"
+            }
           }
         },
         "constraint": {
@@ -6516,10 +6570,13 @@ expression: result
       "name": "experimental_insert_topology_layer",
       "description": "Insert into the topology_layer table",
       "arguments": {
-        "_object": {
+        "_objects": {
           "type": {
-            "type": "named",
-            "name": "experimental_insert_topology_layer_object"
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "experimental_insert_topology_layer_object"
+            }
           }
         },
         "constraint": {
@@ -6539,10 +6596,13 @@ expression: result
       "name": "experimental_insert_topology_topology",
       "description": "Insert into the topology_topology table",
       "arguments": {
-        "_object": {
+        "_objects": {
           "type": {
-            "type": "named",
-            "name": "experimental_insert_topology_topology_object"
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "experimental_insert_topology_topology_object"
+            }
           }
         },
         "constraint": {

--- a/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_Artist_missing_column.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_Artist_missing_column.json
@@ -2,15 +2,19 @@
   "operations": [
     {
       "type": "procedure",
-      "name": "experimental_insert_custom_dog",
+      "name": "experimental_insert_Artist",
       "arguments": {
         "_objects": [
           {
-            "name": "Cremebo"
+            "Name": "Olympians",
+            "ArtistId": 276
+          },
+          {
+            "Name": "The Other Band"
           }
         ],
         "constraint": {
-          "type": "and",
+          "type": "or",
           "expressions": []
         }
       },
@@ -21,6 +25,7 @@
             "column": "affected_rows",
             "type": "column"
           },
+
           "returning": {
             "type": "column",
             "column": "returning",
@@ -29,29 +34,13 @@
               "fields": {
                 "type": "object",
                 "fields": {
-                  "id": {
+                  "artist_id": {
                     "type": "column",
-                    "column": "id"
+                    "column": "ArtistId"
                   },
                   "name": {
                     "type": "column",
-                    "column": "name"
-                  },
-                  "birthday": {
-                    "type": "column",
-                    "column": "birthday"
-                  },
-                  "height_cm": {
-                    "type": "column",
-                    "column": "height_cm"
-                  },
-                  "height_inch": {
-                    "type": "column",
-                    "column": "height_in"
-                  },
-                  "adopter_name": {
-                    "type": "column",
-                    "column": "adopter_name"
+                    "column": "Name"
                   }
                 }
               }

--- a/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_custom_dog.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_custom_dog.json
@@ -4,11 +4,19 @@
       "type": "procedure",
       "name": "experimental_insert_custom_dog",
       "arguments": {
-        "_object": {
-          "name": "Cremebo",
-          "height_cm": 160,
-          "adopter_name": "Strauss"
-        },
+        "_objects": [
+          {
+            "name": "Cremebo",
+            "height_cm": 160,
+            "adopter_name": "Strauss",
+            "birthday": "2020-02-02"
+          },
+          {
+            "name": "Krembo",
+            "height_cm": 160,
+            "adopter_name": "Strauss"
+          }
+        ],
         "constraint": {
           "type": "binary_comparison_operator",
           "column": { "type": "column", "name": "adopter_name", "path": [] },
@@ -66,12 +74,14 @@
       "type": "procedure",
       "name": "experimental_insert_custom_dog",
       "arguments": {
-        "_object": {
-          "name": "Manbo",
-          "height_cm": 345,
-          "adopter_name": "Joseph",
-          "birthday": "2024-01-01"
-        },
+        "_objects": [
+          {
+            "name": "Manbo",
+            "height_cm": 345,
+            "adopter_name": "Joseph",
+            "birthday": "2024-01-01"
+          }
+        ],
         "constraint": {
           "type": "and",
           "expressions": []
@@ -115,12 +125,14 @@
       "type": "procedure",
       "name": "experimental_insert_custom_dog",
       "arguments": {
-        "_object": {
-          "name": "Kremboli",
-          "height_cm": 345,
-          "adopter_name": "Yaakov",
-          "birthday": "2024-02-14"
-        },
+        "_objects": [
+          {
+            "name": "Kremboli",
+            "height_cm": 345,
+            "adopter_name": "Yaakov",
+            "birthday": "2024-02-14"
+          }
+        ],
         "constraint": {
           "type": "and",
           "expressions": []

--- a/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_custom_dog_predicate_fail.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_custom_dog_predicate_fail.json
@@ -5,11 +5,13 @@
       "type": "procedure",
       "name": "experimental_insert_custom_dog",
       "arguments": {
-        "_object": {
-          "name": "Cremebo",
-          "height_cm": 160,
-          "adopter_name": "Strauss"
-        },
+        "_objects": [
+          {
+            "name": "Cremebo",
+            "height_cm": 160,
+            "adopter_name": "Strauss"
+          }
+        ],
         "constraint": {
           "type": "binary_comparison_operator",
           "column": { "type": "column", "name": "adopter_name", "path": [] },
@@ -67,12 +69,14 @@
       "type": "procedure",
       "name": "experimental_insert_custom_dog",
       "arguments": {
-        "_object": {
-          "name": "Manbo",
-          "height_cm": 345,
-          "adopter_name": "Feldman",
-          "birthday": "2024-01-01"
-        },
+        "_objects": [
+          {
+            "name": "Manbo",
+            "height_cm": 345,
+            "adopter_name": "Feldman",
+            "birthday": "2024-01-01"
+          }
+        ],
         "constraint": {
           "type": "binary_comparison_operator",
           "column": { "type": "column", "name": "adopter_name", "path": [] },
@@ -110,31 +114,6 @@
                 }
               }
             }
-          }
-        }
-      }
-    },
-    {
-      "type": "procedure",
-      "name": "experimental_insert_custom_dog",
-      "arguments": {
-        "_object": {
-          "name": "Kremboli",
-          "height_cm": 345,
-          "adopter_name": "Yaakov",
-          "birthday": "2024-02-14"
-        },
-        "constraint": {
-          "type": "and",
-          "expressions": []
-        }
-      },
-      "fields": {
-        "type": "object",
-        "fields": {
-          "affected_rows": {
-            "column": "affected_rows",
-            "type": "column"
           }
         }
       }

--- a/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_enum.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_enum.json
@@ -4,10 +4,12 @@
       "type": "procedure",
       "name": "experimental_insert_deck_of_cards",
       "arguments": {
-        "_object": {
-          "pips": 14,
-          "suit": "hearts"
-        },
+        "_objects": [
+          {
+            "pips": 14,
+            "suit": "hearts"
+          }
+        ],
         "constraint": {
           "type": "and",
           "expressions": []

--- a/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_enum_invalid_label.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_enum_invalid_label.json
@@ -4,10 +4,12 @@
       "type": "procedure",
       "name": "experimental_insert_deck_of_cards",
       "arguments": {
-        "_object": {
-          "pips": 1,
-          "suit": "horses"
-        },
+        "_objects": [
+          {
+            "pips": 1,
+            "suit": "horses"
+          }
+        ],
         "constraint": {
           "type": "and",
           "expressions": []


### PR DESCRIPTION
### What

The currently generated insert implementation only provides a mechanism to insert a single object / row via the `_object` parameter.
In this PR we replace the `_object` parameter with an `_objects` parameter that accepts a list of objects, so we can insert multiple objects / rows (bulk insert).

### How

1. Change the schema to an array of objects
2. Make the sql::ast::Insert have a vector of vector of values, instead of just a vector of values, that might be Default as well as Expression
3. match user input as array of objects
4. Get a union of the columns from all objects, and traverse each object and insert a Default when a column is missing
