### PR TITLE
Warn when the configuration is deprecated

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,8 @@
 
 - Support ndc-sdk-rs v0.2.1, including changes to error messages.
   [#520](https://github.com/hasura/ndc-postgres/pull/520)
+- Warn when starting the connector with an older configuration version.
+  [#537](https://github.com/hasura/ndc-postgres/pull/537)
 
 ### Fixed
 

--- a/crates/configuration/src/configuration.rs
+++ b/crates/configuration/src/configuration.rs
@@ -47,6 +47,13 @@ impl ParsedConfiguration {
     pub fn initial() -> Self {
         ParsedConfiguration::Version5(version5::ParsedConfiguration::empty())
     }
+    pub fn version(&self) -> VersionTag {
+        match self {
+            ParsedConfiguration::Version3(_) => VersionTag::Version3,
+            ParsedConfiguration::Version4(_) => VersionTag::Version4,
+            ParsedConfiguration::Version5(_) => VersionTag::Version5,
+        }
+    }
 }
 
 /// The 'Configuration' type collects all the information necessary to serve queries at runtime.

--- a/crates/configuration/src/lib.rs
+++ b/crates/configuration/src/lib.rs
@@ -25,6 +25,23 @@ pub enum VersionTag {
     Version5,
 }
 
+/// Emit deprecation warning text if the version is deprecated.
+pub fn deprecated_config_warning(version: VersionTag) -> Option<String> {
+    match version {
+		VersionTag::Version3 => Some(
+          "Warning: ndc-postgres configuration version '3' is deprecated.
+Consider upgrading to the latest version:
+https://hasura.io/docs/3.0/connectors/postgresql/configuration-reference/#upgrading-the-configuration-format-version".to_string()
+		),
+		VersionTag::Version4 => Some(
+          "Warning: ndc-postgres configuration version '4' is deprecated.
+Consider upgrading to the latest version:
+https://hasura.io/docs/3.0/connectors/postgresql/configuration-reference/#upgrading-the-configuration-format-version".to_string()
+		),
+		VersionTag::Version5 => None,
+	}
+}
+
 #[cfg(test)]
 pub mod common {
     use std::fmt::Write;
@@ -72,19 +89,4 @@ pub mod common {
             }
         }
     }
-}
-
-/// Emit deprecation warning text if the version is deprecated.
-pub fn deprecated_config_warning(version: VersionTag) -> Option<String> {
-    match version {
-		VersionTag::Version3 => Some(
-          format!("Warning: ndc-postgres configuration version '3' is deprecated.
-Consider upgrading to the latest version:
-https://hasura.io/docs/3.0/connectors/postgresql/configuration-reference/#upgrading-the-configuration-format-version")),
-		VersionTag::Version4 => Some(
-          format!("Warning: ndc-postgres configuration version '4' is deprecated.
-Consider upgrading to the latest version:
-https://hasura.io/docs/3.0/connectors/postgresql/configuration-reference/#upgrading-the-configuration-format-version")),
-		VersionTag::Version5 => None,
-	}
 }

--- a/crates/configuration/src/lib.rs
+++ b/crates/configuration/src/lib.rs
@@ -73,3 +73,18 @@ pub mod common {
         }
     }
 }
+
+/// Emit deprecation warning text if the version is deprecated.
+pub fn deprecated_config_warning(version: VersionTag) -> Option<String> {
+    match version {
+		VersionTag::Version3 => Some(
+          format!("Warning: ndc-postgres configuration version '3' is deprecated.
+Consider upgrading to the latest version:
+https://hasura.io/docs/3.0/connectors/postgresql/configuration-reference/#upgrading-the-configuration-format-version")),
+		VersionTag::Version4 => Some(
+          format!("Warning: ndc-postgres configuration version '4' is deprecated.
+Consider upgrading to the latest version:
+https://hasura.io/docs/3.0/connectors/postgresql/configuration-reference/#upgrading-the-configuration-format-version")),
+		VersionTag::Version5 => None,
+	}
+}

--- a/crates/connectors/ndc-postgres/src/connector.rs
+++ b/crates/connectors/ndc-postgres/src/connector.rs
@@ -256,6 +256,14 @@ impl<Env: Environment + Send + Sync> ConnectorSetup for PostgresSetup<Env> {
                 }
             })?;
 
+        // Warn if the configuration version is deprecated.
+        match configuration::deprecated_config_warning(parsed_configuration.version()) {
+            Some(warning) => {
+                tracing::warn!("{}", warning);
+            }
+            None => {}
+        }
+
         let runtime_configuration =
             configuration::make_runtime_configuration(parsed_configuration, &self.environment)
                 .map_err(|error| {

--- a/crates/connectors/ndc-postgres/src/connector.rs
+++ b/crates/connectors/ndc-postgres/src/connector.rs
@@ -257,11 +257,10 @@ impl<Env: Environment + Send + Sync> ConnectorSetup for PostgresSetup<Env> {
             })?;
 
         // Warn if the configuration version is deprecated.
-        match configuration::deprecated_config_warning(parsed_configuration.version()) {
-            Some(warning) => {
-                tracing::warn!("{}", warning);
-            }
-            None => {}
+        if let Some(warning) =
+            configuration::deprecated_config_warning(parsed_configuration.version())
+        {
+            tracing::warn!("{}", warning);
         }
 
         let runtime_configuration =


### PR DESCRIPTION
### What

We'd like to mark configuration version 3 and 4 as deprecated.
We'll mention this in the docs, and also trace a warning when starting the connector with an older configuration version.

```
{"timestamp":"2024-07-16T13:02:04.857565Z","level":"WARN","fields":{"message":"Warning: ndc-postgres configuration version '3' is deprecated.\nConsider upgrading to the latest version:\nhttps://hasura.io/docs/3.0/connectors/postgresql/configuration-reference/#upgrading-the-configuration-format-version"},"target":"ndc_postgres::connector"}
```

### How

trace a warning pointing at how to upgrade the configuration.
