### PR TITLE
CI: Make the GitHub Actions triggers consistent.

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,6 +1,7 @@
-on: [push]
-
 name: Postgres NDC component benchmarks
+
+on:
+  push:
 
 permissions:
   contents: write

--- a/.github/workflows/cargo-build.yaml
+++ b/.github/workflows/cargo-build.yaml
@@ -1,6 +1,7 @@
-on: [push]
-
 name: Postgres NDC build
+
+on:
+  push:
 
 jobs:
   build:

--- a/.github/workflows/cargo-test.yaml
+++ b/.github/workflows/cargo-test.yaml
@@ -1,6 +1,7 @@
-on: [push]
-
 name: Postgres NDC tests
+
+on:
+  push:
 
 jobs:
   test-unit:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -1,9 +1,7 @@
 name: Postgres E2E tests
 
 on:
-  merge_group:
   push:
-  pull_request:
 
 jobs:
   run_postgres_e2es:

--- a/.github/workflows/schema-definitions.yaml
+++ b/.github/workflows/schema-definitions.yaml
@@ -1,6 +1,7 @@
-on: [push]
-
 name: Schema Definitions for Metadata
+
+on:
+  push:
 
 jobs:
   schema_definitions:


### PR DESCRIPTION
### What

We only need the `push` trigger.

### How

I removed other triggers, and made the syntax consistent.

The merge queue seems to work fine without the `merge_group` trigger.