### PR TITLE
(refactor): rename translate functions and split variables from values

### DIFF
--- a/crates/query-engine/sql/src/sql/helpers.rs
+++ b/crates/query-engine/sql/src/sql/helpers.rs
@@ -764,3 +764,8 @@ pub fn fold_or(expressions: Vec<Expression>) -> Expression {
             right: Box::new(expression),
         })
 }
+
+/// The postgres operator for json extraction.
+pub fn json_extract_operator() -> BinaryOperator {
+    BinaryOperator("->".to_string())
+}

--- a/crates/query-engine/translation/src/translation/mutation/v1/delete.rs
+++ b/crates/query-engine/translation/src/translation/mutation/v1/delete.rs
@@ -1,7 +1,7 @@
 //! Auto-generate delete mutations and translate them into sql ast.
 
 use crate::translation::error::Error;
-use crate::translation::query::values::translate_json_value;
+use crate::translation::query::values::translate;
 use ndc_models as models;
 use query_engine_metadata::metadata;
 use query_engine_metadata::metadata::database;
@@ -102,8 +102,7 @@ pub fn translate_delete(
                 .get(by_column.name.as_str())
                 .ok_or(Error::ArgumentNotFound(by_column.name.clone().into()))?;
 
-            let key_value =
-                translate_json_value(env, state, unique_key, &by_column.r#type).unwrap();
+            let key_value = translate(env, state, unique_key, &by_column.r#type).unwrap();
 
             let unique_expression = sql::ast::Expression::BinaryOperation {
                 left: Box::new(sql::ast::Expression::ColumnReference(

--- a/crates/query-engine/translation/src/translation/mutation/v1/delete.rs
+++ b/crates/query-engine/translation/src/translation/mutation/v1/delete.rs
@@ -1,7 +1,7 @@
 //! Auto-generate delete mutations and translate them into sql ast.
 
 use crate::translation::error::Error;
-use crate::translation::query::values::translate;
+use crate::translation::query::values;
 use ndc_models as models;
 use query_engine_metadata::metadata;
 use query_engine_metadata::metadata::database;
@@ -102,7 +102,7 @@ pub fn translate_delete(
                 .get(by_column.name.as_str())
                 .ok_or(Error::ArgumentNotFound(by_column.name.clone().into()))?;
 
-            let key_value = translate(env, state, unique_key, &by_column.r#type).unwrap();
+            let key_value = values::translate(env, state, unique_key, &by_column.r#type).unwrap();
 
             let unique_expression = sql::ast::Expression::BinaryOperation {
                 left: Box::new(sql::ast::Expression::ColumnReference(

--- a/crates/query-engine/translation/src/translation/mutation/v1/insert.rs
+++ b/crates/query-engine/translation/src/translation/mutation/v1/insert.rs
@@ -1,7 +1,7 @@
 //! Auto-generate insert mutations and translate them into sql ast.
 
 use crate::translation::error::Error;
-use crate::translation::query::values::translate_json_value;
+use crate::translation::query::values;
 use ndc_models as models;
 use query_engine_metadata::metadata;
 use query_engine_metadata::metadata::database;
@@ -65,7 +65,7 @@ pub fn translate(
 
                 columns.push(sql::ast::ColumnName(column_info.name.clone()));
                 values.push(sql::ast::MutationValueExpression::Expression(
-                    translate_json_value(env, state, value, &column_info.r#type)?,
+                    values::translate(env, state, value, &column_info.r#type)?,
                 ));
             }
         }

--- a/crates/query-engine/translation/src/translation/mutation/v2/delete.rs
+++ b/crates/query-engine/translation/src/translation/mutation/v2/delete.rs
@@ -3,7 +3,7 @@
 use crate::translation::error::Error;
 use crate::translation::helpers::{self, TableNameAndReference};
 use crate::translation::query::filtering;
-use crate::translation::query::values::translate_json_value;
+use crate::translation::query::values;
 use ndc_models as models;
 use nonempty::NonEmpty;
 use query_engine_metadata::metadata;
@@ -124,7 +124,7 @@ pub fn translate(
                         .ok_or(Error::ArgumentNotFound(argument_name))?;
 
                     let key_value =
-                        translate_json_value(env, state, unique_key, &by_column.r#type).unwrap();
+                        values::translate(env, state, unique_key, &by_column.r#type).unwrap();
 
                     let unique_expression = sql::ast::Expression::BinaryOperation {
                         left: Box::new(sql::ast::Expression::ColumnReference(
@@ -153,7 +153,7 @@ pub fn translate(
                     ))
                 })?;
 
-            let predicate_expression = filtering::translate_expression(
+            let predicate_expression = filtering::translate(
                 env,
                 state,
                 &helpers::RootAndCurrentTables {

--- a/crates/query-engine/translation/src/translation/mutation/v2/insert.rs
+++ b/crates/query-engine/translation/src/translation/mutation/v2/insert.rs
@@ -4,7 +4,7 @@ use crate::translation::error::Error;
 use crate::translation::helpers::{self, TableNameAndReference};
 use crate::translation::mutation::check_columns;
 use crate::translation::query::filtering;
-use crate::translation::query::values::translate_json_value;
+use crate::translation::query::values;
 use ndc_models as models;
 use query_engine_metadata::metadata;
 use query_engine_metadata::metadata::database;
@@ -75,7 +75,7 @@ fn translate_object_into_columns_and_values(
 
                 columns_to_values.insert(
                     sql::ast::ColumnName(column_info.name.clone()),
-                    sql::ast::MutationValueExpression::Expression(translate_json_value(
+                    sql::ast::MutationValueExpression::Expression(values::translate(
                         env,
                         state,
                         value,
@@ -239,7 +239,7 @@ pub fn translate(
             ))
         })?;
 
-    let predicate_expression = filtering::translate_expression(
+    let predicate_expression = filtering::translate(
         env,
         state,
         &helpers::RootAndCurrentTables {

--- a/crates/query-engine/translation/src/translation/query/filtering.rs
+++ b/crates/query-engine/translation/src/translation/query/filtering.rs
@@ -9,6 +9,7 @@ use query_engine_sql::sql::helpers::where_exists_select;
 use super::relationships;
 use super::root;
 use super::values;
+use super::variables;
 use crate::translation::error::Error;
 use crate::translation::helpers::wrap_in_field_path;
 use crate::translation::helpers::{
@@ -19,7 +20,7 @@ use query_engine_sql::sql;
 use std::collections::VecDeque;
 
 /// Translate a boolean expression to a SQL expression.
-pub fn translate_expression(
+pub fn translate(
     env: &Env,
     state: &mut State,
     root_and_current_tables: &RootAndCurrentTables,
@@ -495,12 +496,11 @@ fn translate_comparison_value(
         models::ComparisonValue::Column { column } => {
             translate_comparison_target(env, state, root_and_current_tables, column)
         }
-        models::ComparisonValue::Scalar { value: json_value } => Ok((
-            values::translate_json_value(env, state, json_value, typ)?,
-            vec![],
-        )),
+        models::ComparisonValue::Scalar { value: json_value } => {
+            Ok((values::translate(env, state, json_value, typ)?, vec![]))
+        }
         models::ComparisonValue::Variable { name: var } => Ok((
-            values::translate_variable(env, state, env.get_variables_table()?, var, typ)?,
+            variables::translate(env, state, env.get_variables_table()?, var, typ)?,
             vec![],
         )),
     }

--- a/crates/query-engine/translation/src/translation/query/mod.rs
+++ b/crates/query-engine/translation/src/translation/query/mod.rs
@@ -8,6 +8,7 @@ pub mod relationships;
 pub mod root;
 mod sorting;
 pub mod values;
+pub mod variables;
 
 use ndc_models as models;
 

--- a/crates/query-engine/translation/src/translation/query/native_queries.rs
+++ b/crates/query-engine/translation/src/translation/query/native_queries.rs
@@ -4,6 +4,7 @@ use ndc_models as models;
 use ref_cast::RefCast;
 
 use super::values;
+use super::variables;
 use crate::translation::error::Error;
 use crate::translation::helpers::{Env, State, TableAliasIndex};
 use query_engine_metadata::metadata;
@@ -56,15 +57,12 @@ pub fn translate(
                     {
                         None => Err(Error::ArgumentNotFound(param.to_string().into())),
                         Some(argument) => match argument {
-                            models::Argument::Literal { value } => values::translate_json_value(
-                                env,
-                                &mut translation_state,
-                                value,
-                                &typ,
-                            ),
+                            models::Argument::Literal { value } => {
+                                values::translate(env, &mut translation_state, value, &typ)
+                            }
                             models::Argument::Variable { name } => match &variables_table {
                                 Err(err) => Err(err.clone()),
-                                Ok(variables_table) => values::translate_variable(
+                                Ok(variables_table) => variables::translate(
                                     env,
                                     &mut translation_state,
                                     variables_table.clone(),

--- a/crates/query-engine/translation/src/translation/query/relationships.rs
+++ b/crates/query-engine/translation/src/translation/query/relationships.rs
@@ -18,7 +18,7 @@ pub struct JoinFieldInfo {
 }
 
 /// translate any joins we should include in the query into our SQL AST
-pub fn translate_joins(
+pub fn translate(
     env: &Env,
     state: &mut State,
     current_table: &TableNameAndReference,

--- a/crates/query-engine/translation/src/translation/query/sorting.rs
+++ b/crates/query-engine/translation/src/translation/query/sorting.rs
@@ -19,7 +19,7 @@ use query_engine_sql::sql;
 
 /// Convert the order by fields from a QueryRequest to a SQL ORDER BY clause and potentially
 /// JOINs when we order by relationship fields.
-pub fn translate_order_by(
+pub fn translate(
     env: &Env,
     state: &mut State,
     root_and_current_tables: &RootAndCurrentTables,
@@ -776,8 +776,7 @@ fn select_for_path_element(
                 root_table: root_and_current_tables.root_table.clone(),
                 current_table: join_table,
             };
-            let predicate_expr =
-                filtering::translate_expression(env, state, &predicate_tables, predicate)?;
+            let predicate_expr = filtering::translate(env, state, &predicate_tables, predicate)?;
 
             // generate a condition for this join.
             let join_condition = relationships::translate_column_mapping(

--- a/crates/query-engine/translation/src/translation/query/variables.rs
+++ b/crates/query-engine/translation/src/translation/query/variables.rs
@@ -1,0 +1,34 @@
+//! Handle the translation of variables into SQL values.
+
+use super::values;
+use crate::translation::{error::Error, helpers::Env, helpers::State};
+use ndc_models as models;
+use query_engine_metadata::metadata::database;
+use query_engine_sql::sql;
+
+/// Convert a variable into a SQL value by selecting it from the variables table.
+pub fn translate(
+    env: &Env,
+    state: &mut State,
+    variables_table: sql::ast::TableReference,
+    variable: &models::VariableName,
+    r#type: &database::Type,
+) -> Result<sql::ast::Expression, Error> {
+    let variables_reference =
+        sql::ast::Expression::ColumnReference(sql::ast::ColumnReference::AliasedColumn {
+            table: variables_table,
+            column: sql::helpers::make_column_alias(sql::helpers::VARIABLES_FIELD.to_string()),
+        });
+
+    // We use the binop '->' to project (as jsonb) the value of a variable from the data column of
+    // the variable table.
+    let projected_variable_exp = sql::ast::Expression::BinaryOperation {
+        left: Box::new(variables_reference),
+        operator: sql::helpers::json_extract_operator(),
+        right: Box::new(sql::ast::Expression::Value(sql::ast::Value::String(
+            variable.to_string(),
+        ))),
+    };
+
+    values::translate_projected(env, state, r#type, projected_variable_exp)
+}


### PR DESCRIPTION
### What

Wanted to streamline the naming of the translate functions which we can do because we use qualified module names.

1. Instead of something like `sorting::translate_order_by`, just use `sorting::translate`.
2. Variables selection get their own module instead of living in `values`  

