### PR TITLE
Avoid using references for number types.

### DIFF
--- a/crates/query-engine/sql/src/sql/convert.rs
+++ b/crates/query-engine/sql/src/sql/convert.rs
@@ -607,10 +607,10 @@ impl CountType {
 
 impl Value {
     pub fn to_sql(&self, sql: &mut SQL) {
-        match &self {
+        match self {
             Value::EmptyJsonArray => sql.append_syntax("'[]'"),
-            Value::Int4(i) => sql.append_i32(i),
-            Value::Float8(n) => sql.append_f64(n),
+            Value::Int4(i) => sql.append_i32(*i),
+            Value::Float8(n) => sql.append_f64(*n),
             Value::Character(s) | Value::String(s) => sql.append_param(Param::String(s.clone())),
             Value::Variable(v) => sql.append_param(Param::Variable(v.clone())),
             Value::Bool(true) => sql.append_syntax("true"),
@@ -678,14 +678,14 @@ impl Limit {
             None => (),
             Some(limit) => {
                 sql.append_syntax(" LIMIT ");
-                sql.append_u32(&limit);
+                sql.append_u32(limit);
             }
         };
         match self.offset {
             None => (),
             Some(offset) => {
                 sql.append_syntax(" OFFSET ");
-                sql.append_u32(&offset);
+                sql.append_u32(offset);
             }
         };
     }

--- a/crates/query-engine/sql/src/sql/string.rs
+++ b/crates/query-engine/sql/src/sql/string.rs
@@ -35,10 +35,12 @@ impl SQL {
             params: vec![],
         }
     }
+
     /// Append regular SQL syntax like a keyword (like `SELECT`), punctuation, etc.
     pub fn append_syntax(&mut self, sql: &str) {
         self.sql.push_str(sql);
     }
+
     /// Append a SQL identifier like a column or a table name, which will be
     /// inserted surrounded by quotes.
     pub fn append_identifier(&mut self, sql: &str) {
@@ -47,6 +49,7 @@ impl SQL {
         self.sql.push_str(sql);
         self.sql.push('"');
     }
+
     /// Append a parameter to a parameterized query. Will be represented as $1, $2, and so on,
     /// in the sql query text, and will be inserted to the `params` vector, so we can
     /// bind them later when we run the query.
@@ -57,20 +60,24 @@ impl SQL {
         self.sql.push('$');
         self.sql.push_str(&self.params.len().to_string());
     }
+
     /// Append a literal number of type usize.
-    pub fn append_usize(&mut self, sql: &usize) {
+    pub fn append_usize(&mut self, sql: usize) {
         self.sql.push_str(&sql.to_string());
     }
+
     /// Append a literal number of type u32.
-    pub fn append_u32(&mut self, sql: &u32) {
+    pub fn append_u32(&mut self, sql: u32) {
         self.sql.push_str(&sql.to_string());
     }
+
     /// Append a literal number of type i32.
-    pub fn append_i32(&mut self, sql: &i32) {
+    pub fn append_i32(&mut self, sql: i32) {
         self.sql.push_str(&sql.to_string());
     }
+
     /// Append a literal number of type f64.
-    pub fn append_f64(&mut self, sql: &f64) {
+    pub fn append_f64(&mut self, sql: f64) {
         self.sql.push_str(&sql.to_string());
     }
 }


### PR DESCRIPTION
### What

Numbers implement `Copy`, so we don't need to use a reference.

### How

This removes the `&` from the functions accepting numbers and modifies calling code accordingly.
