### PR TITLE
introduce unique_constraints module

### DIFF
--- a/crates/query-engine/translation/src/translation/mutation/experimental/delete.rs
+++ b/crates/query-engine/translation/src/translation/mutation/experimental/delete.rs
@@ -1,5 +1,6 @@
 //! Auto-generate delete mutations and translate them into sql ast.
 
+use super::unique_constraints::get_non_compound_uniqueness_constraints;
 use crate::translation::error::Error;
 use crate::translation::helpers::{self, TableNameAndReference};
 use crate::translation::query::filtering;
@@ -32,23 +33,6 @@ pub struct Filter {
     pub description: String,
 }
 
-/// Get all columns that have a uniqueness constraints by themselves in a particular table.
-/// For now, we can delete using any uniqueness constraint with one column in it.
-fn get_non_compound_uniqueness_constraints(table_info: &database::TableInfo) -> Vec<String> {
-    table_info
-        .uniqueness_constraints
-        .0
-        .iter()
-        .filter_map(|(_constraint_name, constraint_set)| {
-            if constraint_set.0.len() == 1 {
-                constraint_set.0.first().cloned()
-            } else {
-                None
-            }
-        })
-        .collect()
-}
-
 /// generate a delete for each simple unique constraint on this table
 pub fn generate_delete_by_unique(
     collection_name: &String,
@@ -64,7 +48,7 @@ pub fn generate_delete_by_unique(
             );
 
             let description = format!(
-                "Delete any value on the '{}' collection using the '{}' key",
+                "Delete any row on the '{}' collection using the '{}' key",
                 collection_name, unique_column.name
             );
 

--- a/crates/query-engine/translation/src/translation/mutation/experimental/mod.rs
+++ b/crates/query-engine/translation/src/translation/mutation/experimental/mod.rs
@@ -5,6 +5,7 @@ pub mod delete;
 pub mod generate;
 pub mod insert;
 pub mod translate;
+pub mod unique_constraints;
 
 pub use generate::{generate, Mutation};
 pub use translate::translate;

--- a/crates/query-engine/translation/src/translation/mutation/experimental/unique_constraints.rs
+++ b/crates/query-engine/translation/src/translation/mutation/experimental/unique_constraints.rs
@@ -1,0 +1,20 @@
+//! Utility functions for generating unique constraints
+
+use query_engine_metadata::metadata::database;
+
+/// Get all columns that have a uniqueness constraints by themselves in a particular table.
+/// For now, we can delete/update using any uniqueness constraint with one column in it.
+pub fn get_non_compound_uniqueness_constraints(table_info: &database::TableInfo) -> Vec<String> {
+    table_info
+        .uniqueness_constraints
+        .0
+        .iter()
+        .filter_map(|(_constraint_name, constraint_set)| {
+            if constraint_set.0.len() == 1 {
+                constraint_set.0.first().cloned()
+            } else {
+                None
+            }
+        })
+        .collect()
+}

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
@@ -5897,7 +5897,7 @@ expression: result
     },
     {
       "name": "experimental_delete_Album_by_AlbumId",
-      "description": "Delete any value on the 'Album' collection using the 'AlbumId' key",
+      "description": "Delete any row on the 'Album' collection using the 'AlbumId' key",
       "arguments": {
         "AlbumId": {
           "description": "The identifier of an album",
@@ -5921,7 +5921,7 @@ expression: result
     },
     {
       "name": "experimental_delete_Artist_by_ArtistId",
-      "description": "Delete any value on the 'Artist' collection using the 'ArtistId' key",
+      "description": "Delete any row on the 'Artist' collection using the 'ArtistId' key",
       "arguments": {
         "ArtistId": {
           "description": "The identifier of an artist",
@@ -5945,7 +5945,7 @@ expression: result
     },
     {
       "name": "experimental_delete_Customer_by_CustomerId",
-      "description": "Delete any value on the 'Customer' collection using the 'CustomerId' key",
+      "description": "Delete any row on the 'Customer' collection using the 'CustomerId' key",
       "arguments": {
         "CustomerId": {
           "description": "The identifier of customer",
@@ -5969,7 +5969,7 @@ expression: result
     },
     {
       "name": "experimental_delete_Employee_by_EmployeeId",
-      "description": "Delete any value on the 'Employee' collection using the 'EmployeeId' key",
+      "description": "Delete any row on the 'Employee' collection using the 'EmployeeId' key",
       "arguments": {
         "EmployeeId": {
           "type": {
@@ -5992,7 +5992,7 @@ expression: result
     },
     {
       "name": "experimental_delete_Genre_by_GenreId",
-      "description": "Delete any value on the 'Genre' collection using the 'GenreId' key",
+      "description": "Delete any row on the 'Genre' collection using the 'GenreId' key",
       "arguments": {
         "GenreId": {
           "type": {
@@ -6015,7 +6015,7 @@ expression: result
     },
     {
       "name": "experimental_delete_InvoiceLine_by_InvoiceLineId",
-      "description": "Delete any value on the 'InvoiceLine' collection using the 'InvoiceLineId' key",
+      "description": "Delete any row on the 'InvoiceLine' collection using the 'InvoiceLineId' key",
       "arguments": {
         "InvoiceLineId": {
           "type": {
@@ -6038,7 +6038,7 @@ expression: result
     },
     {
       "name": "experimental_delete_Invoice_by_InvoiceId",
-      "description": "Delete any value on the 'Invoice' collection using the 'InvoiceId' key",
+      "description": "Delete any row on the 'Invoice' collection using the 'InvoiceId' key",
       "arguments": {
         "InvoiceId": {
           "type": {
@@ -6061,7 +6061,7 @@ expression: result
     },
     {
       "name": "experimental_delete_MediaType_by_MediaTypeId",
-      "description": "Delete any value on the 'MediaType' collection using the 'MediaTypeId' key",
+      "description": "Delete any row on the 'MediaType' collection using the 'MediaTypeId' key",
       "arguments": {
         "MediaTypeId": {
           "type": {
@@ -6084,7 +6084,7 @@ expression: result
     },
     {
       "name": "experimental_delete_Playlist_by_PlaylistId",
-      "description": "Delete any value on the 'Playlist' collection using the 'PlaylistId' key",
+      "description": "Delete any row on the 'Playlist' collection using the 'PlaylistId' key",
       "arguments": {
         "PlaylistId": {
           "type": {
@@ -6107,7 +6107,7 @@ expression: result
     },
     {
       "name": "experimental_delete_Track_by_TrackId",
-      "description": "Delete any value on the 'Track' collection using the 'TrackId' key",
+      "description": "Delete any row on the 'Track' collection using the 'TrackId' key",
       "arguments": {
         "TrackId": {
           "type": {
@@ -6130,7 +6130,7 @@ expression: result
     },
     {
       "name": "experimental_delete_custom_defaults_by_id",
-      "description": "Delete any value on the 'custom_defaults' collection using the 'id' key",
+      "description": "Delete any row on the 'custom_defaults' collection using the 'id' key",
       "arguments": {
         "filter": {
           "description": "Delete permission predicate over the 'custom_defaults' collection",
@@ -6153,7 +6153,7 @@ expression: result
     },
     {
       "name": "experimental_delete_custom_dog_by_id",
-      "description": "Delete any value on the 'custom_dog' collection using the 'id' key",
+      "description": "Delete any row on the 'custom_dog' collection using the 'id' key",
       "arguments": {
         "filter": {
           "description": "Delete permission predicate over the 'custom_dog' collection",
@@ -6176,7 +6176,7 @@ expression: result
     },
     {
       "name": "experimental_delete_spatial_ref_sys_by_srid",
-      "description": "Delete any value on the 'spatial_ref_sys' collection using the 'srid' key",
+      "description": "Delete any row on the 'spatial_ref_sys' collection using the 'srid' key",
       "arguments": {
         "filter": {
           "description": "Delete permission predicate over the 'spatial_ref_sys' collection",
@@ -6199,7 +6199,7 @@ expression: result
     },
     {
       "name": "experimental_delete_topology_topology_by_id",
-      "description": "Delete any value on the 'topology_topology' collection using the 'id' key",
+      "description": "Delete any row on the 'topology_topology' collection using the 'id' key",
       "arguments": {
         "filter": {
           "description": "Delete permission predicate over the 'topology_topology' collection",
@@ -6222,7 +6222,7 @@ expression: result
     },
     {
       "name": "experimental_delete_topology_topology_by_name",
-      "description": "Delete any value on the 'topology_topology' collection using the 'name' key",
+      "description": "Delete any row on the 'topology_topology' collection using the 'name' key",
       "arguments": {
         "filter": {
           "description": "Delete permission predicate over the 'topology_topology' collection",


### PR DESCRIPTION
### What

For Delete by key we have a function that returns the unique constraints of a table.
This can be useful for Update by key, which we will introduce soon, as well.

In this PR we move this function to its own module.

We also change a word in the schema description of delete.
