### PR TITLE
ndc-spec 0.1.3 with filter/order by nested fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,18 +1445,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ndc-models"
-version = "0.1.3"
-source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.3-rc.0#9cb5bce2010d778149715a9c33f68fff9e337861"
-dependencies = [
- "indexmap 2.2.6",
- "schemars",
- "serde",
- "serde_json",
- "serde_with",
-]
-
-[[package]]
 name = "ndc-postgres"
 version = "0.7.0"
 dependencies = [
@@ -1514,8 +1502,8 @@ dependencies = [
 
 [[package]]
 name = "ndc-sdk"
-version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-sdk-rs.git?rev=359a20b1e92ae85c691d943399cd62f1555177ba#359a20b1e92ae85c691d943399cd62f1555177ba"
+version = "0.1.3"
+source = "git+https://github.com/hasura/ndc-sdk-rs.git?rev=266f4db31777d2a0885a665e0d982237503b223c#266f4db31777d2a0885a665e0d982237503b223c"
 dependencies = [
  "async-trait",
  "axum",
@@ -1524,8 +1512,8 @@ dependencies = [
  "clap",
  "http",
  "mime",
- "ndc-models 0.1.3 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.3-rc.0)",
- "ndc-test 0.1.3 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.3-rc.0)",
+ "ndc-models",
+ "ndc-test",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-otlp",
@@ -1554,27 +1542,7 @@ dependencies = [
  "clap",
  "colorful",
  "indexmap 2.2.6",
- "ndc-models 0.1.3 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.3)",
- "rand",
- "reqwest",
- "semver",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "url",
-]
-
-[[package]]
-name = "ndc-test"
-version = "0.1.3"
-source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.3-rc.0#9cb5bce2010d778149715a9c33f68fff9e337861"
-dependencies = [
- "async-trait",
- "clap",
- "colorful",
- "indexmap 2.2.6",
- "ndc-models 0.1.3 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.3-rc.0)",
+ "ndc-models",
  "rand",
  "reqwest",
  "semver",
@@ -3163,7 +3131,7 @@ dependencies = [
  "ndc-postgres",
  "ndc-postgres-configuration",
  "ndc-sdk",
- "ndc-test 0.1.3 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.3)",
+ "ndc-test",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,15 +268,15 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -502,6 +502,15 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -737,6 +746,16 @@ name = "finl_unicode"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
+
+[[package]]
+name = "flate2"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flume"
@@ -1415,8 +1434,20 @@ dependencies = [
 
 [[package]]
 name = "ndc-models"
-version = "0.1.2"
-source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.2#6e7d12a31787d5f618099a42ddc0bea786438c00"
+version = "0.1.3"
+source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.3#b9316d206a6aece470531937f6e1ea9223e88122"
+dependencies = [
+ "indexmap 2.2.6",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "ndc-models"
+version = "0.1.3"
+source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.3-rc.0#9cb5bce2010d778149715a9c33f68fff9e337861"
 dependencies = [
  "indexmap 2.2.6",
  "schemars",
@@ -1484,7 +1515,7 @@ dependencies = [
 [[package]]
 name = "ndc-sdk"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-sdk-rs.git?rev=6158b1adbcc4ac7d8acb721c1626f6f715424a27#6158b1adbcc4ac7d8acb721c1626f6f715424a27"
+source = "git+https://github.com/hasura/ndc-sdk-rs.git?rev=359a20b1e92ae85c691d943399cd62f1555177ba#359a20b1e92ae85c691d943399cd62f1555177ba"
 dependencies = [
  "async-trait",
  "axum",
@@ -1493,8 +1524,8 @@ dependencies = [
  "clap",
  "http",
  "mime",
- "ndc-models",
- "ndc-test",
+ "ndc-models 0.1.3 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.3-rc.0)",
+ "ndc-test 0.1.3 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.3-rc.0)",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-otlp",
@@ -1516,14 +1547,34 @@ dependencies = [
 
 [[package]]
 name = "ndc-test"
-version = "0.1.2"
-source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.2#6e7d12a31787d5f618099a42ddc0bea786438c00"
+version = "0.1.3"
+source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.3#b9316d206a6aece470531937f6e1ea9223e88122"
 dependencies = [
  "async-trait",
  "clap",
  "colorful",
  "indexmap 2.2.6",
- "ndc-models",
+ "ndc-models 0.1.3 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.3)",
+ "rand",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "ndc-test"
+version = "0.1.3"
+source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.1.3-rc.0#9cb5bce2010d778149715a9c33f68fff9e337861"
+dependencies = [
+ "async-trait",
+ "clap",
+ "colorful",
+ "indexmap 2.2.6",
+ "ndc-models 0.1.3 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.3-rc.0)",
  "rand",
  "reqwest",
  "semver",
@@ -2238,7 +2289,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2317,8 +2368,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2331,12 +2409,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -2547,15 +2652,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.3.3"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
+checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
+ "indexmap 2.2.6",
  "serde",
+ "serde_derive",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -2563,9 +2670,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "2.3.3"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2772,8 +2879,8 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.21.10",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "sha2",
@@ -3056,7 +3163,7 @@ dependencies = [
  "ndc-postgres",
  "ndc-postgres-configuration",
  "ndc-sdk",
- "ndc-test",
+ "ndc-test 0.1.3 (git+https://github.com/hasura/ndc-spec.git?tag=v0.1.3)",
  "reqwest",
  "serde",
  "serde_json",
@@ -3220,6 +3327,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3255,6 +3373,7 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "bytes",
+ "flate2",
  "h2",
  "http",
  "http-body",
@@ -3263,7 +3382,11 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-native-certs",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,5 @@ too_many_lines = "allow"
 
 [workspace.dependencies]
 ndc-models = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.3" }
-ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs.git", rev = "359a20b1e92ae85c691d943399cd62f1555177ba" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs.git", rev = "266f4db31777d2a0885a665e0d982237503b223c" }
 ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,6 @@ similar_names = "allow"
 too_many_lines = "allow"
 
 [workspace.dependencies]
-ndc-models = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.2" }
-ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs.git", rev = "6158b1adbcc4ac7d8acb721c1626f6f715424a27" }
-ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.2" }
+ndc-models = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.3" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs.git", rev = "359a20b1e92ae85c691d943399cd62f1555177ba" }
+ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.3" }

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Support ndc-spec v0.1.3 and filter/order by nested fields.
+  ([#408](https://github.com/hasura/ndc-postgres/pull/486))
+
 ### Changed
 
 ### Fixed

--- a/crates/connectors/ndc-postgres/src/capabilities.rs
+++ b/crates/connectors/ndc-postgres/src/capabilities.rs
@@ -8,12 +8,16 @@ use ndc_sdk::models;
 /// from the NDC specification.
 pub fn get_capabilities() -> models::CapabilitiesResponse {
     models::CapabilitiesResponse {
-        version: "0.1.2".into(),
+        version: "0.1.3".into(),
         capabilities: models::Capabilities {
             query: models::QueryCapabilities {
                 aggregates: Some(models::LeafCapability {}),
                 variables: Some(models::LeafCapability {}),
                 explain: Some(models::LeafCapability {}),
+                nested_fields: models::NestedFieldCapabilities {
+                    filter_by: None,
+                    order_by: Some(models::LeafCapability {}),
+                },
             },
             mutation: models::MutationCapabilities {
                 transactional: Some(models::LeafCapability {}),

--- a/crates/connectors/ndc-postgres/src/capabilities.rs
+++ b/crates/connectors/ndc-postgres/src/capabilities.rs
@@ -15,7 +15,7 @@ pub fn get_capabilities() -> models::CapabilitiesResponse {
                 variables: Some(models::LeafCapability {}),
                 explain: Some(models::LeafCapability {}),
                 nested_fields: models::NestedFieldCapabilities {
-                    filter_by: None,
+                    filter_by: Some(models::LeafCapability {}),
                     order_by: Some(models::LeafCapability {}),
                 },
             },

--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -195,6 +195,7 @@ pub fn get_schema(
                             models::ObjectField {
                                 description: column_info.description.clone(),
                                 r#type: column_to_type(column_info),
+                                arguments: BTreeMap::new(),
                             },
                         )
                     })
@@ -220,6 +221,7 @@ pub fn get_schema(
                             models::ObjectField {
                                 description: column_info.description.clone(),
                                 r#type: readonly_column_to_type(column_info),
+                                arguments: BTreeMap::new(),
                             },
                         )
                     })
@@ -245,6 +247,7 @@ pub fn get_schema(
                             models::ObjectField {
                                 description: field_info.description.clone(),
                                 r#type: type_to_type(&field_info.r#type),
+                                arguments: BTreeMap::new(),
                             },
                         )
                     })
@@ -476,6 +479,7 @@ fn make_object_type(
                     models::ObjectField {
                         r#type: column_to_type(column),
                         description: None,
+                        arguments: BTreeMap::new(),
                     },
                 );
             }
@@ -600,6 +604,7 @@ fn make_procedure_type(
             r#type: models::Type::Named {
                 name: "int4".to_string(),
             },
+            arguments: BTreeMap::new(),
         },
     );
 
@@ -610,6 +615,7 @@ fn make_procedure_type(
             r#type: models::Type::Array {
                 element_type: Box::from(result_type),
             },
+            arguments: BTreeMap::new(),
         },
     );
 

--- a/crates/query-engine/sql/src/sql/ast.rs
+++ b/crates/query-engine/sql/src/sql/ast.rs
@@ -288,7 +288,15 @@ pub enum Expression {
     Count(CountType),
     ArrayConstructor(Vec<Expression>),
     CorrelatedSubSelect(Box<Select>),
+    NestedFieldSelect {
+        expression: Box<Expression>,
+        nested_field: NestedField,
+    },
 }
+
+/// Represents the name of a field in a nested object.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NestedField(pub String);
 
 /// An unary operator
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/query-engine/sql/src/sql/convert.rs
+++ b/crates/query-engine/sql/src/sql/convert.rs
@@ -501,6 +501,16 @@ impl Expression {
                 select.to_sql(sql);
                 sql.append_syntax(")");
             }
+            Expression::NestedFieldSelect {
+                expression,
+                nested_field,
+            } => {
+                sql.append_syntax("(");
+                expression.to_sql(sql);
+                sql.append_syntax(")");
+                sql.append_syntax(".");
+                nested_field.to_sql(sql);
+            }
         }
     }
 }
@@ -526,6 +536,12 @@ impl BinaryArrayOperator {
         match self {
             BinaryArrayOperator::In => sql.append_syntax(" IN "),
         }
+    }
+}
+
+impl NestedField {
+    pub fn to_sql(&self, sql: &mut SQL) {
+        sql.append_identifier(&self.0);
     }
 }
 

--- a/crates/query-engine/sql/src/sql/rewrites/constant_folding.rs
+++ b/crates/query-engine/sql/src/sql/rewrites/constant_folding.rs
@@ -283,6 +283,14 @@ pub fn normalize_expr(expr: Expression) -> Expression {
         Expression::CorrelatedSubSelect(select) => {
             Expression::CorrelatedSubSelect(Box::new(normalize_select(*select)))
         }
+        // Apply inner
+        Expression::NestedFieldSelect {
+            expression,
+            nested_field,
+        } => Expression::NestedFieldSelect {
+            expression: Box::new(normalize_expr(*expression)),
+            nested_field,
+        },
         // Nothing to do.
         Expression::RowToJson(_)
         | Expression::ColumnReference(_)

--- a/crates/query-engine/translation/src/translation/error.rs
+++ b/crates/query-engine/translation/src/translation/error.rs
@@ -48,11 +48,15 @@ pub enum Error {
 
 /// Capabilities we don't currently support.
 #[derive(Debug, Clone)]
-pub enum UnsupportedCapabilities {}
+pub enum UnsupportedCapabilities {
+    FieldArguments,
+}
 
 impl std::fmt::Display for UnsupportedCapabilities {
-    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            UnsupportedCapabilities::FieldArguments => write!(f, "Field arguments"),
+        }
     }
 }
 

--- a/crates/query-engine/translation/src/translation/mutation/translate.rs
+++ b/crates/query-engine/translation/src/translation/mutation/translate.rs
@@ -350,10 +350,18 @@ pub fn parse_procedure_fields(
 
             for (alias, field) in fields {
                 match field {
-                    models::Field::Column { column, fields: _ } if column == "affected_rows" => {
+                    models::Field::Column {
+                        column,
+                        fields: _,
+                        arguments,
+                    } if column == "affected_rows" && arguments.is_empty() => {
                         affected_rows = Some(indexmap!(alias => models::Aggregate::StarCount {}));
                     }
-                    models::Field::Column { column, fields } if column == "returning" => {
+                    models::Field::Column {
+                        column,
+                        fields,
+                        arguments,
+                    } if column == "returning" && arguments.is_empty() => {
                         returning = match fields {
                             Some(nested_fields) => match nested_fields {
                                 models::NestedField::Object(models::NestedObject { .. }) => {

--- a/crates/query-engine/translation/src/translation/query/filtering.rs
+++ b/crates/query-engine/translation/src/translation/query/filtering.rs
@@ -644,7 +644,9 @@ pub fn translate_exists_in_collection(
     }
 }
 
-fn match_on_column_type(
+/// Extract the scalar type name of a column down their nested field path.
+/// Will error if path do not lead to a scalar type.
+fn get_column_scalar_type_name(
     env: &Env,
     typ: &database::Type,
     field_path: &mut VecDeque<&String>,
@@ -660,6 +662,7 @@ fn match_on_column_type(
             None => Err(Error::NonScalarTypeUsedInOperator {
                 r#type: database::Type::CompositeType(composite_type.clone()),
             }),
+            // If a composite type has a field, try to extract its type.
             Some(field) => {
                 let composite_type = env.lookup_composite_type(composite_type)?;
                 match composite_type {
@@ -672,7 +675,7 @@ fn match_on_column_type(
                                 name.to_string(),
                             ))?
                             .r#type;
-                        match_on_column_type(env, typ, field_path)
+                        get_column_scalar_type_name(env, typ, field_path)
                     }
                     CompositeTypeInfo::Table { info, name } => {
                         let typ = &info
@@ -683,7 +686,7 @@ fn match_on_column_type(
                                 name.to_string(),
                             ))?
                             .r#type;
-                        match_on_column_type(env, typ, field_path)
+                        get_column_scalar_type_name(env, typ, field_path)
                     }
                 }
             }
@@ -707,7 +710,7 @@ fn get_comparison_target_type(
                 None => VecDeque::new(),
                 Some(field_path) => field_path.iter().collect(),
             };
-            match_on_column_type(env, &column.r#type, &mut field_path)
+            get_column_scalar_type_name(env, &column.r#type, &mut field_path)
         }
         models::ComparisonTarget::Column {
             name,
@@ -724,7 +727,7 @@ fn get_comparison_target_type(
                         .lookup_collection(&root_and_current_tables.current_table.name)?
                         .lookup_column(name)?;
 
-                    match_on_column_type(env, &column.r#type, &mut field_path)
+                    get_column_scalar_type_name(env, &column.r#type, &mut field_path)
                 }
                 Some(last) => {
                     let column = env
@@ -734,7 +737,7 @@ fn get_comparison_target_type(
                         )?
                         .lookup_column(name)?;
 
-                    match_on_column_type(env, &column.r#type, &mut field_path)
+                    get_column_scalar_type_name(env, &column.r#type, &mut field_path)
                 }
             }
         }

--- a/crates/query-engine/translation/src/translation/query/sorting.rs
+++ b/crates/query-engine/translation/src/translation/query/sorting.rs
@@ -10,9 +10,12 @@ use super::relationships;
 use super::root;
 use crate::translation::error::Error;
 use crate::translation::helpers::{
-    CollectionInfo, Env, RootAndCurrentTables, State, TableNameAndReference,
+    wrap_in_field_path, CollectionInfo, Env, FieldPath, RootAndCurrentTables, State,
+    TableNameAndReference,
 };
 use query_engine_sql::sql;
+
+// Top-level //
 
 /// Convert the order by fields from a QueryRequest to a SQL ORDER BY clause and potentially
 /// JOINs when we order by relationship fields.
@@ -61,6 +64,8 @@ pub fn translate_order_by(
     }
 }
 
+// Types //
+
 /// Group columns or aggregates with the same path element.
 /// Columns and aggregates need to be separated because they return
 /// different amount on rows.
@@ -68,7 +73,7 @@ pub fn translate_order_by(
 enum OrderByElementGroup<'a> {
     Columns {
         path: &'a [models::PathElement],
-        columns: Vec<GroupedOrderByElement<Column>>,
+        columns: Vec<GroupedOrderByElement<(Column, FieldPath)>>,
     },
     Aggregates {
         path: &'a [models::PathElement],
@@ -105,6 +110,8 @@ impl OrderByElementGroup<'_> {
     }
 }
 
+// Group elements //
+
 /// Group order by elements with the same path. Separate columns and aggregates
 /// because they each return different amount of rows.
 fn group_elements(elements: &[models::OrderByElement]) -> Vec<OrderByElementGroup> {
@@ -122,6 +129,7 @@ fn group_elements(elements: &[models::OrderByElement]) -> Vec<OrderByElementGrou
         (
             usize,                  // index
             &[models::PathElement], // path
+            FieldPath,              // field path
             models::OrderDirection, // order by direction
             Column,                 // column
         ),
@@ -140,20 +148,29 @@ fn group_elements(elements: &[models::OrderByElement]) -> Vec<OrderByElementGrou
     // for each element, insert them to their respective group according to their kind and path.
     for (i, element) in elements.iter().enumerate() {
         match &element.target {
-            models::OrderByTarget::Column { path, name } => column_element_groups.insert(
+            models::OrderByTarget::Column {
+                path,
+                name,
+                field_path,
+            } => column_element_groups.insert(
                 hash_path(path),
-                (i, path, element.order_direction, Column(name.to_string())),
-            ),
-            models::OrderByTarget::StarCountAggregate { path, .. } => aggregate_element_groups
-                .insert(
-                    hash_path(path),
-                    (
-                        i,
-                        path,
-                        element.order_direction,
-                        Aggregate::CountStarAggregate,
-                    ),
+                (
+                    i,
+                    path,
+                    field_path.into(),
+                    element.order_direction,
+                    Column(name.to_string()),
                 ),
+            ),
+            models::OrderByTarget::StarCountAggregate { path } => aggregate_element_groups.insert(
+                hash_path(path),
+                (
+                    i,
+                    path,
+                    element.order_direction,
+                    Aggregate::CountStarAggregate,
+                ),
+            ),
             models::OrderByTarget::SingleColumnAggregate {
                 path,
                 column,
@@ -181,11 +198,13 @@ fn group_elements(elements: &[models::OrderByElement]) -> Vec<OrderByElementGrou
             path: vec.first().unwrap().1,
             columns: vec
                 .into_iter()
-                .map(|(index, _, direction, element)| GroupedOrderByElement {
-                    index,
-                    direction,
-                    element,
-                })
+                .map(
+                    |(index, _, field_path, direction, element)| GroupedOrderByElement {
+                        index,
+                        direction,
+                        element: (element, field_path),
+                    },
+                )
                 .collect::<Vec<_>>(),
         });
     }
@@ -208,6 +227,8 @@ fn group_elements(elements: &[models::OrderByElement]) -> Vec<OrderByElementGrou
     element_vecs
 }
 
+// Translate a group //
+
 /// Translate an order by group and add additional JOINs to the wrapping SELECT
 /// and return the order by elements which capture the references to the expressions
 /// used for the sort by the wrapping SELECTs, together with their place in the order by list.
@@ -229,11 +250,14 @@ fn translate_order_by_target_group(
         // The column is from the source table, we just need to query it directly.
         ColumnsOrSelect::Columns(columns) => Ok(columns
             .into_iter()
-            .map(|(i, direction, column_name)| {
+            .map(|(i, direction, field_path, column_name)| {
                 (
                     i,
                     sql::ast::OrderByElement {
-                        target: sql::ast::Expression::ColumnReference(column_name.clone()),
+                        target: wrap_in_field_path(
+                            &field_path,
+                            sql::ast::Expression::ColumnReference(column_name.clone()),
+                        ),
                         direction: match direction {
                             models::OrderDirection::Asc => sql::ast::OrderByDirection::Asc,
                             models::OrderDirection::Desc => sql::ast::OrderByDirection::Desc,
@@ -260,17 +284,20 @@ fn translate_order_by_target_group(
             // Build an alias to query the column from this select.
             let columns = columns
                 .into_iter()
-                .map(|(i, direction, column)| {
+                .map(|(i, direction, field_path, column)| {
                     (
                         i,
                         sql::ast::OrderByElement {
-                            target: sql::ast::Expression::ColumnReference(
-                                sql::ast::ColumnReference::AliasedColumn {
-                                    table: sql::ast::TableReference::AliasedTable(
-                                        table_alias.clone(),
-                                    ),
-                                    column: column.clone(),
-                                },
+                            target: wrap_in_field_path(
+                                &field_path,
+                                sql::ast::Expression::ColumnReference(
+                                    sql::ast::ColumnReference::AliasedColumn {
+                                        table: sql::ast::TableReference::AliasedTable(
+                                            table_alias.clone(),
+                                        ),
+                                        column: column.clone(),
+                                    },
+                                ),
                             ),
                             direction: match direction {
                                 models::OrderDirection::Asc => sql::ast::OrderByDirection::Asc,
@@ -291,10 +318,23 @@ fn translate_order_by_target_group(
 /// or a select query describing how to reach the columns.
 enum ColumnsOrSelect {
     /// Columns represents target columns that are referenced from the current table.
-    Columns(Vec<(usize, models::OrderDirection, sql::ast::ColumnReference)>),
-    /// Select represents a select query which contain the requested columns.
+    Columns(
+        Vec<(
+            usize,                     // The global order by index for this column.
+            models::OrderDirection,    // The order direction.
+            FieldPath,                 // The nested field path.
+            sql::ast::ColumnReference, // A reference for this column.
+        )>,
+    ),
+    /// Select represents a select query for a relationship table which contain the requested columns.
     Select {
-        columns: Vec<(usize, models::OrderDirection, sql::ast::ColumnAlias)>,
+        columns: Vec<(
+            usize,                  // The global order by index for this column.
+            models::OrderDirection, // The order direction.
+            FieldPath,              // The nested field path.
+            sql::ast::ColumnAlias,  // The name of the selected column.
+                                    // This is not ColumnReference because the caller decides on the table alias.
+        )>,
         select: sql::ast::Select,
     },
 }
@@ -349,6 +389,7 @@ fn build_select_and_joins_for_order_by_group(
                     (
                         column.index,
                         column.direction,
+                        column.field_path,
                         sql::ast::ColumnReference::AliasedColumn {
                             table: root_and_current_tables.current_table.reference.clone(),
                             column: column.alias,
@@ -439,7 +480,14 @@ fn build_select_and_joins_for_order_by_group(
                 Ok(ColumnsOrSelect::Select {
                     columns: exprs
                         .into_iter()
-                        .map(|column| (column.index, column.direction, column.alias))
+                        .map(|column| {
+                            (
+                                column.index,
+                                column.direction,
+                                column.field_path,
+                                column.alias,
+                            )
+                        })
                         .collect(),
                     select,
                 })
@@ -476,6 +524,7 @@ impl PathElementSelectColumns {
 struct OrderBySelectExpression {
     index: usize,
     direction: models::OrderDirection,
+    field_path: FieldPath,
     alias: sql::ast::ColumnAlias,
     expression: sql::ast::Expression,
     aggregate: Option<sql::ast::Function>,
@@ -599,16 +648,17 @@ fn translate_targets(
     element_group: &OrderByElementGroup,
 ) -> Result<Vec<OrderBySelectExpression>, Error> {
     match element_group {
-        OrderByElementGroup::Columns { columns, .. } => {
+        OrderByElementGroup::Columns { columns, path: _ } => {
             let columns = columns
                 .iter()
                 .map(|element| {
-                    let Column(target_column_name) = &element.element;
+                    let (Column(target_column_name), field_path) = &element.element;
                     let selected_column = target_collection.lookup_column(target_column_name)?;
                     // we are going to deliberately use the table column name and not an alias we get from
                     // the query request because this is internal to the sorting mechanism.
                     let selected_column_alias =
                         sql::helpers::make_column_alias(selected_column.name.0.clone());
+
                     // we use the real name of the column as an alias as well.
                     Ok::<OrderBySelectExpression, Error>(OrderBySelectExpression {
                         index: element.index,
@@ -620,6 +670,7 @@ fn translate_targets(
                                 column: selected_column_alias,
                             },
                         ),
+                        field_path: field_path.clone(),
                         aggregate: None,
                     })
                 })
@@ -638,6 +689,8 @@ fn translate_targets(
                                 index: element.index,
                                 direction: element.direction,
                                 alias: column_alias.clone(),
+                                // Aggregates do not have a field path.
+                                field_path: (&None).into(),
                                 expression: sql::ast::Expression::Value(sql::ast::Value::Int4(1)),
                                 aggregate: Some(sql::ast::Function::Unknown("COUNT".to_string())),
                             })
@@ -653,6 +706,8 @@ fn translate_targets(
                                 index: element.index,
                                 direction: element.direction,
                                 alias: selected_column_alias.clone(),
+                                // Aggregates do not have a field path.
+                                field_path: (&None).into(),
                                 expression: sql::ast::Expression::ColumnReference(
                                     sql::ast::ColumnReference::AliasedColumn {
                                         table: table.reference.clone(),

--- a/crates/tests/databases-tests/src/postgres/explain_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/explain_tests.rs
@@ -61,6 +61,18 @@ mod query {
         insta::assert_snapshot!(result.details.query);
     }
 
+    #[tokio::test]
+    async fn order_by_nested_field() {
+        let result = run_query_explain(create_router().await, "order_by_nested_field").await;
+        let keywords = &[
+            "Sort Key",
+            "ProjectSet",
+            "group_leader\".characters).name) DESC",
+        ];
+        is_contained_in_lines(keywords, &result.details.plan);
+        insta::assert_snapshot!(result.details.query);
+    }
+
     mod native_queries {
         use super::super::super::common::create_router;
         use tests_common::assert::is_contained_in_lines;

--- a/crates/tests/databases-tests/src/postgres/query_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/query_tests.rs
@@ -308,6 +308,12 @@ mod predicates {
         let result = run_query(create_router().await, "duplicate_filter_results_nested").await;
         insta::assert_json_snapshot!(result);
     }
+
+    #[tokio::test]
+    async fn filter_by_nested_field() {
+        let result = run_query(create_router().await, "filter_by_nested_field").await;
+        insta::assert_json_snapshot!(result);
+    }
 }
 
 #[cfg(test)]
@@ -406,6 +412,12 @@ mod sorting {
             "sorting_by_nested_relationship_count",
         )
         .await;
+        insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test]
+    async fn order_by_nested_field() {
+        let result = run_query(create_router().await, "order_by_nested_field").await;
         insta::assert_json_snapshot!(result);
     }
 }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__order_by_nested_field.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__order_by_nested_field.snap
@@ -1,0 +1,72 @@
+---
+source: crates/tests/databases-tests/src/postgres/explain_tests.rs
+expression: result.details.query
+---
+EXPLAIN
+SELECT
+  coalesce(json_agg(row_to_json("%10_universe")), '[]') AS "universe"
+FROM
+  (
+    SELECT
+      *
+    FROM
+      (
+        SELECT
+          coalesce(json_agg(row_to_json("%11_rows")), '[]') AS "rows"
+        FROM
+          (
+            SELECT
+              "%3_nested_fields_collect"."collected" AS "name",
+              "%9_nested_fields_collect"."collected" AS "characters"
+            FROM
+              "public"."group_leader" AS "%0_group_leader"
+              LEFT OUTER JOIN LATERAL (
+                SELECT
+                  row_to_json("%1_nested_fields") AS "collected"
+                FROM
+                  (
+                    SELECT
+                      "%2_nested_field_binding"."name" AS "name",
+                      cast("%2_nested_field_binding"."popularity" as "text") AS "popularity"
+                    FROM
+                      (
+                        SELECT
+                          ("%0_group_leader"."name").*
+                      ) AS "%2_nested_field_binding"
+                  ) AS "%1_nested_fields"
+              ) AS "%3_nested_fields_collect" ON ('true')
+              LEFT OUTER JOIN LATERAL (
+                SELECT
+                  row_to_json("%4_nested_fields") AS "collected"
+                FROM
+                  (
+                    SELECT
+                      "%8_nested_fields_collect"."collected" AS "members",
+                      "%5_nested_field_binding"."name" AS "name"
+                    FROM
+                      (
+                        SELECT
+                          ("%0_group_leader"."characters").*
+                      ) AS "%5_nested_field_binding"
+                      LEFT OUTER JOIN LATERAL (
+                        SELECT
+                          json_agg(row_to_json("%6_nested_fields")) AS "collected"
+                        FROM
+                          (
+                            SELECT
+                              "%7_nested_field_binding"."name" AS "name",
+                              cast("%7_nested_field_binding"."popularity" as "text") AS "popularity"
+                            FROM
+                              (
+                                SELECT
+                                  (unnest("%5_nested_field_binding"."members")).*
+                              ) AS "%7_nested_field_binding"
+                          ) AS "%6_nested_fields"
+                      ) AS "%8_nested_fields_collect" ON ('true')
+                  ) AS "%4_nested_fields"
+              ) AS "%9_nested_fields_collect" ON ('true')
+            ORDER BY
+              ("%0_group_leader"."characters")."name" DESC
+          ) AS "%11_rows"
+      ) AS "%11_rows"
+  ) AS "%10_universe"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__predicates__filter_by_nested_field.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__predicates__filter_by_nested_field.snap
@@ -1,0 +1,29 @@
+---
+source: crates/tests/databases-tests/src/postgres/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": [
+      {
+        "name": {
+          "name": "Frodo",
+          "popularity": "3"
+        },
+        "characters": {
+          "members": [
+            {
+              "name": "Legolas",
+              "popularity": "200"
+            },
+            {
+              "name": "Gimli",
+              "popularity": "300"
+            }
+          ],
+          "name": "Fellowship"
+        }
+      }
+    ]
+  }
+]

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__sorting__order_by_nested_field.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__sorting__order_by_nested_field.snap
@@ -1,0 +1,63 @@
+---
+source: crates/tests/databases-tests/src/postgres/query_tests.rs
+expression: result
+---
+[
+  {
+    "rows": [
+      {
+        "name": {
+          "name": "Witch-king of Angmar",
+          "popularity": "70"
+        },
+        "characters": {
+          "members": [
+            {
+              "name": "Otsëa",
+              "popularity": "7"
+            }
+          ],
+          "name": "Nazgûl"
+        }
+      },
+      {
+        "name": {
+          "name": "Gollum",
+          "popularity": "1"
+        },
+        "characters": {
+          "members": [
+            {
+              "name": "Frodo",
+              "popularity": "3"
+            },
+            {
+              "name": "Sam",
+              "popularity": "9000"
+            }
+          ],
+          "name": "Mellowship"
+        }
+      },
+      {
+        "name": {
+          "name": "Frodo",
+          "popularity": "3"
+        },
+        "characters": {
+          "members": [
+            {
+              "name": "Legolas",
+              "popularity": "200"
+            },
+            {
+              "name": "Gimli",
+              "popularity": "300"
+            }
+          ],
+          "name": "Fellowship"
+        }
+      }
+    ]
+  }
+]

--- a/crates/tests/databases-tests/src/snapshots/databases_tests__capabilities_tests__get_capabilities.snap
+++ b/crates/tests/databases-tests/src/snapshots/databases_tests__capabilities_tests__get_capabilities.snap
@@ -10,6 +10,7 @@ expression: "ndc_postgres::capabilities::get_capabilities()"
       "variables": {},
       "explain": {},
       "nested_fields": {
+        "filter_by": {},
         "order_by": {}
       }
     },

--- a/crates/tests/databases-tests/src/snapshots/databases_tests__capabilities_tests__get_capabilities.snap
+++ b/crates/tests/databases-tests/src/snapshots/databases_tests__capabilities_tests__get_capabilities.snap
@@ -3,12 +3,15 @@ source: crates/tests/databases-tests/src/capabilities_tests.rs
 expression: "ndc_postgres::capabilities::get_capabilities()"
 ---
 {
-  "version": "0.1.2",
+  "version": "0.1.3",
   "capabilities": {
     "query": {
       "aggregates": {},
       "variables": {},
-      "explain": {}
+      "explain": {},
+      "nested_fields": {
+        "order_by": {}
+      }
     },
     "mutation": {
       "transactional": {},

--- a/crates/tests/tests-common/goldenfiles/filter_by_nested_field.json
+++ b/crates/tests/tests-common/goldenfiles/filter_by_nested_field.json
@@ -13,21 +13,20 @@
         "arguments": {}
       }
     },
-    "predicate":
-        {
-          "type": "binary_comparison_operator",
-          "column": {
-            "type": "column",
-            "name": "characters",
-            "path": [],
-            "field_path": ["name"]
-          },
-          "operator": "_eq",
-          "value": {
-            "type": "scalar",
-            "value": "Fellowship"
-          }
-        }
+    "predicate": {
+      "type": "binary_comparison_operator",
+      "column": {
+        "type": "column",
+        "name": "characters",
+        "path": [],
+        "field_path": ["name"]
+      },
+      "operator": "_eq",
+      "value": {
+        "type": "scalar",
+        "value": "Fellowship"
+      }
+    }
   },
   "arguments": {},
   "collection_relationships": {}

--- a/crates/tests/tests-common/goldenfiles/filter_by_nested_field.json
+++ b/crates/tests/tests-common/goldenfiles/filter_by_nested_field.json
@@ -13,19 +13,21 @@
         "arguments": {}
       }
     },
-    "order_by": {
-      "elements": [
+    "predicate":
         {
-          "order_direction": "asc",
-          "target": {
+          "type": "binary_comparison_operator",
+          "column": {
             "type": "column",
             "name": "characters",
-            "path": []
+            "path": [],
+            "field_path": ["name"]
+          },
+          "operator": "_eq",
+          "value": {
+            "type": "scalar",
+            "value": "Fellowship"
           }
         }
-      ]
-    },
-    "limit": 1
   },
   "arguments": {},
   "collection_relationships": {}

--- a/crates/tests/tests-common/goldenfiles/order_by_nested_field.json
+++ b/crates/tests/tests-common/goldenfiles/order_by_nested_field.json
@@ -16,16 +16,16 @@
     "order_by": {
       "elements": [
         {
-          "order_direction": "asc",
+          "order_direction": "desc",
           "target": {
             "type": "column",
             "name": "characters",
-            "path": []
+            "path": [],
+            "field_path": ["name"]
           }
         }
       ]
-    },
-    "limit": 1
+    }
   },
   "arguments": {},
   "collection_relationships": {}

--- a/crates/tests/tests-common/src/common_tests/ndc_tests.rs
+++ b/crates/tests/tests-common/src/common_tests/ndc_tests.rs
@@ -51,6 +51,9 @@ pub async fn test_connector(router: axum::Router) -> Result {
 
     ndc_test::test_connector(
         &ndc_test::configuration::TestConfiguration {
+            options: ndc_test::configuration::TestOptions {
+                validate_responses: true,
+            },
             seed: None,
             snapshots_dir: None,
             gen_config: ndc_test::configuration::TestGenerationConfiguration::default(),

--- a/static/composite-types-complex.sql
+++ b/static/composite-types-complex.sql
@@ -42,3 +42,19 @@ insert into group_leader values
       ARRAY[ROW('Legolas', 200)::chara, ROW('Gimli', 300)::chara]::chara[]
     )::characters
   );
+
+insert into group_leader values
+  ( 2,
+    ROW('Gollum', 1)::chara,
+    ROW('Mellowship',
+      ARRAY[ROW('Frodo', 3)::chara, ROW('Sam', 9000)::chara]::chara[]
+    )::characters
+  );
+
+insert into group_leader values
+  ( 3,
+    ROW('Witch-king of Angmar', 70)::chara,
+    ROW('Nazgûl',
+      ARRAY[ROW('Otsëa', 7)::chara]::chara[]
+    )::characters
+  );


### PR DESCRIPTION
### What

1. Update ndc-spec to version [0.1.3](https://github.com/hasura/ndc-spec/releases/tag/v0.1.3).
2. Implemented the new capabilities: filter and order by nested fields.

### How

#### Nested fields selection

We add SQL syntax for accessing an expression's field. The syntax is `(<expression>).<field>`

#### Order by nested fields

We add the field selection to the sort expression in the `ORDER BY` clause so it looks like this: `ORDER BY (column).field ASC`.
Implementation wise, we thread the field path like we do for the sort direction, and wrap the expressions in a NestedFieldSelect clause.

#### Filter by nested fields

- We directly wrap columns that contain field paths when they are used inside the predicate.
- We extract the type of a nested field by recursively looking it up in the environment.