### PR TITLE
some sql phase fixes

### DIFF
--- a/crates/query-engine/sql/src/sql/ast.rs
+++ b/crates/query-engine/sql/src/sql/ast.rs
@@ -412,9 +412,7 @@ pub struct TableAlias {
 
 /// aliases that we give to columns
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ColumnAlias {
-    pub name: String,
-}
+pub struct ColumnAlias(pub String);
 
 /// Transactions manipulation
 pub mod transaction {

--- a/crates/query-engine/sql/src/sql/ast.rs
+++ b/crates/query-engine/sql/src/sql/ast.rs
@@ -261,7 +261,7 @@ pub enum Expression {
         select: Box<Select>,
     },
     /// A json_build_object function call
-    JsonBuildObject(BTreeMap<String, Box<Expression>>),
+    JsonBuildObject(BTreeMap<String, Expression>),
     // SELECT queries can appear in a select list if they return
     // one row. For now we can only do this with 'row_to_json'.
     // Consider changing this if we encounter more ways.
@@ -320,7 +320,7 @@ pub enum CountType {
 /// Value
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
-    Int8(i32),
+    Int4(i32),
     Float8(f64),
     Bool(bool),
     Character(String),

--- a/crates/query-engine/sql/src/sql/convert.rs
+++ b/crates/query-engine/sql/src/sql/convert.rs
@@ -152,7 +152,7 @@ impl Insert {
         sql.append_identifier(&self.table.0);
         sql.append_syntax("(");
         for (index, column_name) in self.columns.iter().enumerate() {
-            sql.append_identifier(&column_name.0.to_string());
+            sql.append_identifier(&column_name.0);
             if index < (self.columns.len() - 1) {
                 sql.append_syntax(", ");
             }
@@ -540,8 +540,8 @@ impl Value {
     pub fn to_sql(&self, sql: &mut SQL) {
         match &self {
             Value::EmptyJsonArray => sql.append_syntax("'[]'"),
-            Value::Int8(i) => sql.append_syntax(&i.to_string()),
-            Value::Float8(n) => sql.append_syntax(&n.to_string()),
+            Value::Int4(i) => sql.append_i32(i),
+            Value::Float8(n) => sql.append_f64(n),
             Value::Character(s) | Value::String(s) => sql.append_param(Param::String(s.clone())),
             Value::Variable(v) => sql.append_param(Param::Variable(v.clone())),
             Value::Bool(true) => sql.append_syntax("true"),
@@ -609,14 +609,14 @@ impl Limit {
             None => (),
             Some(limit) => {
                 sql.append_syntax(" LIMIT ");
-                sql.append_syntax(&limit.to_string());
+                sql.append_u32(&limit);
             }
         };
         match self.offset {
             None => (),
             Some(offset) => {
                 sql.append_syntax(" OFFSET ");
-                sql.append_syntax(&offset.to_string());
+                sql.append_u32(&offset);
             }
         };
     }
@@ -649,7 +649,7 @@ impl ColumnReference {
             ColumnReference::TableColumn { table, name } => {
                 table.to_sql(sql);
                 sql.append_syntax(".");
-                sql.append_identifier(&name.0.to_string());
+                sql.append_identifier(&name.0);
             }
             ColumnReference::AliasedColumn { table, column } => {
                 table.to_sql(sql);
@@ -662,8 +662,7 @@ impl ColumnReference {
 
 impl ColumnAlias {
     pub fn to_sql(&self, sql: &mut SQL) {
-        let name = self.name.to_string();
-        sql.append_identifier(&name);
+        sql.append_identifier(&self.name);
     }
 }
 

--- a/crates/query-engine/sql/src/sql/convert.rs
+++ b/crates/query-engine/sql/src/sql/convert.rs
@@ -662,7 +662,7 @@ impl ColumnReference {
 
 impl ColumnAlias {
     pub fn to_sql(&self, sql: &mut SQL) {
-        sql.append_identifier(&self.name);
+        sql.append_identifier(&self.0);
     }
 }
 

--- a/crates/query-engine/sql/src/sql/helpers.rs
+++ b/crates/query-engine/sql/src/sql/helpers.rs
@@ -443,13 +443,11 @@ pub fn select_mutation_rowset(
         Expression::JsonBuildObject(BTreeMap::from([
             (
                 "type".to_string(),
-                Box::new(Expression::Value(Value::String("procedure".to_string()))),
+                Expression::Value(Value::String("procedure".to_string())),
             ),
             (
                 "result".to_string(),
-                Box::new(Expression::RowToJson(TableReference::AliasedTable(
-                    output_table_alias.clone(),
-                ))),
+                Expression::RowToJson(TableReference::AliasedTable(output_table_alias.clone())),
             ),
         ])),
     )];

--- a/crates/query-engine/sql/src/sql/helpers.rs
+++ b/crates/query-engine/sql/src/sql/helpers.rs
@@ -75,7 +75,7 @@ pub fn make_column(
 }
 /// Create column aliases using this function so we build everything in one place.
 pub fn make_column_alias(name: String) -> ColumnAlias {
-    ColumnAlias { name }
+    ColumnAlias(name)
 }
 
 // SELECTs //

--- a/crates/query-engine/sql/src/sql/rewrites/constant_folding.rs
+++ b/crates/query-engine/sql/src/sql/rewrites/constant_folding.rs
@@ -213,7 +213,68 @@ pub fn normalize_expr(expr: Expression) -> Expression {
             Expression::Value(Value::Bool(true)) => Expression::Value(Value::Bool(false)),
             expr => Expression::Not(Box::new(expr)),
         },
-        e => e,
+        // Apply inner
+        Expression::BinaryOperation {
+            left,
+            operator,
+            right,
+            // Apply inner
+        } => Expression::BinaryOperation {
+            left: Box::new(normalize_expr(*left)),
+            operator,
+            right: Box::new(normalize_expr(*right)),
+        },
+        // Apply inner
+        Expression::BinaryArrayOperation {
+            left,
+            operator,
+            right,
+        } => Expression::BinaryArrayOperation {
+            left: Box::new(normalize_expr(*left)),
+            operator,
+            right: right.into_iter().map(normalize_expr).collect(),
+        },
+        // Apply inner
+        Expression::UnaryOperation {
+            expression,
+            operator,
+        } => Expression::UnaryOperation {
+            expression: Box::new(normalize_expr(*expression)),
+            operator,
+        },
+        // Apply inner
+        Expression::FunctionCall { function, args } => Expression::FunctionCall {
+            function,
+            args: args.into_iter().map(normalize_expr).collect(),
+        },
+        // Apply inner
+        Expression::JsonBuildObject(object) => Expression::JsonBuildObject(
+            object
+                .into_iter()
+                .map(|(key, expr)| (key, normalize_expr(expr)))
+                .collect(),
+        ),
+        // Apply inner
+        Expression::Cast {
+            expression,
+            r#type: scalar_type,
+        } => Expression::Cast {
+            expression: Box::new(normalize_expr(*expression)),
+            r#type: scalar_type,
+        },
+        // Apply inner
+        Expression::ArrayConstructor(array) => {
+            Expression::ArrayConstructor(array.into_iter().map(normalize_expr).collect())
+        }
+        // Apply inner
+        Expression::CorrelatedSubSelect(select) => {
+            Expression::CorrelatedSubSelect(Box::new(normalize_select(*select)))
+        }
+        // Nothing to do.
+        Expression::RowToJson(_)
+        | Expression::ColumnReference(_)
+        | Expression::Value(_)
+        | Expression::Count(_) => expr,
     }
 }
 
@@ -232,7 +293,7 @@ mod tests {
     }
 
     fn expr_seven() -> Expression {
-        Expression::Value(Value::Int8(7))
+        Expression::Value(Value::Int4(7))
     }
 
     fn expr_and(left: Expression, right: Expression) -> Expression {

--- a/crates/query-engine/sql/src/sql/string.rs
+++ b/crates/query-engine/sql/src/sql/string.rs
@@ -40,7 +40,7 @@ impl SQL {
         self.sql.push_str(sql);
     }
     /// Append a SQL identifier like a column or a table name, which will be
-    /// inserted surrounded by quotes
+    /// inserted surrounded by quotes.
     pub fn append_identifier(&mut self, sql: &str) {
         // todo: sanitize
         self.sql.push('"');
@@ -56,5 +56,21 @@ impl SQL {
         self.params.push(param);
         self.sql.push('$');
         self.sql.push_str(&self.params.len().to_string());
+    }
+    /// Append a literal number of type usize.
+    pub fn append_usize(&mut self, sql: &usize) {
+        self.sql.push_str(&sql.to_string());
+    }
+    /// Append a literal number of type u32.
+    pub fn append_u32(&mut self, sql: &u32) {
+        self.sql.push_str(&sql.to_string());
+    }
+    /// Append a literal number of type i32.
+    pub fn append_i32(&mut self, sql: &i32) {
+        self.sql.push_str(&sql.to_string());
+    }
+    /// Append a literal number of type f64.
+    pub fn append_f64(&mut self, sql: &f64) {
+        self.sql.push_str(&sql.to_string());
     }
 }

--- a/crates/query-engine/translation/src/translation/query/fields.rs
+++ b/crates/query-engine/translation/src/translation/query/fields.rs
@@ -165,9 +165,8 @@ fn translate_nested_field(
     field: models::NestedField,
     join_relationship_fields: &mut Vec<relationships::JoinFieldInfo>,
 ) -> Result<(JoinNestedFieldInfo, sql::ast::ColumnReference), Error> {
-    let nested_field_column_collect_alias = sql::ast::ColumnAlias {
-        name: "collected".to_string(),
-    };
+    let nested_field_column_collect_alias =
+        sql::helpers::make_column_alias("collected".to_string());
     let nested_fields_alias = state.make_table_alias("nested_fields".to_string());
 
     // How we project and collect nested fields depend on whether the nested value is an object or
@@ -191,9 +190,7 @@ fn translate_nested_field(
             let field_binding_expression =
                 sql::ast::Expression::ColumnReference(sql::ast::ColumnReference::AliasedColumn {
                     table: current_table.reference.clone(),
-                    column: sql::ast::ColumnAlias {
-                        name: current_column.name.0.clone(),
-                    },
+                    column: sql::helpers::make_column_alias(current_column.name.0.clone()),
                 });
 
             let nested_field_type_name = match &current_column.r#type {
@@ -239,9 +236,9 @@ fn translate_nested_field(
                         args: vec![sql::ast::Expression::ColumnReference(
                             sql::ast::ColumnReference::AliasedColumn {
                                 table: current_table.reference.clone(),
-                                column: sql::ast::ColumnAlias {
-                                    name: current_column.name.0.clone(),
-                                },
+                                column: sql::helpers::make_column_alias(
+                                    current_column.name.0.clone(),
+                                ),
                             },
                         )],
                     };

--- a/crates/query-engine/translation/src/translation/query/filtering.rs
+++ b/crates/query-engine/translation/src/translation/query/filtering.rs
@@ -528,7 +528,7 @@ pub fn translate_exists_in_collection(
 
             let select_cols = vec![(
                 column_alias.clone(),
-                sql::ast::Expression::Value(sql::ast::Value::Int8(1)),
+                sql::ast::Expression::Value(sql::ast::Value::Int4(1)),
             )];
 
             // build a SELECT querying this table with the relevant predicate.
@@ -589,7 +589,7 @@ pub fn translate_exists_in_collection(
 
             let select_cols = vec![(
                 column_alias.clone(),
-                sql::ast::Expression::Value(sql::ast::Value::Int8(1)),
+                sql::ast::Expression::Value(sql::ast::Value::Int4(1)),
             )];
 
             // build a SELECT querying this table with the relevant predicate.

--- a/crates/query-engine/translation/src/translation/query/sorting.rs
+++ b/crates/query-engine/translation/src/translation/query/sorting.rs
@@ -638,7 +638,7 @@ fn translate_targets(
                                 index: element.index,
                                 direction: element.direction,
                                 alias: column_alias.clone(),
-                                expression: sql::ast::Expression::Value(sql::ast::Value::Int8(1)),
+                                expression: sql::ast::Expression::Value(sql::ast::Value::Int4(1)),
                                 aggregate: Some(sql::ast::Function::Unknown("COUNT".to_string())),
                             })
                         }

--- a/crates/query-engine/translation/src/translation/query/values.rs
+++ b/crates/query-engine/translation/src/translation/query/values.rs
@@ -165,9 +165,7 @@ pub fn translate_projected_variable(
         // ```
         database::Type::ArrayType(type_name) => {
             let array_table = state.make_table_alias("array".to_string());
-            let element_column = sql::ast::ColumnAlias {
-                name: "element".to_string(),
-            };
+            let element_column = sql::helpers::make_column_alias("element".to_string());
 
             let from_arr = sql::ast::From::JsonbArrayElements {
                 expression: exp,


### PR DESCRIPTION
### What

A few small refactorings of the sql stage:

1. Introduce `sql::string::append_<number-type>` functions for literal numbers instead of using `append_syntax`.
2. Remove a couple of unnecessary to_string()s
3. Remove box from a BTreeMap
4. Rename `Int8(i32)` to `Int4(i32)`.
5. Exhaustive list for `sql::ast::Expression` in the constant folding rewrite.
6. Use a newtype instead of a struct for column alias.