### PR TITLE
Mutations: improve the error on wrong structure for checks

### DIFF
--- a/crates/query-engine/translation/src/translation/mutation/experimental/delete.rs
+++ b/crates/query-engine/translation/src/translation/mutation/experimental/delete.rs
@@ -141,7 +141,12 @@ pub fn translate(
                 .ok_or(Error::ArgumentNotFound(pre_check.argument_name.clone()))?;
 
             let predicate: models::Expression = serde_json::from_value(predicate_json.clone())
-                .map_err(|_| Error::ArgumentNotFound(pre_check.argument_name.clone()))?;
+                .map_err(|_| {
+                    Error::UnexpectedStructure(format!(
+                        "Argument '{}' should have an ndc-spec Expression structure",
+                        pre_check.argument_name.clone()
+                    ))
+                })?;
 
             let predicate_expression = filtering::translate_expression(
                 env,

--- a/crates/query-engine/translation/src/translation/mutation/experimental/insert.rs
+++ b/crates/query-engine/translation/src/translation/mutation/experimental/insert.rs
@@ -233,8 +233,13 @@ pub fn translate(
                 mutation.post_check.argument_name.clone(),
             ))?;
 
-    let predicate: models::Expression = serde_json::from_value(predicate_json.clone())
-        .map_err(|_| Error::ArgumentNotFound(mutation.post_check.argument_name.clone()))?;
+    let predicate: models::Expression =
+        serde_json::from_value(predicate_json.clone()).map_err(|_| {
+            Error::UnexpectedStructure(format!(
+                "Argument '{}' should have an ndc-spec Expression structure",
+                mutation.post_check.argument_name.clone()
+            ))
+        })?;
 
     let predicate_expression = filtering::translate_expression(
         env,

--- a/crates/query-engine/translation/src/translation/mutation/experimental/update.rs
+++ b/crates/query-engine/translation/src/translation/mutation/experimental/update.rs
@@ -166,7 +166,10 @@ pub fn translate(
 
             let pre_predicate: models::Expression =
                 serde_json::from_value(pre_predicate_json.clone()).map_err(|_| {
-                    Error::ArgumentNotFound(mutation.pre_check.argument_name.clone())
+                    Error::UnexpectedStructure(format!(
+                        "Argument '{}' should have an ndc-spec Expression structure",
+                        mutation.pre_check.argument_name.clone()
+                    ))
                 })?;
 
             let pre_predicate_expression = filtering::translate_expression(
@@ -183,7 +186,10 @@ pub fn translate(
 
             let post_predicate: models::Expression =
                 serde_json::from_value(post_predicate_json.clone()).map_err(|_| {
-                    Error::ArgumentNotFound(mutation.post_check.argument_name.clone())
+                    Error::UnexpectedStructure(format!(
+                        "Argument '{}' should have an ndc-spec Expression structure",
+                        mutation.post_check.argument_name.clone()
+                    ))
                 })?;
 
             let post_predicate_expression = filtering::translate_expression(


### PR DESCRIPTION
### What

We improve the error message on receiving an unexpected structure for checks in experimental mutations.

### How

Instead of "Argument not found" we say "Unexpected Structure".
