### PR TITLE
Array elements are always nullable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,9 @@
 
 ### Fixed
 
+- Make array element types nullable in the schema.
+  [#565](https://github.com/hasura/ndc-postgres/pull/571)
+
 ## [v1.0.2]
 
 ### Changed

--- a/crates/connectors/ndc-postgres/src/schema/helpers.rs
+++ b/crates/connectors/ndc-postgres/src/schema/helpers.rs
@@ -27,7 +27,9 @@ pub fn readonly_column_to_type(column: &metadata::ReadOnlyColumnInfo) -> models:
 pub fn type_to_type(typ: &metadata::Type) -> models::Type {
     match typ {
         metadata::Type::ArrayType(typ) => models::Type::Array {
-            element_type: Box::new(type_to_type(typ)),
+            element_type: Box::new(models::Type::Nullable {
+                underlying_type: Box::new(type_to_type(typ)),
+            }),
         },
         metadata::Type::ScalarType(scalar_type) => models::Type::Named {
             name: scalar_type.as_str().into(),

--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__schema_tests__schema_test__get_schema.snap
@@ -2883,8 +2883,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "varchar"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "varchar"
+                }
               }
             }
           }
@@ -2900,8 +2903,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "int4"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "int4"
+                }
               }
             }
           }
@@ -2991,8 +2997,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "chara"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "chara"
+                }
               }
             }
           }
@@ -3016,8 +3025,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "person_name"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "person_name"
+                }
               }
             }
           }
@@ -3293,8 +3305,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "committee"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "committee"
+                }
               }
             }
           }
@@ -5068,8 +5083,11 @@ expression: result
           "type": {
             "type": "array",
             "element_type": {
-              "type": "named",
-              "name": "varchar"
+              "type": "nullable",
+              "underlying_type": {
+                "type": "named",
+                "name": "varchar"
+              }
             }
           }
         }
@@ -5139,8 +5157,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "text"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "text"
+                }
               }
             }
           }
@@ -5205,8 +5226,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "organization"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "organization"
+                }
               }
             }
           }

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__schema_tests__schema_test__get_schema.snap
@@ -2496,8 +2496,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "varchar"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "varchar"
+                }
               }
             }
           }
@@ -2513,8 +2516,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "int4"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "int4"
+                }
               }
             }
           }
@@ -4483,8 +4489,11 @@ expression: result
           "type": {
             "type": "array",
             "element_type": {
-              "type": "named",
-              "name": "varchar"
+              "type": "nullable",
+              "underlying_type": {
+                "type": "named",
+                "name": "varchar"
+              }
             }
           }
         }
@@ -4554,8 +4563,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "text"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "text"
+                }
               }
             }
           }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__relationships__nested_field_relationship.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__query_tests__relationships__nested_field_relationship.snap
@@ -44,6 +44,10 @@ expression: result
             }
           }
         ]
+      },
+      {
+        "name": "University of Nowhere",
+        "staff": null
       }
     ]
   }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
@@ -3209,8 +3209,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "varchar"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "varchar"
+                }
               }
             }
           }
@@ -3226,8 +3229,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "int4"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "int4"
+                }
               }
             }
           }
@@ -3317,8 +3323,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "chara"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "chara"
+                }
               }
             }
           }
@@ -3342,8 +3351,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "person_name"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "person_name"
+                }
               }
             }
           }
@@ -3735,8 +3747,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "text"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "text"
+                }
               }
             }
           }
@@ -3780,8 +3795,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "institution_staff"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "institution_staff"
+                }
               }
             }
           }
@@ -3818,8 +3836,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "text"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "text"
+                }
               }
             }
           }
@@ -3879,8 +3900,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "text"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "text"
+                }
               }
             }
           }
@@ -3909,8 +3933,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "committee"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "committee"
+                }
               }
             }
           }
@@ -5141,8 +5168,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "text"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "text"
+                }
               }
             }
           }
@@ -5216,8 +5246,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "institution_staff"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "institution_staff"
+                }
               }
             }
           }
@@ -6972,8 +7005,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "text"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "text"
+                }
               }
             }
           }
@@ -7017,8 +7053,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "institution_staff"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "institution_staff"
+                }
               }
             }
           }
@@ -9445,8 +9484,11 @@ expression: result
           "type": {
             "type": "array",
             "element_type": {
-              "type": "named",
-              "name": "varchar"
+              "type": "nullable",
+              "underlying_type": {
+                "type": "named",
+                "name": "varchar"
+              }
             }
           }
         }
@@ -9516,8 +9558,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "text"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "text"
+                }
               }
             }
           }
@@ -9582,8 +9627,11 @@ expression: result
             "underlying_type": {
               "type": "array",
               "element_type": {
-                "type": "named",
-                "name": "organization"
+                "type": "nullable",
+                "underlying_type": {
+                  "type": "named",
+                  "name": "organization"
+                }
               }
             }
           }

--- a/static/institution.sql
+++ b/static/institution.sql
@@ -66,7 +66,7 @@ ROW(
 ARRAY ['Architecture and Civil Engineering','Computer Science and Engineering','Electrical Engineering','Physics','Industrial and Materials Science'],
 ROW(
     3421,
-    3421 -- NULL
+    NULL
   )::institution.institution_songs
 )
 ,(

--- a/static/institution.sql
+++ b/static/institution.sql
@@ -69,12 +69,11 @@ ROW(
     3421 -- NULL
   )::institution.institution_songs
 )
-;
--- ,(
---   3,
---   'University of Nowhere',
---   null,
---   null,
---   ARRAY ['nothing',null],
---   NULL
--- );
+,(
+  3,
+  'University of Nowhere',
+   null,
+  null,
+  ARRAY ['nothing',null],
+  NULL
+);


### PR DESCRIPTION
### What

PR #565 fixed field nullability of composite type fields, but neglected to treat the similar issue that exists for arrays.

In Postgres, any array type (e.g. `int4[]`, `text[]`, etc.) may contain elements which are null. The type system does not support declaring arrays with non-null elements.

This PR fixes that issue.

### How

Whenever we have to translate an ndc-postgres array type to an ndc-spec array type in the schema generation we annotate the element type as being nullable.
