### PR TITLE
native operation cli delete command should write to file

### DIFF
--- a/crates/cli/src/native_operations.rs
+++ b/crates/cli/src/native_operations.rs
@@ -225,5 +225,9 @@ async fn delete(
             }
         }
     }
+
+    // We write the configuration excluding the deleted Native Operation.
+    configuration::write_parsed_configuration(configuration, context.context_path.clone()).await?;
+
     Ok(())
 }


### PR DESCRIPTION
### What

The delete command did not write the change to file, this fixes it.

### How

Write the configuration file after deleting.
