### PR TITLE
Support setting ssl client certificate information via environment variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,6 +1459,7 @@ dependencies = [
 name = "ndc-postgres"
 version = "1.0.2"
 dependencies = [
+ "anyhow",
  "async-trait",
  "mimalloc",
  "ndc-postgres-configuration",

--- a/changelog.md
+++ b/changelog.md
@@ -4,12 +4,15 @@
 
 ### Added
 
+- Support setting ssl client certificate information via environment variables.
+  [#574](https://github.com/hasura/ndc-postgres/pull/574)
+
 ### Changed
 
 ### Fixed
 
 - Make array element types nullable in the schema.
-  [#565](https://github.com/hasura/ndc-postgres/pull/571)
+  [#571](https://github.com/hasura/ndc-postgres/pull/571)
 
 ## [v1.0.2]
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -98,11 +98,28 @@ async fn initialize(with_metadata: bool, context: Context<impl Environment>) -> 
                     ),
                 },
             ),
-            supported_environment_variables: vec![metadata::EnvironmentVariableDefinition {
-                name: "CONNECTION_URI".to_string(),
-                description: "The PostgreSQL connection URI".to_string(),
-                default_value: Some("postgresql://read_only_user:readonlyuser@35.236.11.122:5432/v3-docs-sample-app".to_string()),
-            }],
+            supported_environment_variables: vec![
+				metadata::EnvironmentVariableDefinition {
+					name: "CONNECTION_URI".to_string(),
+					description: "The PostgreSQL connection URI".to_string(),
+					default_value: Some("postgresql://read_only_user:readonlyuser@35.236.11.122:5432/v3-docs-sample-app".to_string()),
+				},
+				metadata::EnvironmentVariableDefinition {
+					name: "CLIENT_CERT".to_string(),
+					description: "The SSL client certificate".to_string(),
+					default_value: None,
+				},
+				metadata::EnvironmentVariableDefinition {
+					name: "CLIENT_KEY".to_string(),
+					description: "The SSL client key".to_string(),
+					default_value: None,
+				},
+				metadata::EnvironmentVariableDefinition {
+					name: "ROOT_CERT".to_string(),
+					description: "The SSL root certificate".to_string(),
+					default_value: None,
+				},
+			],
             commands: metadata::Commands {
                 update: Some("hasura-ndc-postgres update".to_string()),
                 watch: None,

--- a/crates/cli/src/native_operations.rs
+++ b/crates/cli/src/native_operations.rs
@@ -190,6 +190,7 @@ async fn create(
 
             let new_native_operation = configuration::version5::native_operations::create(
                 configuration,
+                &context.environment,
                 &connection_string,
                 &operation_path,
                 &file_contents,

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
@@ -9,6 +9,12 @@ supportedEnvironmentVariables:
 - name: CONNECTION_URI
   description: The PostgreSQL connection URI
   defaultValue: postgresql://read_only_user:readonlyuser@35.236.11.122:5432/v3-docs-sample-app
+- name: CLIENT_CERT
+  description: The SSL client certificate
+- name: CLIENT_KEY
+  description: The SSL client key
+- name: ROOT_CERT
+  description: The SSL root certificate
 commands:
   update: hasura-ndc-postgres update
 cliPlugin:

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
@@ -9,6 +9,12 @@ supportedEnvironmentVariables:
 - name: CONNECTION_URI
   description: The PostgreSQL connection URI
   defaultValue: postgresql://read_only_user:readonlyuser@35.236.11.122:5432/v3-docs-sample-app
+- name: CLIENT_CERT
+  description: The SSL client certificate
+- name: CLIENT_KEY
+  description: The SSL client key
+- name: ROOT_CERT
+  description: The SSL root certificate
 commands:
   update: hasura-ndc-postgres update
 cliPlugin:

--- a/crates/configuration/src/connect.rs
+++ b/crates/configuration/src/connect.rs
@@ -1,0 +1,66 @@
+//! Connection settings.
+
+use std::borrow::Cow;
+
+use sqlx::postgres::PgConnectOptions;
+use sqlx::ConnectOptions;
+
+use crate::environment::{Environment, Variable};
+use crate::values::{ConnectionUri, Secret};
+
+/// Get the connect options from the connection string and environment.
+pub fn get_connect_options(
+    connection_uri: &ConnectionUri,
+    environment: impl Environment,
+) -> anyhow::Result<PgConnectOptions> {
+    let uri = match &connection_uri {
+        ConnectionUri(Secret::Plain(value)) => Cow::Borrowed(value),
+        ConnectionUri(Secret::FromEnvironment { variable }) => {
+            Cow::Owned(environment.read(variable)?)
+        }
+    };
+
+    let connect_options = PgConnectOptions::from_url(&uri.parse()?)?;
+
+    let ssl = read_ssl_info(environment);
+
+    // Add ssl info if present.
+    Ok(match ssl {
+        None => connect_options,
+        Some(secret) => connect_options
+            .ssl_client_cert_from_pem(secret.certificate)
+            .ssl_client_key_from_pem(secret.key)
+            .ssl_root_cert_from_pem(secret.root_certificate),
+    })
+}
+
+/// SSL client certificate information.
+struct SslClientInfo {
+    certificate: String,
+    key: String,
+    root_certificate: Vec<u8>,
+}
+
+/// Read ssl certificate and key from the environment.
+fn read_ssl_info(environment: impl Environment) -> Option<SslClientInfo> {
+    // read ssl info
+    let certificate = environment.read(&Variable::from("CLIENT_CERT")).ok();
+    let key = environment.read(&Variable::from("CLIENT_KEY")).ok();
+    let root_certificate = environment
+        .read(&Variable::from("ROOT_CERT"))
+        .ok()
+        .map(|text| text.as_bytes().to_vec());
+
+    match (certificate, key, root_certificate) {
+        (Some(certificate), Some(key), Some(root_certificate))
+            if !certificate.is_empty() && !key.is_empty() && !root_certificate.is_empty() =>
+        {
+            Some(SslClientInfo {
+                certificate,
+                key,
+                root_certificate,
+            })
+        }
+        _ => None,
+    }
+}

--- a/crates/configuration/src/lib.rs
+++ b/crates/configuration/src/lib.rs
@@ -1,4 +1,5 @@
 mod configuration;
+mod connect;
 mod values;
 
 pub mod environment;
@@ -17,6 +18,8 @@ pub use configuration::{
 pub use values::{ConnectionUri, IsolationLevel, PoolSettings, Secret};
 
 pub use metrics::Metrics;
+
+pub use connect::get_connect_options;
 
 #[derive(Debug, Copy, Clone)]
 pub enum VersionTag {

--- a/crates/connectors/ndc-postgres/Cargo.toml
+++ b/crates/connectors/ndc-postgres/Cargo.toml
@@ -26,6 +26,7 @@ query-engine-translation = { path = "../../query-engine/translation" }
 
 ndc-sdk = { workspace = true }
 
+anyhow = { workspace = true }
 async-trait = { workspace = true }
 mimalloc = { workspace = true }
 percent-encoding = { workspace = true }

--- a/crates/connectors/ndc-postgres/src/connector.rs
+++ b/crates/connectors/ndc-postgres/src/connector.rs
@@ -277,8 +277,10 @@ impl<Env: Environment + Send + Sync> ConnectorSetup for PostgresSetup<Env> {
         configuration: &<Self::Connector as Connector>::Configuration,
         metrics: &mut prometheus::Registry,
     ) -> Result<<Self::Connector as Connector>::State> {
+        // create the state
         state::create_state(
             &configuration.connection_uri,
+            &self.environment,
             &configuration.pool_settings,
             metrics,
             configuration.configuration_version_tag,

--- a/crates/tests/tests-common/src/common_tests/configuration_tests.rs
+++ b/crates/tests/tests-common/src/common_tests/configuration_tests.rs
@@ -1,5 +1,6 @@
 //! Tests the configuration generation has not changed.
 
+use ndc_postgres_configuration::environment::EmptyEnvironment;
 use ndc_postgres_configuration::version5;
 use ndc_postgres_configuration::ParsedConfiguration;
 use std::collections::HashMap;
@@ -24,6 +25,7 @@ pub async fn test_native_operation_create_v5(
         ParsedConfiguration::Version5(parsed_configuration) => {
             let result = version5::native_operations::create(
                 &parsed_configuration,
+                &EmptyEnvironment,
                 connection_string,
                 &PathBuf::from("test.sql"),
                 &sql,


### PR DESCRIPTION
### What

We'd like to support setting ssl certificate information via environment variables.

### How

1. We create a new function, `get_connect_options`, which will read both the uri and the ssl information, and use it and `connect_with` everywhere instead of `connect` with just the `uri`. We make sure all operations using configuration version 5 including the connector and the cli use `get_connect_options` (except tests).
2. We read the `client_cert`, `client_key` and `root_cert` from the environment and put them directly into the sqlx connection options. 

#### How we tested this

We used [this article](https://dev.to/danvixent/how-to-setup-postgresql-with-ssl-inside-a-docker-container-5f3) as a guide on how to set up postgres+certs with docker.

After running all of the commands, we had to do the following as well:

```sh
$ certstrap request-cert --common-name postgresdb  --domain localhost
$ cp certs/out/myCA.crt out/
$ cp certs/out/myCA.key out/
$ certstrap sign postgresdb --CA myCA
```

Then, we added the following environment variables:

```sh
$ export CLIENT_CERT="$(cat /tmp/ssl/out/postgresdb.crt)"
$ export CLIENT_KEY="$(cat /tmp/ssl/out/postgresdb.key)"
$ export ROOT_CERT="$(cat /tmp/ssl/certs/out/myCA.crt)"
```

Initialized and updated the connector:

```sh
$ mdkir /tmp/ssltest
$ CONNECTION_URI="postgresql://postgres:postgres@localhost:64009/postgres?sslmode=verify-ca" target/debug/ndc-postgres-cli --context /tmp/ssltest initialize
$ CONNECTION_URI="postgresql://postgres:postgres@localhost:64009/postgres?sslmode=verify-ca" target/debug/ndc-postgres-cli --context /tmp/ssltest update
```

Added a native query:

```sh
$ echo "select 'gil' as "name", 35 as 'age'" > /tmp/ssltest/a.sql

$ CONNECTION_URI="postgresql://postgres:postgres@localhost:64009/postgres?sslmode=verify-ca" target/debug/ndc-postgres-cli --context /tmp/ssltest native-operation create --kind query --operation-path a.sql
```

Started the connector:

```sh
CONNECTION_URI="postgresql://postgres:postgres@localhost:64009/postgres?sslmode=verify-ca" target/debug/ndc-postgres serve --configuration /tmp/ssltest
```

And ran a query:

```sh
curl -X POST \
    -H 'Host: example.hasura.app' \
    -H 'Content-Type: application/json' \
    -H 'x-hasura-role: admin' \
    http://localhost:8080/query \
    -d '{ "collection": "a", "query": { "fields": { "name": { "type": "column", "column": "name" } } }, "arguments": {}, "collection_relationships": {} }' | jq
```