### PR TITLE
Release ndc-postgres v1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "databases-tests"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-postgres"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "ndc-postgres-configuration",
@@ -1458,7 +1458,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-postgres-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "build-data",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-postgres-configuration"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1704,7 +1704,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openapi-generator"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "ndc-postgres-configuration",
  "serde_json",
@@ -2049,7 +2049,7 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "query-engine-execution"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bytes",
  "ndc-models",
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "query-engine-metadata"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "ndc-models",
  "smol_str",
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "query-engine-sql"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "ndc-models",
  "schemars",
@@ -2082,7 +2082,7 @@ dependencies = [
 
 [[package]]
 name = "query-engine-translation"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3098,7 +3098,7 @@ dependencies = [
 
 [[package]]
 name = "tests-common"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 
-package.version = "1.0.0"
+package.version = "1.0.1"
 package.edition = "2021"
 package.license = "Apache-2.0"
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,17 @@
 
 ### Fixed
 
+## [v1.0.1]
+
+### Added
+
+- Support network_supeq and network_subeq by default.
+  [#541](https://github.com/hasura/ndc-postgres/pull/541)
+
+### Changed
+
+### Fixed
+
 - Generate the comparison operator `_neq`.
   [#540](https://github.com/hasura/ndc-postgres/pull/540)
 
@@ -291,7 +302,8 @@ Initial release.
 
 <!-- end -->
 
-[Unreleased]: https://github.com/hasura/ndc-postgres/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/hasura/ndc-postgres/compare/v1.0.1...HEAD
+[v1.0.1]: https://github.com/hasura/ndc-postgres/releases/tag/v1.0.1
 [v1.0.0]: https://github.com/hasura/ndc-postgres/releases/tag/v1.0.0
 [v0.8.0]: https://github.com/hasura/ndc-postgres/releases/tag/v0.8.0
 [v0.7.1]: https://github.com/hasura/ndc-postgres/releases/tag/v0.7.1


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

Bump the ndc-postgres `v1.0.0` -> `v1.0.1`
<!-- What is this PR trying to accomplish (and why, if it's not obvious)? -->

<!-- Consider: do we need to add a changelog entry? -->