### PR TITLE
Set the default CONNECTION_URI in package manifest, release v0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "databases-tests"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "axum",
  "insta",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-postgres"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "ndc-postgres-configuration",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-postgres-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "build-data",
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-postgres-configuration"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "insta",
@@ -1837,7 +1837,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openapi-generator"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ndc-postgres-configuration",
  "serde_json",
@@ -2229,7 +2229,7 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "query-engine-execution"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bytes",
  "prometheus",
@@ -2243,11 +2243,11 @@ dependencies = [
 
 [[package]]
 name = "query-engine-metadata"
-version = "0.7.0"
+version = "0.7.1"
 
 [[package]]
 name = "query-engine-sql"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "schemars",
  "serde",
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "query-engine-translation"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3274,7 +3274,7 @@ dependencies = [
 
 [[package]]
 name = "tests-common"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 
-package.version = "0.7.0"
+package.version = "0.7.1"
 package.edition = "2021"
 package.license = "Apache-2.0"
 

--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,7 @@
 ### Added
 
 - A default value for `CONNECTION_URI` for newly initialized connector configurations.
-  ([#503)](https://github.com/hasura/ndc-postgres/pull/503)
+  ([#503](https://github.com/hasura/ndc-postgres/pull/503))
 
 - Support ndc-spec v0.1.4.
   ([#499](https://github.com/hasura/ndc-postgres/pull/499))
@@ -25,7 +25,7 @@
 
 - Aggregate functions (except COUNT) are now all marked as having nullable
   return types, as they will return null for empty row sets.
-  ([#498])(https://github.com/hasura/ndc-postgres/pull/498))
+  ([#498](https://github.com/hasura/ndc-postgres/pull/498))
 
 ### Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -257,7 +257,8 @@ Initial release.
 
 <!-- end -->
 
-[Unreleased]: https://github.com/hasura/ndc-postgres/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/hasura/ndc-postgres/compare/v0.7.1...HEAD
+[v0.7.1]: https://github.com/hasura/ndc-postgres/releases/tag/v0.7.1
 [v0.7.0]: https://github.com/hasura/ndc-postgres/releases/tag/v0.7.0
 [v0.6.0]: https://github.com/hasura/ndc-postgres/releases/tag/v0.6.0
 [v0.5.2]: https://github.com/hasura/ndc-postgres/releases/tag/v0.5.2

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- A default value for `CONNECTION_URI` for newly initialized connector configurations.
+  ([#503)](https://github.com/hasura/ndc-postgres/pull/503)
+
 - Support ndc-spec v0.1.3 and filter/order by nested fields.
   ([#408](https://github.com/hasura/ndc-postgres/pull/486))
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,6 @@
 
 ### Added
 
-
 ### Changed
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -4,11 +4,23 @@
 
 ### Added
 
+
+### Changed
+
+### Fixed
+
+## [v0.7.1] - 2024-06-20
+
+### Added
+
 - A default value for `CONNECTION_URI` for newly initialized connector configurations.
   ([#503)](https://github.com/hasura/ndc-postgres/pull/503)
 
+- Support ndc-spec v0.1.4.
+  ([#499](https://github.com/hasura/ndc-postgres/pull/499))
+
 - Support ndc-spec v0.1.3 and filter/order by nested fields.
-  ([#408](https://github.com/hasura/ndc-postgres/pull/486))
+  ([#486](https://github.com/hasura/ndc-postgres/pull/486))
 
 ### Changed
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -97,7 +97,7 @@ async fn initialize(with_metadata: bool, context: Context<impl Environment>) -> 
             supported_environment_variables: vec![metadata::EnvironmentVariableDefinition {
                 name: "CONNECTION_URI".to_string(),
                 description: "The PostgreSQL connection URI".to_string(),
-                default_value: None,
+                default_value: Some("postgresql://read_only_user:readonlyuser@35.236.11.122:5432/v3-docs-sample-app".to_string()),
             }],
             commands: metadata::Commands {
                 update: Some("hasura-ndc-postgres update".to_string()),


### PR DESCRIPTION
### What

It's nice to have a default value for the `CONNECTION_URI` environment variable when initializing a new connector, since that reduces the number of steps to try it out.
