### PR TITLE
Upgrade ndc-sdk-rs to v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,7 +1497,7 @@ dependencies = [
 [[package]]
 name = "ndc-sdk"
 version = "0.2.1"
-source = "git+https://github.com/hasura/ndc-sdk-rs.git?tag=v0.2.1#83a906e8a744ee78d84aeee95f61bf3298a982ea"
+source = "git+https://github.com/hasura/ndc-sdk-rs.git?tag=v0.2.2#9120a826037cc16f8261c83663fef63452f4d5c6"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ too_many_lines = "allow"
 
 [workspace.dependencies]
 ndc-models = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.5" }
-ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs.git", tag = "v0.2.1" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs.git", tag = "v0.2.2" }
 ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.1.5" }
 
 anyhow = "1"

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@
 
 ### Changed
 
+- Upgrade ndc-sdk-rs to v0.2.2
+  [#555](https://github.com/hasura/ndc-postgres/pull/555)
+
 ### Fixed
 
 ## [v1.0.1]


### PR DESCRIPTION
### What

https://github.com/hasura/ndc-sdk-rs/releases/tag/v0.2.2

> What's Changed
>   - listen on all ipv4 and ipv6 interfaces by default
