### PR TITLE
add UPDATE ast

### DIFF
--- a/crates/query-engine/sql/src/sql/ast.rs
+++ b/crates/query-engine/sql/src/sql/ast.rs
@@ -29,6 +29,7 @@ pub enum CTExpr {
     RawSql(Vec<RawSql>),
     Delete(Delete),
     Insert(Insert),
+    Update(Update),
 }
 
 /// Raw SQL written by a user which is opaque to us
@@ -83,6 +84,24 @@ pub struct Delete {
     pub from: From,
     pub where_: Where,
     pub returning: Returning,
+}
+
+/// An UPDATE clause
+#[derive(Debug, Clone, PartialEq)]
+pub struct Update {
+    pub schema: SchemaName,
+    pub table: TableName,
+    pub alias: TableAlias,
+    pub set: BTreeMap<ColumnName, UpdateExpression>,
+    pub where_: Where,
+    pub returning: Returning,
+}
+
+/// An expression inside an UPDATE SET clause
+#[derive(Debug, Clone, PartialEq)]
+pub enum UpdateExpression {
+    Default,
+    Expression(Expression),
 }
 
 /// a RETURNING clause

--- a/crates/query-engine/sql/src/sql/convert.rs
+++ b/crates/query-engine/sql/src/sql/convert.rs
@@ -57,6 +57,7 @@ impl CTExpr {
             }
             CTExpr::Delete(delete) => delete.to_sql(sql),
             CTExpr::Insert(insert) => insert.to_sql(sql),
+            CTExpr::Update(update) => update.to_sql(sql),
         }
     }
 }
@@ -217,6 +218,38 @@ impl Delete {
         sql.append_syntax(" ");
 
         returning.to_sql(sql);
+    }
+}
+
+impl Update {
+    pub fn to_sql(&self, sql: &mut SQL) {
+        sql.append_syntax("UPDATE ");
+
+        self.schema.to_sql(sql);
+        sql.append_syntax(".");
+        self.table.to_sql(sql);
+        sql.append_syntax(" AS ");
+        self.alias.to_sql(sql);
+
+        sql.append_syntax(" SET ");
+
+        // Set values to columns
+        for (index, (column, expression)) in self.set.iter().enumerate() {
+            column.to_sql(sql);
+            sql.append_syntax(" = ");
+            expression.to_sql(sql);
+            if index < (self.set.len() - 1) {
+                sql.append_syntax(", ");
+            }
+        }
+
+        sql.append_syntax(" ");
+
+        self.where_.to_sql(sql);
+
+        sql.append_syntax(" ");
+
+        self.returning.to_sql(sql);
     }
 }
 
@@ -605,6 +638,15 @@ impl InsertExpression {
         match &self {
             InsertExpression::Expression(expression) => expression.to_sql(sql),
             InsertExpression::Default => sql.append_syntax("DEFAULT"),
+        }
+    }
+}
+
+impl UpdateExpression {
+    pub fn to_sql(&self, sql: &mut SQL) {
+        match &self {
+            UpdateExpression::Expression(expression) => expression.to_sql(sql),
+            UpdateExpression::Default => sql.append_syntax("DEFAULT"),
         }
     }
 }


### PR DESCRIPTION
### What

We will soon add an auto generated Update by key procedure. This procedure will be translate to a SQL UPDATE statement.

In this PR we introduce this AST representation of Update statements.
Of course, this might change once we actually implement the feature.

### How

Add AST definition, conversion to string, and constant folding handling.

https://www.postgresql.org/docs/current/sql-update.html
