### PR TITLE
new-version.sh script for new version PRs

### DIFF
--- a/scripts/changelog.hs
+++ b/scripts/changelog.hs
@@ -1,0 +1,64 @@
+-- | The purpose of script is to automate some of the actions necessarily to update the changelog
+--   before releasing a new version. It will:
+--
+--   1. Replace the `[Unreleased]` header with a `[<version>] - <date>` header
+--   2. Insert a new `[Unreleased]` template at the top
+--   3. Fix the references at the bottom
+
+{-# language LambdaCase #-}
+
+import System.Environment
+import Data.List
+
+main :: IO ()
+main = do
+  (filepath, today'sDate, newVersion) <- getArgs >>= \case
+    [filepath, date, ver] -> pure (filepath, date, "v" <> ver)
+    _ -> error "Usage: runghc changelog.hs <changelog-filepath> <today's date> <version>"
+  file <- lines <$> readFile filepath
+
+  -- This is mostly just to force reading the entire file before we can write to it.
+  putStrLn $
+    "Found "
+      <> show (length (filter ("## " `isPrefixOf`) file) - 1)
+      <> " versions. Adding: "
+      <> newVersion
+      <> " to changelog."
+
+  let result = map (replaceUnrelated newVersion) $ addNewTemplate today'sDate newVersion $ drop 4 file
+  writeFile filepath $ unlines result
+
+addNewTemplate :: String -> String -> [String] -> [String]
+addNewTemplate date newVersion rest =
+    [ "# Changelog",
+      "",
+      "## [Unreleased]",
+      "",
+      "### Added",
+      "",
+      "### Changed",
+      "",
+      "### Fixed",
+      "",
+      "## [" <> newVersion <> "] - " <> date,
+      ""
+    ] <> rest
+
+replaceUnrelated :: String -> String -> String
+replaceUnrelated newVersion line
+  | "[Unreleased]: " `isPrefixOf` line =
+    let
+      oldVersion =
+        reverse
+          $ drop (length "...HEAD")
+          $ reverse
+          $ drop (length $ "[Unreleased]: " <> "https://github.com/hasura/ndc-postgres/compare/")
+          $ line
+
+    in
+      intercalate "\n"
+        [ "[Unreleased]: https://github.com/hasura/ndc-postgres/compare/" <> newVersion <> "...HEAD",
+          "[" <> newVersion <> "]: https://github.com/hasura/ndc-postgres/releases/tag/" <> newVersion
+        ]
+
+  | otherwise = line

--- a/scripts/changelog.hs
+++ b/scripts/changelog.hs
@@ -25,8 +25,16 @@ main = do
       <> newVersion
       <> " to changelog."
 
-  let result = map (replaceUnrelated newVersion) $ addNewTemplate today'sDate newVersion $ drop 4 file
+  let
+    result =
+      map (replaceUnrelated newVersion)
+        $ addNewTemplate today'sDate newVersion
+        $ deleteTop
+        $ file
   writeFile filepath $ unlines result
+
+deleteTop :: [String] -> [String]
+deleteTop = drop 4
 
 addNewTemplate :: String -> String -> [String] -> [String]
 addNewTemplate date newVersion rest =

--- a/scripts/changelog.hs
+++ b/scripts/changelog.hs
@@ -47,18 +47,9 @@ addNewTemplate date newVersion rest =
 replaceUnrelated :: String -> String -> String
 replaceUnrelated newVersion line
   | "[Unreleased]: " `isPrefixOf` line =
-    let
-      oldVersion =
-        reverse
-          $ drop (length "...HEAD")
-          $ reverse
-          $ drop (length $ "[Unreleased]: " <> "https://github.com/hasura/ndc-postgres/compare/")
-          $ line
-
-    in
-      intercalate "\n"
-        [ "[Unreleased]: https://github.com/hasura/ndc-postgres/compare/" <> newVersion <> "...HEAD",
-          "[" <> newVersion <> "]: https://github.com/hasura/ndc-postgres/releases/tag/" <> newVersion
-        ]
+    intercalate "\n"
+      [ "[Unreleased]: https://github.com/hasura/ndc-postgres/compare/" <> newVersion <> "...HEAD",
+        "[" <> newVersion <> "]: https://github.com/hasura/ndc-postgres/releases/tag/" <> newVersion
+      ]
 
   | otherwise = line

--- a/scripts/new-version.sh
+++ b/scripts/new-version.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Update cargo packages version and changelog entries for a new version.
+
+set -e -u -o pipefail
+
+if [ "$#" != 1 ];
+then
+  echo "Usage: $0 <new-version>"
+  exit 1
+fi
+
+NEW_VERSION="$1"
+DATE_TODAY=$(date +"%Y-%m-%d")
+
+echo "Updating version to v$NEW_VERSION"
+
+sed -i "s/package.version = .*/package.version = \"${NEW_VERSION}\"/" Cargo.toml
+
+just test
+
+runghc scripts/changelog.hs "changelog.md" "${DATE_TODAY}" "${NEW_VERSION}"


### PR DESCRIPTION
### What

We want to automate some of the release process for ndc-postgres by introducing a new `scripts/new-version.sh` script that updates the cargo package version and updates the changelog.

Run with: `scripts/new-version.sh 1.0.2`, for example.

### How

1. A bash script to run everything
2. A sed script to change the package version
3. A Haskell script to manipulate the changelog to:
   - Change the unreleased header to the version
   - Insert a new unreleased template
   - Fix the references at the bottom of the changelog