### PR TITLE
Revise the mutations API

### DIFF
--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -426,7 +426,7 @@ fn experimental_delete_to_procedure(
     match delete {
         mutation::experimental::delete::DeleteMutation::DeleteByKey {
             by_columns,
-            filter,
+            pre_check,
             description,
             collection_name,
             table_name: _,
@@ -445,12 +445,12 @@ fn experimental_delete_to_procedure(
             }
 
             arguments.insert(
-                filter.argument_name.clone(),
+                pre_check.argument_name.clone(),
                 models::ArgumentInfo {
                     argument_type: models::Type::Predicate {
                         object_type_name: collection_name.clone(),
                     },
-                    description: Some(filter.description.clone()),
+                    description: Some(pre_check.description.clone()),
                 },
             );
 
@@ -547,7 +547,7 @@ fn experimental_insert_to_procedure(
     object_types.insert(object_name.clone(), object_type);
 
     arguments.insert(
-        "_objects".to_string(),
+        insert.objects_argument_name.clone(),
         models::ArgumentInfo {
             argument_type: models::Type::Array {
                 element_type: Box::new(models::Type::Named { name: object_name }),
@@ -556,12 +556,12 @@ fn experimental_insert_to_procedure(
         },
     );
     arguments.insert(
-        insert.constraint.argument_name.clone(),
+        insert.post_check.argument_name.clone(),
         models::ArgumentInfo {
             argument_type: models::Type::Predicate {
                 object_type_name: insert.collection_name.clone(),
             },
-            description: Some(insert.constraint.description.clone()),
+            description: Some(insert.post_check.description.clone()),
         },
     );
 

--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -437,7 +437,7 @@ fn experimental_delete_to_procedure(
 
             for column in by_columns {
                 arguments.insert(
-                    format!("{}{}", columns_prefix, column.name.clone()),
+                    format!("{}{}", columns_prefix, column.name),
                     models::ArgumentInfo {
                         argument_type: column_to_type(column),
                         description: column.description.clone(),
@@ -592,7 +592,7 @@ fn experimental_update_to_procedure(
     // by columns arguments.
     for by_column in &update_by_key.by_columns {
         arguments.insert(
-            format!("{}{}", update_by_key.columns_prefix, by_column.name.clone()),
+            format!("{}{}", update_by_key.columns_prefix, by_column.name),
             models::ArgumentInfo {
                 argument_type: column_to_type(by_column),
                 description: by_column.description.clone(),

--- a/crates/connectors/ndc-postgres/src/schema.rs
+++ b/crates/connectors/ndc-postgres/src/schema.rs
@@ -429,6 +429,7 @@ fn experimental_delete_to_procedure(
             pre_check,
             description,
             collection_name,
+            columns_prefix,
             table_name: _,
             schema_name: _,
         } => {
@@ -436,7 +437,7 @@ fn experimental_delete_to_procedure(
 
             for column in by_columns {
                 arguments.insert(
-                    column.name.clone(),
+                    format!("{}{}", columns_prefix, column.name.clone()),
                     models::ArgumentInfo {
                         argument_type: column_to_type(column),
                         description: column.description.clone(),
@@ -591,7 +592,7 @@ fn experimental_update_to_procedure(
     // by columns arguments.
     for by_column in &update_by_key.by_columns {
         arguments.insert(
-            by_column.name.clone(),
+            format!("{}{}", update_by_key.columns_prefix, by_column.name.clone()),
             models::ArgumentInfo {
                 argument_type: column_to_type(by_column),
                 description: by_column.description.clone(),

--- a/crates/query-engine/translation/src/translation/mutation/experimental/common.rs
+++ b/crates/query-engine/translation/src/translation/mutation/experimental/common.rs
@@ -94,3 +94,10 @@ pub fn get_unique_constraint_name_and_key_columns(
 
     Some((constraint_name, key_columns))
 }
+
+/// The name and description of a check input argument.
+#[derive(Debug, Clone)]
+pub struct CheckArgument {
+    pub argument_name: String,
+    pub description: String,
+}

--- a/crates/query-engine/translation/src/translation/mutation/experimental/delete.rs
+++ b/crates/query-engine/translation/src/translation/mutation/experimental/delete.rs
@@ -24,6 +24,7 @@ pub enum DeleteMutation {
         schema_name: sql::ast::SchemaName,
         table_name: sql::ast::TableName,
         by_columns: NonEmpty<metadata::database::ColumnInfo>,
+        columns_prefix: String,
         pre_check: CheckArgument,
     },
 }
@@ -59,6 +60,7 @@ pub fn generate_delete_by_unique(
                 table_name: sql::ast::TableName(table_info.table_name.clone()),
                 collection_name: collection_name.clone(),
                 by_columns: key_columns,
+                columns_prefix: "key_".to_string(),
                 pre_check: CheckArgument {
                     argument_name: "pre_check".to_string(),
                     description: format!(
@@ -86,6 +88,7 @@ pub fn translate(
             schema_name,
             table_name,
             by_columns,
+            columns_prefix,
             pre_check,
             description: _,
         } => {
@@ -112,7 +115,7 @@ pub fn translate(
                 .iter()
                 .map(|by_column| {
                     let unique_key = arguments
-                        .get(&by_column.name)
+                        .get(&format!("{}{}", columns_prefix, by_column.name))
                         .ok_or(Error::ArgumentNotFound(by_column.name.clone()))?;
 
                     let key_value =

--- a/crates/query-engine/translation/src/translation/mutation/experimental/delete.rs
+++ b/crates/query-engine/translation/src/translation/mutation/experimental/delete.rs
@@ -11,7 +11,7 @@ use query_engine_metadata::metadata::database;
 use query_engine_sql::sql;
 use std::collections::BTreeMap;
 
-use super::common;
+use super::common::{self, CheckArgument};
 
 /// A representation of an auto-generated delete mutation.
 ///
@@ -24,15 +24,8 @@ pub enum DeleteMutation {
         schema_name: sql::ast::SchemaName,
         table_name: sql::ast::TableName,
         by_columns: NonEmpty<metadata::database::ColumnInfo>,
-        filter: Filter,
+        pre_check: CheckArgument,
     },
-}
-
-/// The name and description of the filter input argument.
-#[derive(Debug, Clone)]
-pub struct Filter {
-    pub argument_name: String,
-    pub description: String,
 }
 
 /// generate a delete for each simple unique constraint on this table
@@ -66,8 +59,8 @@ pub fn generate_delete_by_unique(
                 table_name: sql::ast::TableName(table_info.table_name.clone()),
                 collection_name: collection_name.clone(),
                 by_columns: key_columns,
-                filter: Filter {
-                    argument_name: "%filter".to_string(),
+                pre_check: CheckArgument {
+                    argument_name: "pre_check".to_string(),
                     description: format!(
                         "Delete permission predicate over the '{collection_name}' collection"
                     ),
@@ -93,7 +86,7 @@ pub fn translate(
             schema_name,
             table_name,
             by_columns,
-            filter,
+            pre_check,
             description: _,
         } => {
             // The root table we are going to be deleting from.
@@ -139,13 +132,13 @@ pub fn translate(
                 })
                 .collect::<Result<Vec<sql::ast::Expression>, Error>>()?;
 
-            // Build the `filter` argument boolean expression.
+            // Build the `pre_check` argument boolean expression.
             let predicate_json = arguments
-                .get(&filter.argument_name)
-                .ok_or(Error::ArgumentNotFound(filter.argument_name.clone()))?;
+                .get(&pre_check.argument_name)
+                .ok_or(Error::ArgumentNotFound(pre_check.argument_name.clone()))?;
 
             let predicate: models::Expression = serde_json::from_value(predicate_json.clone())
-                .map_err(|_| Error::ArgumentNotFound(filter.argument_name.clone()))?;
+                .map_err(|_| Error::ArgumentNotFound(pre_check.argument_name.clone()))?;
 
             let predicate_expression = filtering::translate_expression(
                 env,

--- a/crates/query-engine/translation/src/translation/mutation/experimental/mod.rs
+++ b/crates/query-engine/translation/src/translation/mutation/experimental/mod.rs
@@ -8,21 +8,21 @@
 //! * A single insert procedure is generated per table of the form:
 //!   > <version>_insert_<table>(
 //!   >     objects: [<object>],
-//!   >     constraint: <boolexpr>
+//!   >     post_check: <boolexpr>
 //!   > )
 //!   It allows us to insert multiple objects and include a post check for permissions.
 //!
 //! * A delete procedure is generated per table X unique constraint of the form:
-//!   > <version>_delete_<table>_by_<column, ...>(
+//!   > <version>_delete_<table>_by_<column_and_...>(
 //!   >     <column1>: <value>,
 //!   >     <column2>: <value>,
 //!   >     ...,
-//!   >     filter: <boolexpr>
+//!   >     pre_check: <boolexpr>
 //!   > )
 //!   It allows us to delete a single row using the uniqueness constraint, and contains a boolexpr for permissions.
 //!
 //! * An update procedure is generated per table X unique constraint of the form:
-//!   > <version>_update_<table>_by_<column, ...>(
+//!   > <version>_update_<table>_by_<column_and_...>(
 //!   >     <column1>: <value>,
 //!   >     <column2>: <value>,
 //!   >     ...,
@@ -34,8 +34,8 @@
 //!   and contains a pre check and post check for permissions.
 //!
 //! * Mutations using uniqueness constraints use the naming schema `by_column_and_column_and_column` instead of the db constraint name.
-//! * If generating a mutation encounters an internal error, we skip that particular mutation instead of throwing an error so the
-//!   connector can start at any situation.
+//! * If generating a mutation encounters an internal error, we skip that particular mutation and trace a warning instead of throwing
+//!   an error so the connector can start at any situation.
 //! * Naming collisions between the unique constraints and the update_columns / pre_check / post_check could be a problem.
 
 pub mod common;

--- a/crates/query-engine/translation/src/translation/mutation/experimental/mod.rs
+++ b/crates/query-engine/translation/src/translation/mutation/experimental/mod.rs
@@ -14,8 +14,8 @@
 //!
 //! * A delete procedure is generated per table X unique constraint of the form:
 //!   > <version>_delete_<table>_by_<column_and_...>(
-//!   >     <column1>: <value>,
-//!   >     <column2>: <value>,
+//!   >     key_<column1>: <value>,
+//!   >     key_<column2>: <value>,
 //!   >     ...,
 //!   >     pre_check: <boolexpr>
 //!   > )
@@ -23,8 +23,8 @@
 //!
 //! * An update procedure is generated per table X unique constraint of the form:
 //!   > <version>_update_<table>_by_<column_and_...>(
-//!   >     <column1>: <value>,
-//!   >     <column2>: <value>,
+//!   >     key_<column1>: <value>,
+//!   >     key_<column2>: <value>,
 //!   >     ...,
 //!   >     update_columns: { <column>: { _set: <value> }, ... },
 //!   >     pre_check: <boolexpr>,
@@ -36,7 +36,6 @@
 //! * Mutations using uniqueness constraints use the naming schema `by_column_and_column_and_column` instead of the db constraint name.
 //! * If generating a mutation encounters an internal error, we skip that particular mutation and trace a warning instead of throwing
 //!   an error so the connector can start at any situation.
-//! * Naming collisions between the unique constraints and the update_columns / pre_check / post_check could be a problem.
 
 pub mod common;
 pub mod delete;

--- a/crates/query-engine/translation/src/translation/mutation/experimental/mod.rs
+++ b/crates/query-engine/translation/src/translation/mutation/experimental/mod.rs
@@ -33,9 +33,12 @@
 //!   It allows us to update a single row using the uniqueness constraint by updating the relevant columns,
 //!   and contains a pre check and post check for permissions.
 //!
-//! * Mutations using uniqueness constraints use the naming schema `by_column_and_column_and_column` instead of the db constraint name.
+//! * Mutations using uniqueness constraints use the naming schema `by_column_and_column_and_column` instead of the db constraint name,
+//!   because the former is far more helpful.
 //! * If generating a mutation encounters an internal error, we skip that particular mutation and trace a warning instead of throwing
 //!   an error so the connector can start at any situation.
+//! * Naming collisions between the unique constraints and the update_columns / pre_check / post_check is avoided by prefixing argument
+//!   names of the columns of a unique constraint with `key_`.
 
 pub mod common;
 pub mod delete;

--- a/crates/query-engine/translation/src/translation/mutation/experimental/update.rs
+++ b/crates/query-engine/translation/src/translation/mutation/experimental/update.rs
@@ -30,6 +30,7 @@ pub struct UpdateByKey {
     pub schema_name: sql::ast::SchemaName,
     pub table_name: sql::ast::TableName,
     pub by_columns: NonEmpty<metadata::database::ColumnInfo>,
+    pub columns_prefix: String,
     pub update_columns_argument_name: String,
     pub pre_check: Constraint,
     pub post_check: Constraint,
@@ -74,6 +75,7 @@ pub fn generate_update_by_unique(
                 table_name: sql::ast::TableName(table_info.table_name.clone()),
                 collection_name: collection_name.clone(),
                 by_columns: key_columns,
+                columns_prefix: "key_".to_string(),
                 update_columns_argument_name: "update_columns".to_string(),
                 pre_check: Constraint {
                     argument_name: "pre_check".to_string(),
@@ -129,7 +131,7 @@ pub fn translate(
                 .iter()
                 .map(|by_column| {
                     let unique_key = arguments
-                        .get(&by_column.name)
+                        .get(&format!("{}{}", mutation.columns_prefix, by_column.name))
                         .ok_or(Error::ArgumentNotFound(by_column.name.clone()))?;
 
                     let key_value =

--- a/crates/query-engine/translation/tests/goldenfiles/mutations/experimental_insert/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/mutations/experimental_insert/request.json
@@ -4,7 +4,7 @@
       "type": "procedure",
       "name": "experimental_insert_Artist",
       "arguments": {
-        "_objects": [
+        "objects": [
           {
             "name": "Olympians",
             "id": 276
@@ -13,7 +13,7 @@
             "name": "The Other Band"
           }
         ],
-        "constraint": {
+        "post_check": {
           "type": "or",
           "expressions": []
         }

--- a/crates/query-engine/translation/tests/goldenfiles/mutations/experimental_insert_empty_objects/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/mutations/experimental_insert_empty_objects/request.json
@@ -4,8 +4,8 @@
       "type": "procedure",
       "name": "experimental_insert_Dog",
       "arguments": {
-        "_objects": [{}, {}, {}, {}],
-        "constraint": {
+        "objects": [{}, {}, {}, {}],
+        "post_check": {
           "type": "and",
           "expressions": []
         }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
@@ -8771,18 +8771,18 @@ expression: result
       "name": "experimental_delete_Album_by_AlbumId",
       "description": "Delete any row on the 'Album' collection using the 'AlbumId' key",
       "arguments": {
-        "%filter": {
-          "description": "Delete permission predicate over the 'Album' collection",
-          "type": {
-            "type": "predicate",
-            "object_type_name": "Album"
-          }
-        },
         "AlbumId": {
           "description": "The identifier of an album",
           "type": {
             "type": "named",
             "name": "int4"
+          }
+        },
+        "pre_check": {
+          "description": "Delete permission predicate over the 'Album' collection",
+          "type": {
+            "type": "predicate",
+            "object_type_name": "Album"
           }
         }
       },
@@ -8795,18 +8795,18 @@ expression: result
       "name": "experimental_delete_Artist_by_ArtistId",
       "description": "Delete any row on the 'Artist' collection using the 'ArtistId' key",
       "arguments": {
-        "%filter": {
-          "description": "Delete permission predicate over the 'Artist' collection",
-          "type": {
-            "type": "predicate",
-            "object_type_name": "Artist"
-          }
-        },
         "ArtistId": {
           "description": "The identifier of an artist",
           "type": {
             "type": "named",
             "name": "int4"
+          }
+        },
+        "pre_check": {
+          "description": "Delete permission predicate over the 'Artist' collection",
+          "type": {
+            "type": "predicate",
+            "object_type_name": "Artist"
           }
         }
       },
@@ -8819,18 +8819,18 @@ expression: result
       "name": "experimental_delete_Customer_by_CustomerId",
       "description": "Delete any row on the 'Customer' collection using the 'CustomerId' key",
       "arguments": {
-        "%filter": {
-          "description": "Delete permission predicate over the 'Customer' collection",
-          "type": {
-            "type": "predicate",
-            "object_type_name": "Customer"
-          }
-        },
         "CustomerId": {
           "description": "The identifier of customer",
           "type": {
             "type": "named",
             "name": "int4"
+          }
+        },
+        "pre_check": {
+          "description": "Delete permission predicate over the 'Customer' collection",
+          "type": {
+            "type": "predicate",
+            "object_type_name": "Customer"
           }
         }
       },
@@ -8843,17 +8843,17 @@ expression: result
       "name": "experimental_delete_Employee_by_EmployeeId",
       "description": "Delete any row on the 'Employee' collection using the 'EmployeeId' key",
       "arguments": {
-        "%filter": {
-          "description": "Delete permission predicate over the 'Employee' collection",
-          "type": {
-            "type": "predicate",
-            "object_type_name": "Employee"
-          }
-        },
         "EmployeeId": {
           "type": {
             "type": "named",
             "name": "int4"
+          }
+        },
+        "pre_check": {
+          "description": "Delete permission predicate over the 'Employee' collection",
+          "type": {
+            "type": "predicate",
+            "object_type_name": "Employee"
           }
         }
       },
@@ -8866,17 +8866,17 @@ expression: result
       "name": "experimental_delete_Genre_by_GenreId",
       "description": "Delete any row on the 'Genre' collection using the 'GenreId' key",
       "arguments": {
-        "%filter": {
-          "description": "Delete permission predicate over the 'Genre' collection",
-          "type": {
-            "type": "predicate",
-            "object_type_name": "Genre"
-          }
-        },
         "GenreId": {
           "type": {
             "type": "named",
             "name": "int4"
+          }
+        },
+        "pre_check": {
+          "description": "Delete permission predicate over the 'Genre' collection",
+          "type": {
+            "type": "predicate",
+            "object_type_name": "Genre"
           }
         }
       },
@@ -8889,17 +8889,17 @@ expression: result
       "name": "experimental_delete_InvoiceLine_by_InvoiceLineId",
       "description": "Delete any row on the 'InvoiceLine' collection using the 'InvoiceLineId' key",
       "arguments": {
-        "%filter": {
-          "description": "Delete permission predicate over the 'InvoiceLine' collection",
-          "type": {
-            "type": "predicate",
-            "object_type_name": "InvoiceLine"
-          }
-        },
         "InvoiceLineId": {
           "type": {
             "type": "named",
             "name": "int4"
+          }
+        },
+        "pre_check": {
+          "description": "Delete permission predicate over the 'InvoiceLine' collection",
+          "type": {
+            "type": "predicate",
+            "object_type_name": "InvoiceLine"
           }
         }
       },
@@ -8912,17 +8912,17 @@ expression: result
       "name": "experimental_delete_Invoice_by_InvoiceId",
       "description": "Delete any row on the 'Invoice' collection using the 'InvoiceId' key",
       "arguments": {
-        "%filter": {
-          "description": "Delete permission predicate over the 'Invoice' collection",
-          "type": {
-            "type": "predicate",
-            "object_type_name": "Invoice"
-          }
-        },
         "InvoiceId": {
           "type": {
             "type": "named",
             "name": "int4"
+          }
+        },
+        "pre_check": {
+          "description": "Delete permission predicate over the 'Invoice' collection",
+          "type": {
+            "type": "predicate",
+            "object_type_name": "Invoice"
           }
         }
       },
@@ -8935,17 +8935,17 @@ expression: result
       "name": "experimental_delete_MediaType_by_MediaTypeId",
       "description": "Delete any row on the 'MediaType' collection using the 'MediaTypeId' key",
       "arguments": {
-        "%filter": {
-          "description": "Delete permission predicate over the 'MediaType' collection",
-          "type": {
-            "type": "predicate",
-            "object_type_name": "MediaType"
-          }
-        },
         "MediaTypeId": {
           "type": {
             "type": "named",
             "name": "int4"
+          }
+        },
+        "pre_check": {
+          "description": "Delete permission predicate over the 'MediaType' collection",
+          "type": {
+            "type": "predicate",
+            "object_type_name": "MediaType"
           }
         }
       },
@@ -8958,13 +8958,6 @@ expression: result
       "name": "experimental_delete_PlaylistTrack_by_PlaylistId_and_TrackId",
       "description": "Delete any row on the 'PlaylistTrack' collection using the 'PlaylistId' and 'TrackId' keys",
       "arguments": {
-        "%filter": {
-          "description": "Delete permission predicate over the 'PlaylistTrack' collection",
-          "type": {
-            "type": "predicate",
-            "object_type_name": "PlaylistTrack"
-          }
-        },
         "PlaylistId": {
           "type": {
             "type": "named",
@@ -8975,6 +8968,13 @@ expression: result
           "type": {
             "type": "named",
             "name": "int4"
+          }
+        },
+        "pre_check": {
+          "description": "Delete permission predicate over the 'PlaylistTrack' collection",
+          "type": {
+            "type": "predicate",
+            "object_type_name": "PlaylistTrack"
           }
         }
       },
@@ -8987,17 +8987,17 @@ expression: result
       "name": "experimental_delete_Playlist_by_PlaylistId",
       "description": "Delete any row on the 'Playlist' collection using the 'PlaylistId' key",
       "arguments": {
-        "%filter": {
-          "description": "Delete permission predicate over the 'Playlist' collection",
-          "type": {
-            "type": "predicate",
-            "object_type_name": "Playlist"
-          }
-        },
         "PlaylistId": {
           "type": {
             "type": "named",
             "name": "int4"
+          }
+        },
+        "pre_check": {
+          "description": "Delete permission predicate over the 'Playlist' collection",
+          "type": {
+            "type": "predicate",
+            "object_type_name": "Playlist"
           }
         }
       },
@@ -9010,17 +9010,17 @@ expression: result
       "name": "experimental_delete_Track_by_TrackId",
       "description": "Delete any row on the 'Track' collection using the 'TrackId' key",
       "arguments": {
-        "%filter": {
-          "description": "Delete permission predicate over the 'Track' collection",
-          "type": {
-            "type": "predicate",
-            "object_type_name": "Track"
-          }
-        },
         "TrackId": {
           "type": {
             "type": "named",
             "name": "int4"
+          }
+        },
+        "pre_check": {
+          "description": "Delete permission predicate over the 'Track' collection",
+          "type": {
+            "type": "predicate",
+            "object_type_name": "Track"
           }
         }
       },
@@ -9033,17 +9033,17 @@ expression: result
       "name": "experimental_delete_custom_defaults_by_id",
       "description": "Delete any row on the 'custom_defaults' collection using the 'id' key",
       "arguments": {
-        "%filter": {
-          "description": "Delete permission predicate over the 'custom_defaults' collection",
-          "type": {
-            "type": "predicate",
-            "object_type_name": "custom_defaults"
-          }
-        },
         "id": {
           "type": {
             "type": "named",
             "name": "int8"
+          }
+        },
+        "pre_check": {
+          "description": "Delete permission predicate over the 'custom_defaults' collection",
+          "type": {
+            "type": "predicate",
+            "object_type_name": "custom_defaults"
           }
         }
       },
@@ -9056,17 +9056,17 @@ expression: result
       "name": "experimental_delete_custom_dog_by_id",
       "description": "Delete any row on the 'custom_dog' collection using the 'id' key",
       "arguments": {
-        "%filter": {
-          "description": "Delete permission predicate over the 'custom_dog' collection",
-          "type": {
-            "type": "predicate",
-            "object_type_name": "custom_dog"
-          }
-        },
         "id": {
           "type": {
             "type": "named",
             "name": "int8"
+          }
+        },
+        "pre_check": {
+          "description": "Delete permission predicate over the 'custom_dog' collection",
+          "type": {
+            "type": "predicate",
+            "object_type_name": "custom_dog"
           }
         }
       },
@@ -9079,7 +9079,7 @@ expression: result
       "name": "experimental_delete_spatial_ref_sys_by_srid",
       "description": "Delete any row on the 'spatial_ref_sys' collection using the 'srid' key",
       "arguments": {
-        "%filter": {
+        "pre_check": {
           "description": "Delete permission predicate over the 'spatial_ref_sys' collection",
           "type": {
             "type": "predicate",
@@ -9102,17 +9102,17 @@ expression: result
       "name": "experimental_delete_topology_layer_by_feature_column_and_schema_name_and_table_name",
       "description": "Delete any row on the 'topology_layer' collection using the 'feature_column', 'schema_name' and 'table_name' keys",
       "arguments": {
-        "%filter": {
-          "description": "Delete permission predicate over the 'topology_layer' collection",
-          "type": {
-            "type": "predicate",
-            "object_type_name": "topology_layer"
-          }
-        },
         "feature_column": {
           "type": {
             "type": "named",
             "name": "varchar"
+          }
+        },
+        "pre_check": {
+          "description": "Delete permission predicate over the 'topology_layer' collection",
+          "type": {
+            "type": "predicate",
+            "object_type_name": "topology_layer"
           }
         },
         "schema_name": {
@@ -9137,17 +9137,17 @@ expression: result
       "name": "experimental_delete_topology_layer_by_layer_id_and_topology_id",
       "description": "Delete any row on the 'topology_layer' collection using the 'layer_id' and 'topology_id' keys",
       "arguments": {
-        "%filter": {
-          "description": "Delete permission predicate over the 'topology_layer' collection",
-          "type": {
-            "type": "predicate",
-            "object_type_name": "topology_layer"
-          }
-        },
         "layer_id": {
           "type": {
             "type": "named",
             "name": "int4"
+          }
+        },
+        "pre_check": {
+          "description": "Delete permission predicate over the 'topology_layer' collection",
+          "type": {
+            "type": "predicate",
+            "object_type_name": "topology_layer"
           }
         },
         "topology_id": {
@@ -9166,17 +9166,17 @@ expression: result
       "name": "experimental_delete_topology_topology_by_id",
       "description": "Delete any row on the 'topology_topology' collection using the 'id' key",
       "arguments": {
-        "%filter": {
-          "description": "Delete permission predicate over the 'topology_topology' collection",
-          "type": {
-            "type": "predicate",
-            "object_type_name": "topology_topology"
-          }
-        },
         "id": {
           "type": {
             "type": "named",
             "name": "int4"
+          }
+        },
+        "pre_check": {
+          "description": "Delete permission predicate over the 'topology_topology' collection",
+          "type": {
+            "type": "predicate",
+            "object_type_name": "topology_topology"
           }
         }
       },
@@ -9189,17 +9189,17 @@ expression: result
       "name": "experimental_delete_topology_topology_by_name",
       "description": "Delete any row on the 'topology_topology' collection using the 'name' key",
       "arguments": {
-        "%filter": {
-          "description": "Delete permission predicate over the 'topology_topology' collection",
-          "type": {
-            "type": "predicate",
-            "object_type_name": "topology_topology"
-          }
-        },
         "name": {
           "type": {
             "type": "named",
             "name": "varchar"
+          }
+        },
+        "pre_check": {
+          "description": "Delete permission predicate over the 'topology_topology' collection",
+          "type": {
+            "type": "predicate",
+            "object_type_name": "topology_topology"
           }
         }
       },
@@ -9212,7 +9212,7 @@ expression: result
       "name": "experimental_insert_Album",
       "description": "Insert into the Album table",
       "arguments": {
-        "_objects": {
+        "objects": {
           "type": {
             "type": "array",
             "element_type": {
@@ -9221,7 +9221,7 @@ expression: result
             }
           }
         },
-        "constraint": {
+        "post_check": {
           "description": "Insert permission predicate over the 'Album' collection",
           "type": {
             "type": "predicate",
@@ -9238,7 +9238,7 @@ expression: result
       "name": "experimental_insert_Artist",
       "description": "Insert into the Artist table",
       "arguments": {
-        "_objects": {
+        "objects": {
           "type": {
             "type": "array",
             "element_type": {
@@ -9247,7 +9247,7 @@ expression: result
             }
           }
         },
-        "constraint": {
+        "post_check": {
           "description": "Insert permission predicate over the 'Artist' collection",
           "type": {
             "type": "predicate",
@@ -9264,7 +9264,7 @@ expression: result
       "name": "experimental_insert_Customer",
       "description": "Insert into the Customer table",
       "arguments": {
-        "_objects": {
+        "objects": {
           "type": {
             "type": "array",
             "element_type": {
@@ -9273,7 +9273,7 @@ expression: result
             }
           }
         },
-        "constraint": {
+        "post_check": {
           "description": "Insert permission predicate over the 'Customer' collection",
           "type": {
             "type": "predicate",
@@ -9290,7 +9290,7 @@ expression: result
       "name": "experimental_insert_Employee",
       "description": "Insert into the Employee table",
       "arguments": {
-        "_objects": {
+        "objects": {
           "type": {
             "type": "array",
             "element_type": {
@@ -9299,7 +9299,7 @@ expression: result
             }
           }
         },
-        "constraint": {
+        "post_check": {
           "description": "Insert permission predicate over the 'Employee' collection",
           "type": {
             "type": "predicate",
@@ -9316,7 +9316,7 @@ expression: result
       "name": "experimental_insert_Genre",
       "description": "Insert into the Genre table",
       "arguments": {
-        "_objects": {
+        "objects": {
           "type": {
             "type": "array",
             "element_type": {
@@ -9325,7 +9325,7 @@ expression: result
             }
           }
         },
-        "constraint": {
+        "post_check": {
           "description": "Insert permission predicate over the 'Genre' collection",
           "type": {
             "type": "predicate",
@@ -9342,7 +9342,7 @@ expression: result
       "name": "experimental_insert_Invoice",
       "description": "Insert into the Invoice table",
       "arguments": {
-        "_objects": {
+        "objects": {
           "type": {
             "type": "array",
             "element_type": {
@@ -9351,7 +9351,7 @@ expression: result
             }
           }
         },
-        "constraint": {
+        "post_check": {
           "description": "Insert permission predicate over the 'Invoice' collection",
           "type": {
             "type": "predicate",
@@ -9368,7 +9368,7 @@ expression: result
       "name": "experimental_insert_InvoiceLine",
       "description": "Insert into the InvoiceLine table",
       "arguments": {
-        "_objects": {
+        "objects": {
           "type": {
             "type": "array",
             "element_type": {
@@ -9377,7 +9377,7 @@ expression: result
             }
           }
         },
-        "constraint": {
+        "post_check": {
           "description": "Insert permission predicate over the 'InvoiceLine' collection",
           "type": {
             "type": "predicate",
@@ -9394,7 +9394,7 @@ expression: result
       "name": "experimental_insert_MediaType",
       "description": "Insert into the MediaType table",
       "arguments": {
-        "_objects": {
+        "objects": {
           "type": {
             "type": "array",
             "element_type": {
@@ -9403,7 +9403,7 @@ expression: result
             }
           }
         },
-        "constraint": {
+        "post_check": {
           "description": "Insert permission predicate over the 'MediaType' collection",
           "type": {
             "type": "predicate",
@@ -9420,7 +9420,7 @@ expression: result
       "name": "experimental_insert_Playlist",
       "description": "Insert into the Playlist table",
       "arguments": {
-        "_objects": {
+        "objects": {
           "type": {
             "type": "array",
             "element_type": {
@@ -9429,7 +9429,7 @@ expression: result
             }
           }
         },
-        "constraint": {
+        "post_check": {
           "description": "Insert permission predicate over the 'Playlist' collection",
           "type": {
             "type": "predicate",
@@ -9446,7 +9446,7 @@ expression: result
       "name": "experimental_insert_PlaylistTrack",
       "description": "Insert into the PlaylistTrack table",
       "arguments": {
-        "_objects": {
+        "objects": {
           "type": {
             "type": "array",
             "element_type": {
@@ -9455,7 +9455,7 @@ expression: result
             }
           }
         },
-        "constraint": {
+        "post_check": {
           "description": "Insert permission predicate over the 'PlaylistTrack' collection",
           "type": {
             "type": "predicate",
@@ -9472,7 +9472,7 @@ expression: result
       "name": "experimental_insert_Track",
       "description": "Insert into the Track table",
       "arguments": {
-        "_objects": {
+        "objects": {
           "type": {
             "type": "array",
             "element_type": {
@@ -9481,7 +9481,7 @@ expression: result
             }
           }
         },
-        "constraint": {
+        "post_check": {
           "description": "Insert permission predicate over the 'Track' collection",
           "type": {
             "type": "predicate",
@@ -9498,7 +9498,7 @@ expression: result
       "name": "experimental_insert_custom_defaults",
       "description": "Insert into the custom_defaults table",
       "arguments": {
-        "_objects": {
+        "objects": {
           "type": {
             "type": "array",
             "element_type": {
@@ -9507,7 +9507,7 @@ expression: result
             }
           }
         },
-        "constraint": {
+        "post_check": {
           "description": "Insert permission predicate over the 'custom_defaults' collection",
           "type": {
             "type": "predicate",
@@ -9524,7 +9524,7 @@ expression: result
       "name": "experimental_insert_custom_dog",
       "description": "Insert into the custom_dog table",
       "arguments": {
-        "_objects": {
+        "objects": {
           "type": {
             "type": "array",
             "element_type": {
@@ -9533,7 +9533,7 @@ expression: result
             }
           }
         },
-        "constraint": {
+        "post_check": {
           "description": "Insert permission predicate over the 'custom_dog' collection",
           "type": {
             "type": "predicate",
@@ -9550,7 +9550,7 @@ expression: result
       "name": "experimental_insert_deck_of_cards",
       "description": "Insert into the deck_of_cards table",
       "arguments": {
-        "_objects": {
+        "objects": {
           "type": {
             "type": "array",
             "element_type": {
@@ -9559,7 +9559,7 @@ expression: result
             }
           }
         },
-        "constraint": {
+        "post_check": {
           "description": "Insert permission predicate over the 'deck_of_cards' collection",
           "type": {
             "type": "predicate",
@@ -9576,7 +9576,7 @@ expression: result
       "name": "experimental_insert_discoverable_types_root_occurrence",
       "description": "Insert into the discoverable_types_root_occurrence table",
       "arguments": {
-        "_objects": {
+        "objects": {
           "type": {
             "type": "array",
             "element_type": {
@@ -9585,7 +9585,7 @@ expression: result
             }
           }
         },
-        "constraint": {
+        "post_check": {
           "description": "Insert permission predicate over the 'discoverable_types_root_occurrence' collection",
           "type": {
             "type": "predicate",
@@ -9602,7 +9602,7 @@ expression: result
       "name": "experimental_insert_even_numbers",
       "description": "Insert into the even_numbers table",
       "arguments": {
-        "_objects": {
+        "objects": {
           "type": {
             "type": "array",
             "element_type": {
@@ -9611,7 +9611,7 @@ expression: result
             }
           }
         },
-        "constraint": {
+        "post_check": {
           "description": "Insert permission predicate over the 'even_numbers' collection",
           "type": {
             "type": "predicate",
@@ -9628,7 +9628,7 @@ expression: result
       "name": "experimental_insert_group_leader",
       "description": "Insert into the group_leader table",
       "arguments": {
-        "_objects": {
+        "objects": {
           "type": {
             "type": "array",
             "element_type": {
@@ -9637,7 +9637,7 @@ expression: result
             }
           }
         },
-        "constraint": {
+        "post_check": {
           "description": "Insert permission predicate over the 'group_leader' collection",
           "type": {
             "type": "predicate",
@@ -9654,7 +9654,7 @@ expression: result
       "name": "experimental_insert_phone_numbers",
       "description": "Insert into the phone_numbers table",
       "arguments": {
-        "_objects": {
+        "objects": {
           "type": {
             "type": "array",
             "element_type": {
@@ -9663,7 +9663,7 @@ expression: result
             }
           }
         },
-        "constraint": {
+        "post_check": {
           "description": "Insert permission predicate over the 'phone_numbers' collection",
           "type": {
             "type": "predicate",
@@ -9680,7 +9680,7 @@ expression: result
       "name": "experimental_insert_spatial_ref_sys",
       "description": "Insert into the spatial_ref_sys table",
       "arguments": {
-        "_objects": {
+        "objects": {
           "type": {
             "type": "array",
             "element_type": {
@@ -9689,7 +9689,7 @@ expression: result
             }
           }
         },
-        "constraint": {
+        "post_check": {
           "description": "Insert permission predicate over the 'spatial_ref_sys' collection",
           "type": {
             "type": "predicate",
@@ -9706,7 +9706,7 @@ expression: result
       "name": "experimental_insert_topology_layer",
       "description": "Insert into the topology_layer table",
       "arguments": {
-        "_objects": {
+        "objects": {
           "type": {
             "type": "array",
             "element_type": {
@@ -9715,7 +9715,7 @@ expression: result
             }
           }
         },
-        "constraint": {
+        "post_check": {
           "description": "Insert permission predicate over the 'topology_layer' collection",
           "type": {
             "type": "predicate",
@@ -9732,7 +9732,7 @@ expression: result
       "name": "experimental_insert_topology_topology",
       "description": "Insert into the topology_topology table",
       "arguments": {
-        "_objects": {
+        "objects": {
           "type": {
             "type": "array",
             "element_type": {
@@ -9741,7 +9741,7 @@ expression: result
             }
           }
         },
-        "constraint": {
+        "post_check": {
           "description": "Insert permission predicate over the 'topology_topology' collection",
           "type": {
             "type": "predicate",

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
@@ -8771,7 +8771,7 @@ expression: result
       "name": "experimental_delete_Album_by_AlbumId",
       "description": "Delete any row on the 'Album' collection using the 'AlbumId' key",
       "arguments": {
-        "AlbumId": {
+        "key_AlbumId": {
           "description": "The identifier of an album",
           "type": {
             "type": "named",
@@ -8795,7 +8795,7 @@ expression: result
       "name": "experimental_delete_Artist_by_ArtistId",
       "description": "Delete any row on the 'Artist' collection using the 'ArtistId' key",
       "arguments": {
-        "ArtistId": {
+        "key_ArtistId": {
           "description": "The identifier of an artist",
           "type": {
             "type": "named",
@@ -8819,7 +8819,7 @@ expression: result
       "name": "experimental_delete_Customer_by_CustomerId",
       "description": "Delete any row on the 'Customer' collection using the 'CustomerId' key",
       "arguments": {
-        "CustomerId": {
+        "key_CustomerId": {
           "description": "The identifier of customer",
           "type": {
             "type": "named",
@@ -8843,7 +8843,7 @@ expression: result
       "name": "experimental_delete_Employee_by_EmployeeId",
       "description": "Delete any row on the 'Employee' collection using the 'EmployeeId' key",
       "arguments": {
-        "EmployeeId": {
+        "key_EmployeeId": {
           "type": {
             "type": "named",
             "name": "int4"
@@ -8866,7 +8866,7 @@ expression: result
       "name": "experimental_delete_Genre_by_GenreId",
       "description": "Delete any row on the 'Genre' collection using the 'GenreId' key",
       "arguments": {
-        "GenreId": {
+        "key_GenreId": {
           "type": {
             "type": "named",
             "name": "int4"
@@ -8889,7 +8889,7 @@ expression: result
       "name": "experimental_delete_InvoiceLine_by_InvoiceLineId",
       "description": "Delete any row on the 'InvoiceLine' collection using the 'InvoiceLineId' key",
       "arguments": {
-        "InvoiceLineId": {
+        "key_InvoiceLineId": {
           "type": {
             "type": "named",
             "name": "int4"
@@ -8912,7 +8912,7 @@ expression: result
       "name": "experimental_delete_Invoice_by_InvoiceId",
       "description": "Delete any row on the 'Invoice' collection using the 'InvoiceId' key",
       "arguments": {
-        "InvoiceId": {
+        "key_InvoiceId": {
           "type": {
             "type": "named",
             "name": "int4"
@@ -8935,7 +8935,7 @@ expression: result
       "name": "experimental_delete_MediaType_by_MediaTypeId",
       "description": "Delete any row on the 'MediaType' collection using the 'MediaTypeId' key",
       "arguments": {
-        "MediaTypeId": {
+        "key_MediaTypeId": {
           "type": {
             "type": "named",
             "name": "int4"
@@ -8958,13 +8958,13 @@ expression: result
       "name": "experimental_delete_PlaylistTrack_by_PlaylistId_and_TrackId",
       "description": "Delete any row on the 'PlaylistTrack' collection using the 'PlaylistId' and 'TrackId' keys",
       "arguments": {
-        "PlaylistId": {
+        "key_PlaylistId": {
           "type": {
             "type": "named",
             "name": "int4"
           }
         },
-        "TrackId": {
+        "key_TrackId": {
           "type": {
             "type": "named",
             "name": "int4"
@@ -8987,7 +8987,7 @@ expression: result
       "name": "experimental_delete_Playlist_by_PlaylistId",
       "description": "Delete any row on the 'Playlist' collection using the 'PlaylistId' key",
       "arguments": {
-        "PlaylistId": {
+        "key_PlaylistId": {
           "type": {
             "type": "named",
             "name": "int4"
@@ -9010,7 +9010,7 @@ expression: result
       "name": "experimental_delete_Track_by_TrackId",
       "description": "Delete any row on the 'Track' collection using the 'TrackId' key",
       "arguments": {
-        "TrackId": {
+        "key_TrackId": {
           "type": {
             "type": "named",
             "name": "int4"
@@ -9033,7 +9033,7 @@ expression: result
       "name": "experimental_delete_custom_defaults_by_id",
       "description": "Delete any row on the 'custom_defaults' collection using the 'id' key",
       "arguments": {
-        "id": {
+        "key_id": {
           "type": {
             "type": "named",
             "name": "int8"
@@ -9056,7 +9056,7 @@ expression: result
       "name": "experimental_delete_custom_dog_by_id",
       "description": "Delete any row on the 'custom_dog' collection using the 'id' key",
       "arguments": {
-        "id": {
+        "key_id": {
           "type": {
             "type": "named",
             "name": "int8"
@@ -9079,17 +9079,17 @@ expression: result
       "name": "experimental_delete_spatial_ref_sys_by_srid",
       "description": "Delete any row on the 'spatial_ref_sys' collection using the 'srid' key",
       "arguments": {
+        "key_srid": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
         "pre_check": {
           "description": "Delete permission predicate over the 'spatial_ref_sys' collection",
           "type": {
             "type": "predicate",
             "object_type_name": "spatial_ref_sys"
-          }
-        },
-        "srid": {
-          "type": {
-            "type": "named",
-            "name": "int4"
           }
         }
       },
@@ -9102,7 +9102,19 @@ expression: result
       "name": "experimental_delete_topology_layer_by_feature_column_and_schema_name_and_table_name",
       "description": "Delete any row on the 'topology_layer' collection using the 'feature_column', 'schema_name' and 'table_name' keys",
       "arguments": {
-        "feature_column": {
+        "key_feature_column": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        },
+        "key_schema_name": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        },
+        "key_table_name": {
           "type": {
             "type": "named",
             "name": "varchar"
@@ -9113,18 +9125,6 @@ expression: result
           "type": {
             "type": "predicate",
             "object_type_name": "topology_layer"
-          }
-        },
-        "schema_name": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
-          }
-        },
-        "table_name": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
           }
         }
       },
@@ -9137,7 +9137,13 @@ expression: result
       "name": "experimental_delete_topology_layer_by_layer_id_and_topology_id",
       "description": "Delete any row on the 'topology_layer' collection using the 'layer_id' and 'topology_id' keys",
       "arguments": {
-        "layer_id": {
+        "key_layer_id": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "key_topology_id": {
           "type": {
             "type": "named",
             "name": "int4"
@@ -9148,12 +9154,6 @@ expression: result
           "type": {
             "type": "predicate",
             "object_type_name": "topology_layer"
-          }
-        },
-        "topology_id": {
-          "type": {
-            "type": "named",
-            "name": "int4"
           }
         }
       },
@@ -9166,7 +9166,7 @@ expression: result
       "name": "experimental_delete_topology_topology_by_id",
       "description": "Delete any row on the 'topology_topology' collection using the 'id' key",
       "arguments": {
-        "id": {
+        "key_id": {
           "type": {
             "type": "named",
             "name": "int4"
@@ -9189,7 +9189,7 @@ expression: result
       "name": "experimental_delete_topology_topology_by_name",
       "description": "Delete any row on the 'topology_topology' collection using the 'name' key",
       "arguments": {
-        "name": {
+        "key_name": {
           "type": {
             "type": "named",
             "name": "varchar"
@@ -9758,7 +9758,7 @@ expression: result
       "name": "experimental_update_Album_by_AlbumId",
       "description": "Update any row on the 'Album' collection using the 'AlbumId' key",
       "arguments": {
-        "AlbumId": {
+        "key_AlbumId": {
           "description": "The identifier of an album",
           "type": {
             "type": "named",
@@ -9795,7 +9795,7 @@ expression: result
       "name": "experimental_update_Artist_by_ArtistId",
       "description": "Update any row on the 'Artist' collection using the 'ArtistId' key",
       "arguments": {
-        "ArtistId": {
+        "key_ArtistId": {
           "description": "The identifier of an artist",
           "type": {
             "type": "named",
@@ -9832,7 +9832,7 @@ expression: result
       "name": "experimental_update_Customer_by_CustomerId",
       "description": "Update any row on the 'Customer' collection using the 'CustomerId' key",
       "arguments": {
-        "CustomerId": {
+        "key_CustomerId": {
           "description": "The identifier of customer",
           "type": {
             "type": "named",
@@ -9869,7 +9869,7 @@ expression: result
       "name": "experimental_update_Employee_by_EmployeeId",
       "description": "Update any row on the 'Employee' collection using the 'EmployeeId' key",
       "arguments": {
-        "EmployeeId": {
+        "key_EmployeeId": {
           "type": {
             "type": "named",
             "name": "int4"
@@ -9905,7 +9905,7 @@ expression: result
       "name": "experimental_update_Genre_by_GenreId",
       "description": "Update any row on the 'Genre' collection using the 'GenreId' key",
       "arguments": {
-        "GenreId": {
+        "key_GenreId": {
           "type": {
             "type": "named",
             "name": "int4"
@@ -9941,7 +9941,7 @@ expression: result
       "name": "experimental_update_InvoiceLine_by_InvoiceLineId",
       "description": "Update any row on the 'InvoiceLine' collection using the 'InvoiceLineId' key",
       "arguments": {
-        "InvoiceLineId": {
+        "key_InvoiceLineId": {
           "type": {
             "type": "named",
             "name": "int4"
@@ -9977,7 +9977,7 @@ expression: result
       "name": "experimental_update_Invoice_by_InvoiceId",
       "description": "Update any row on the 'Invoice' collection using the 'InvoiceId' key",
       "arguments": {
-        "InvoiceId": {
+        "key_InvoiceId": {
           "type": {
             "type": "named",
             "name": "int4"
@@ -10013,7 +10013,7 @@ expression: result
       "name": "experimental_update_MediaType_by_MediaTypeId",
       "description": "Update any row on the 'MediaType' collection using the 'MediaTypeId' key",
       "arguments": {
-        "MediaTypeId": {
+        "key_MediaTypeId": {
           "type": {
             "type": "named",
             "name": "int4"
@@ -10049,13 +10049,13 @@ expression: result
       "name": "experimental_update_PlaylistTrack_by_PlaylistId_and_TrackId",
       "description": "Update any row on the 'PlaylistTrack' collection using the 'PlaylistId' and 'TrackId' keys",
       "arguments": {
-        "PlaylistId": {
+        "key_PlaylistId": {
           "type": {
             "type": "named",
             "name": "int4"
           }
         },
-        "TrackId": {
+        "key_TrackId": {
           "type": {
             "type": "named",
             "name": "int4"
@@ -10091,7 +10091,7 @@ expression: result
       "name": "experimental_update_Playlist_by_PlaylistId",
       "description": "Update any row on the 'Playlist' collection using the 'PlaylistId' key",
       "arguments": {
-        "PlaylistId": {
+        "key_PlaylistId": {
           "type": {
             "type": "named",
             "name": "int4"
@@ -10127,7 +10127,7 @@ expression: result
       "name": "experimental_update_Track_by_TrackId",
       "description": "Update any row on the 'Track' collection using the 'TrackId' key",
       "arguments": {
-        "TrackId": {
+        "key_TrackId": {
           "type": {
             "type": "named",
             "name": "int4"
@@ -10163,7 +10163,7 @@ expression: result
       "name": "experimental_update_custom_defaults_by_id",
       "description": "Update any row on the 'custom_defaults' collection using the 'id' key",
       "arguments": {
-        "id": {
+        "key_id": {
           "type": {
             "type": "named",
             "name": "int8"
@@ -10199,7 +10199,7 @@ expression: result
       "name": "experimental_update_custom_dog_by_id",
       "description": "Update any row on the 'custom_dog' collection using the 'id' key",
       "arguments": {
-        "id": {
+        "key_id": {
           "type": {
             "type": "named",
             "name": "int8"
@@ -10235,6 +10235,12 @@ expression: result
       "name": "experimental_update_spatial_ref_sys_by_srid",
       "description": "Update any row on the 'spatial_ref_sys' collection using the 'srid' key",
       "arguments": {
+        "key_srid": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
         "post_check": {
           "description": "Update permission post-condition predicate over the 'spatial_ref_sys' collection",
           "type": {
@@ -10247,12 +10253,6 @@ expression: result
           "type": {
             "type": "predicate",
             "object_type_name": "spatial_ref_sys"
-          }
-        },
-        "srid": {
-          "type": {
-            "type": "named",
-            "name": "int4"
           }
         },
         "update_columns": {
@@ -10271,7 +10271,19 @@ expression: result
       "name": "experimental_update_topology_layer_by_feature_column_and_schema_name_and_table_name",
       "description": "Update any row on the 'topology_layer' collection using the 'feature_column', 'schema_name' and 'table_name' keys",
       "arguments": {
-        "feature_column": {
+        "key_feature_column": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        },
+        "key_schema_name": {
+          "type": {
+            "type": "named",
+            "name": "varchar"
+          }
+        },
+        "key_table_name": {
           "type": {
             "type": "named",
             "name": "varchar"
@@ -10289,18 +10301,6 @@ expression: result
           "type": {
             "type": "predicate",
             "object_type_name": "topology_layer"
-          }
-        },
-        "schema_name": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
-          }
-        },
-        "table_name": {
-          "type": {
-            "type": "named",
-            "name": "varchar"
           }
         },
         "update_columns": {
@@ -10319,7 +10319,13 @@ expression: result
       "name": "experimental_update_topology_layer_by_layer_id_and_topology_id",
       "description": "Update any row on the 'topology_layer' collection using the 'layer_id' and 'topology_id' keys",
       "arguments": {
-        "layer_id": {
+        "key_layer_id": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "key_topology_id": {
           "type": {
             "type": "named",
             "name": "int4"
@@ -10339,12 +10345,6 @@ expression: result
             "object_type_name": "topology_layer"
           }
         },
-        "topology_id": {
-          "type": {
-            "type": "named",
-            "name": "int4"
-          }
-        },
         "update_columns": {
           "type": {
             "type": "named",
@@ -10361,7 +10361,7 @@ expression: result
       "name": "experimental_update_topology_topology_by_id",
       "description": "Update any row on the 'topology_topology' collection using the 'id' key",
       "arguments": {
-        "id": {
+        "key_id": {
           "type": {
             "type": "named",
             "name": "int4"
@@ -10397,7 +10397,7 @@ expression: result
       "name": "experimental_update_topology_topology_by_name",
       "description": "Update any row on the 'topology_topology' collection using the 'name' key",
       "arguments": {
-        "name": {
+        "key_name": {
           "type": {
             "type": "named",
             "name": "varchar"

--- a/crates/tests/tests-common/goldenfiles/mutations/delete_invoice_line.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/delete_invoice_line.json
@@ -5,7 +5,7 @@
       "name": "experimental_delete_InvoiceLine_by_InvoiceLineId",
       "arguments": {
         "InvoiceLineId": 90,
-        "%filter": {
+        "pre_check": {
           "type": "binary_comparison_operator",
           "column": {
             "type": "column",

--- a/crates/tests/tests-common/goldenfiles/mutations/delete_invoice_line.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/delete_invoice_line.json
@@ -4,7 +4,7 @@
       "type": "procedure",
       "name": "experimental_delete_InvoiceLine_by_InvoiceLineId",
       "arguments": {
-        "InvoiceLineId": 90,
+        "key_InvoiceLineId": 90,
         "pre_check": {
           "type": "binary_comparison_operator",
           "column": {

--- a/crates/tests/tests-common/goldenfiles/mutations/experimental_delete_and_update_playlist_track.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/experimental_delete_and_update_playlist_track.json
@@ -4,8 +4,8 @@
       "type": "procedure",
       "name": "experimental_delete_PlaylistTrack_by_PlaylistId_and_TrackId",
       "arguments": {
-        "TrackId": 90,
-        "PlaylistId": 8,
+        "key_TrackId": 90,
+        "key_PlaylistId": 8,
         "pre_check": {
           "type": "and",
           "expressions": []
@@ -45,8 +45,8 @@
       "type": "procedure",
       "name": "experimental_update_PlaylistTrack_by_PlaylistId_and_TrackId",
       "arguments": {
-        "TrackId": 89,
-        "PlaylistId": 1,
+        "key_TrackId": 89,
+        "key_PlaylistId": 1,
         "update_columns": {
           "PlaylistId": { "_set": 7 }
         },

--- a/crates/tests/tests-common/goldenfiles/mutations/experimental_delete_and_update_playlist_track.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/experimental_delete_and_update_playlist_track.json
@@ -6,7 +6,7 @@
       "arguments": {
         "TrackId": 90,
         "PlaylistId": 8,
-        "%filter": {
+        "pre_check": {
           "type": "and",
           "expressions": []
         }

--- a/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_Artist_missing_column.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_Artist_missing_column.json
@@ -4,7 +4,7 @@
       "type": "procedure",
       "name": "experimental_insert_Artist",
       "arguments": {
-        "_objects": [
+        "objects": [
           {
             "Name": "Olympians",
             "ArtistId": 276
@@ -13,7 +13,7 @@
             "Name": "The Other Band"
           }
         ],
-        "constraint": {
+        "post_check": {
           "type": "or",
           "expressions": []
         }

--- a/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_custom_dog.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_custom_dog.json
@@ -4,7 +4,7 @@
       "type": "procedure",
       "name": "experimental_insert_custom_dog",
       "arguments": {
-        "_objects": [
+        "objects": [
           {
             "name": "Cremebo",
             "height_cm": 160,
@@ -17,7 +17,7 @@
             "adopter_name": "Strauss"
           }
         ],
-        "constraint": {
+        "post_check": {
           "type": "binary_comparison_operator",
           "column": { "type": "column", "name": "adopter_name", "path": [] },
           "operator": "_eq",
@@ -74,7 +74,7 @@
       "type": "procedure",
       "name": "experimental_insert_custom_dog",
       "arguments": {
-        "_objects": [
+        "objects": [
           {
             "name": "Manbo",
             "height_cm": 345,
@@ -82,7 +82,7 @@
             "birthday": "2024-01-01"
           }
         ],
-        "constraint": {
+        "post_check": {
           "type": "and",
           "expressions": []
         }
@@ -125,7 +125,7 @@
       "type": "procedure",
       "name": "experimental_insert_custom_dog",
       "arguments": {
-        "_objects": [
+        "objects": [
           {
             "name": "Kremboli",
             "height_cm": 345,
@@ -133,7 +133,7 @@
             "birthday": "2024-02-14"
           }
         ],
-        "constraint": {
+        "post_check": {
           "type": "and",
           "expressions": []
         }

--- a/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_custom_dog_missing_column.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_custom_dog_missing_column.json
@@ -4,12 +4,12 @@
       "type": "procedure",
       "name": "experimental_insert_custom_dog",
       "arguments": {
-        "_objects": [
+        "objects": [
           {
             "name": "Cremebo"
           }
         ],
-        "constraint": {
+        "post_check": {
           "type": "and",
           "expressions": []
         }

--- a/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_custom_dog_predicate_fail.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_custom_dog_predicate_fail.json
@@ -1,18 +1,18 @@
 {
-  "comment": "This test checks that the constraints are managed properly. The second operation should not pass.",
+  "comment": "This test checks that the post_checks are managed properly. The second operation should not pass.",
   "operations": [
     {
       "type": "procedure",
       "name": "experimental_insert_custom_dog",
       "arguments": {
-        "_objects": [
+        "objects": [
           {
             "name": "Cremebo",
             "height_cm": 160,
             "adopter_name": "Strauss"
           }
         ],
-        "constraint": {
+        "post_check": {
           "type": "binary_comparison_operator",
           "column": { "type": "column", "name": "adopter_name", "path": [] },
           "operator": "_eq",
@@ -69,7 +69,7 @@
       "type": "procedure",
       "name": "experimental_insert_custom_dog",
       "arguments": {
-        "_objects": [
+        "objects": [
           {
             "name": "Manbo",
             "height_cm": 345,
@@ -77,7 +77,7 @@
             "birthday": "2024-01-01"
           }
         ],
-        "constraint": {
+        "post_check": {
           "type": "binary_comparison_operator",
           "column": { "type": "column", "name": "adopter_name", "path": [] },
           "operator": "_eq",

--- a/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_defaults.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_defaults.json
@@ -4,8 +4,8 @@
       "type": "procedure",
       "name": "experimental_insert_custom_defaults",
       "arguments": {
-        "_objects": [{}, {}, {}, {}, {}],
-        "constraint": {
+        "objects": [{}, {}, {}, {}, {}],
+        "post_check": {
           "type": "binary_comparison_operator",
           "column": { "type": "column", "name": "name", "path": [] },
           "operator": "_eq",

--- a/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_enum.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_enum.json
@@ -4,13 +4,13 @@
       "type": "procedure",
       "name": "experimental_insert_deck_of_cards",
       "arguments": {
-        "_objects": [
+        "objects": [
           {
             "pips": 14,
             "suit": "hearts"
           }
         ],
-        "constraint": {
+        "post_check": {
           "type": "and",
           "expressions": []
         }

--- a/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_enum_invalid_label.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_enum_invalid_label.json
@@ -4,13 +4,13 @@
       "type": "procedure",
       "name": "experimental_insert_deck_of_cards",
       "arguments": {
-        "_objects": [
+        "objects": [
           {
             "pips": 1,
             "suit": "horses"
           }
         ],
-        "constraint": {
+        "post_check": {
           "type": "and",
           "expressions": []
         }

--- a/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_update_custom_dog.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_update_custom_dog.json
@@ -4,7 +4,7 @@
       "type": "procedure",
       "name": "experimental_insert_custom_dog",
       "arguments": {
-        "_objects": [
+        "objects": [
           {
             "name": "Cremebo",
             "height_cm": 160,
@@ -17,7 +17,7 @@
             "adopter_name": "Strauss"
           }
         ],
-        "constraint": {
+        "post_check": {
           "type": "binary_comparison_operator",
           "column": { "type": "column", "name": "adopter_name", "path": [] },
           "operator": "_eq",

--- a/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_update_custom_dog.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/experimental_insert_update_custom_dog.json
@@ -74,7 +74,7 @@
       "type": "procedure",
       "name": "experimental_update_custom_dog_by_id",
       "arguments": {
-        "id": 1,
+        "key_id": 1,
         "update_columns": {
           "height_cm": { "_set": 300 },
           "adopter_name": { "_set": "Strauss" }


### PR DESCRIPTION
### What

We want to make the api for mutations pretty. We make the following changes:
1. Rename arguments
2. prefix the argument names of unique constraint columns with `key_`

### How

#### General design

* We generate delete, insert and update procedures for each table.
* A single insert procedure is generated per _table_ of the form:
  ```graphql
  <mutation-version>_insert_<table>(
      objects: [<object>],
      post_check: <boolexpr>
  )
  ```
  It lets us insert multiple objects and include a post check for permissions.
* A delete procedure is generated per _table X unique constraint_ of the form:
  ```graphql
  <mutation-version>_delete_<table>_by_<column_and_column_and...>(
      key_<column1>: <value>,
      key_<column2>: <value>,
      ...,
      pre_check: <boolexpr>
  )
  ```
  It lets us delete a single row using the uniqueness constraint, and contains a pre check for permissions.
* An update procedure is generated per _table X unique constraint_ of the form:
  ```graphql
  <mutation-version>_update_<table>_by_<column_and_column_and...>(
      key_<column1>: <value>,
      key_<column2>: <value>,
      ...,
      update_columns: { <column>: { _set: <value> }, ... },
      pre_check: <boolexpr>,
      post_check: <boolexpr>
  )
  ```
  It lets us update a single row using the uniqueness constraint by updating the relevant columns, and contains a pre check and post check for permissions.
  Note that the `update_columns` structure is different than the v2 version where we had `_set`, `_inc`, and other fields.
* Mutations using uniqueness constraints use the naming schema `by_column_and_column_and_column` instead of the db constraint name, because the former is far more helpful.
* If generating a mutation encounters an internal error, we skip that particular mutation instead of throwing an error so the connector can start at any situation.
* Naming collisions between the unique constraints and the update_columns / pre_check / post_check is avoided by prefixing argument names of the columns of a unique constraint with `key_`.
