### PR TITLE
[Native Operations]: trim semicolon suffix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@
 
 ### Fixed
 
-- Allow Native Queries that end with a semicolon when it's easy to remove them.
+- Allow Native Operations that end with a semicolon when it's easy to remove them.
   [#566](https://github.com/hasura/ndc-postgres/pull/566)
 
 ## [v1.0.1]

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,9 @@
 
 ### Fixed
 
+- Allow Native Queries that end with a semicolon when it's easy to remove them.
+  [#566](https://github.com/hasura/ndc-postgres/pull/566)
+
 ## [v1.0.1]
 
 ### Added

--- a/crates/configuration/src/version5/metadata/native_operations.rs
+++ b/crates/configuration/src/version5/metadata/native_operations.rs
@@ -286,8 +286,11 @@ pub fn parse_native_query_from_file(
 }
 
 /// Parse a native query into parts where variables have the syntax `{{<variable>}}`.
-pub fn parse_native_query(string: &str) -> NativeQueryParts {
-    let vec: Vec<Vec<NativeQueryPart>> = string
+pub fn parse_native_query(string_untrimmed: &str) -> NativeQueryParts {
+    let string_trimmed = string_untrimmed.trim_end();
+    let vec: Vec<Vec<NativeQueryPart>> = string_trimmed
+        .strip_suffix(';')
+        .unwrap_or(string_trimmed)
         .split("{{")
         .map(|part| match part.split_once("}}") {
             None => vec![NativeQueryPart::Text(part.to_string())],
@@ -344,6 +347,16 @@ mod tests {
                 NativeQueryPart::Text(" = ".to_string()),
                 NativeQueryPart::Parameter("other_name".into()),
             ])
+        );
+    }
+
+    #[test]
+    fn with_trailing_semicolon() {
+        assert_eq!(
+            parse_native_query("select *, 'a ; string' from t;   \n"),
+            NativeQueryParts(vec![NativeQueryPart::Text(
+                "select *, 'a ; string' from t".to_string()
+            )])
         );
     }
 

--- a/crates/configuration/src/version5/metadata/native_operations.rs
+++ b/crates/configuration/src/version5/metadata/native_operations.rs
@@ -288,11 +288,11 @@ pub fn parse_native_query_from_file(
 /// Parse a native query into parts where variables have the syntax `{{<variable>}}`.
 pub fn parse_native_query(string_untrimmed: &str) -> NativeQueryParts {
     let string_trimmed = string_untrimmed.trim_end();
-    let vec: Vec<Vec<NativeQueryPart>> = string_trimmed
+    let vec: Vec<NativeQueryPart> = string_trimmed
         .strip_suffix(';')
         .unwrap_or(string_trimmed)
         .split("{{")
-        .map(|part| match part.split_once("}}") {
+        .flat_map(|part| match part.split_once("}}") {
             None => vec![NativeQueryPart::Text(part.to_string())],
             Some((var, text)) => {
                 if text.is_empty() {
@@ -306,7 +306,7 @@ pub fn parse_native_query(string_untrimmed: &str) -> NativeQueryParts {
             }
         })
         .collect();
-    NativeQueryParts(vec.concat())
+    NativeQueryParts(vec)
 }
 
 // tests

--- a/justfile
+++ b/justfile
@@ -46,7 +46,7 @@ dev: start-dependencies
   OTEL_SERVICE_NAME=ndc-postgres \
     cargo watch -i "**/snapshots/*" \
     -c \
-    -x 'test -p query-engine-metadata -p query-engine-sql -p query-engine-translation -p databases-tests --features postgres' \
+    -x 'test -p ndc-postgres-configuration -p query-engine-metadata -p query-engine-sql -p query-engine-translation -p databases-tests --features postgres' \
     -x clippy \
     -x 'run --bin ndc-postgres -- serve --otlp-endpoint http://localhost:4317 --configuration {{POSTGRES_LATEST_CHINOOK_NDC_METADATA}}'
 

--- a/static/postgres/v5-configuration/native_queries/summarize_organizations.sql
+++ b/static/postgres/v5-configuration/native_queries/summarize_organizations.sql
@@ -20,3 +20,4 @@ FROM
           unnest(committee.members) AS members
       ) AS members_agg ON TRUE
   ) AS coms ON TRUE
+;


### PR DESCRIPTION
### What

There are simple cases where we can handle native queries that end with semicolon. This might help some users. https://hasurahq.slack.com/archives/C0329ERCSA1/p1723212643398509

### How

When parsing a native query,

1. trim end
2. strip_suffix(';'), or keep the trimmed version.
