### PR TITLE
Bump Rust to v1.78.0.

### DIFF
--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -132,7 +132,7 @@ pub fn get_schema(
                                         // provided, we need to default back to the originating
                                         // table's schema
                                         foreign_schema.as_ref().unwrap_or(&table.schema_name),
-                                        &foreign_table,
+                                        foreign_table,
                                     ))
                                     .unwrap_or_else(|| {
                                         panic!(

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712681629,
-        "narHash": "sha256-bMDXn4AkTXLCpoZbII6pDGoSeSe9gI87jxPsHRXgu/E=",
+        "lastModified": 1715274763,
+        "narHash": "sha256-3Iv1PGHJn9sV3HO4FlOVaaztOxa9uGLfOmUWrH7v7+A=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "220387ac8e99cbee0ca4c95b621c4bc782b6a235",
+        "rev": "27025ab71bdca30e7ed0a16c88fd74c5970fc7f5",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712742472,
-        "narHash": "sha256-EVubu9UGPhayvDit0KYKysZiXUo2BRyd6v7bNoCfkrI=",
+        "lastModified": 1715859993,
+        "narHash": "sha256-vLp62qr+t+Kzp4HsLgIlSiGaBF4R28VPUasWhF1RCnA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f9cee3306b1c7b94459e03cefc94f522f74d4f11",
+        "rev": "2eef017af08b91e353849dfe58436684e169b71d",
         "type": "github"
       },
       "original": {
@@ -71,11 +71,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712715149,
-        "narHash": "sha256-uOx7GaLV+5hekAYtm/CBr627Pi7+d1Yh70hwKmVjYYo=",
+        "lastModified": 1715825775,
+        "narHash": "sha256-7np2/EEr5Xm8IuKWQ43q8AA1Lb6Us2BW6rYMxGrInIg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9ef1eca23bee5fb8080863909af3802130b2ee57",
+        "rev": "55f468b3d49c5d3321e85f2f9b1158476a2a90fb",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.77.2"
+channel = "1.78.0"
 profile = "default"  # see https://rust-lang.github.io/rustup/concepts/profiles.html
 components = ["rust-analyzer", "rust-src"]  # see https://rust-lang.github.io/rustup/concepts/components.html


### PR DESCRIPTION
Nothing noteworthy, just seems sensible to keep up to date.