### PR TITLE
Support setting ssl client certificate information and ssl root certificate independently

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@
 
 ### Changed
 
+- Support setting ssl client certificate information and ssl root certificate independently.
+  [#578](https://github.com/hasura/ndc-postgres/pull/578)
+
 ### Fixed
 
 ## [v1.1.0] - 2024-08-16

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -106,17 +106,17 @@ async fn initialize(with_metadata: bool, context: Context<impl Environment>) -> 
 				},
 				metadata::EnvironmentVariableDefinition {
 					name: "CLIENT_CERT".to_string(),
-					description: "The SSL client certificate".to_string(),
+					description: "The SSL client certificate (Optional)".to_string(),
 					default_value: None,
 				},
 				metadata::EnvironmentVariableDefinition {
 					name: "CLIENT_KEY".to_string(),
-					description: "The SSL client key".to_string(),
+					description: "The SSL client key (Optional)".to_string(),
 					default_value: None,
 				},
 				metadata::EnvironmentVariableDefinition {
 					name: "ROOT_CERT".to_string(),
-					description: "The SSL root certificate".to_string(),
+					description: "The SSL root certificate (Optional)".to_string(),
 					default_value: None,
 				},
 			],

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -107,17 +107,17 @@ async fn initialize(with_metadata: bool, context: Context<impl Environment>) -> 
 				metadata::EnvironmentVariableDefinition {
 					name: "CLIENT_CERT".to_string(),
 					description: "The SSL client certificate (Optional)".to_string(),
-					default_value: Some("".to_string()),
+					default_value: Some(String::new()),
 				},
 				metadata::EnvironmentVariableDefinition {
 					name: "CLIENT_KEY".to_string(),
 					description: "The SSL client key (Optional)".to_string(),
-					default_value: Some("".to_string()),
+					default_value: Some(String::new()),
 				},
 				metadata::EnvironmentVariableDefinition {
 					name: "ROOT_CERT".to_string(),
 					description: "The SSL root certificate (Optional)".to_string(),
-					default_value: Some("".to_string()),
+					default_value: Some(String::new()),
 				},
 			],
             commands: metadata::Commands {

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -107,17 +107,17 @@ async fn initialize(with_metadata: bool, context: Context<impl Environment>) -> 
 				metadata::EnvironmentVariableDefinition {
 					name: "CLIENT_CERT".to_string(),
 					description: "The SSL client certificate (Optional)".to_string(),
-					default_value: None,
+					default_value: Some("".to_string()),
 				},
 				metadata::EnvironmentVariableDefinition {
 					name: "CLIENT_KEY".to_string(),
 					description: "The SSL client key (Optional)".to_string(),
-					default_value: None,
+					default_value: Some("".to_string()),
 				},
 				metadata::EnvironmentVariableDefinition {
 					name: "ROOT_CERT".to_string(),
 					description: "The SSL root certificate (Optional)".to_string(),
-					default_value: None,
+					default_value: Some("".to_string()),
 				},
 			],
             commands: metadata::Commands {

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
@@ -11,10 +11,13 @@ supportedEnvironmentVariables:
   defaultValue: postgresql://read_only_user:readonlyuser@35.236.11.122:5432/v3-docs-sample-app
 - name: CLIENT_CERT
   description: The SSL client certificate (Optional)
+  defaultValue: ''
 - name: CLIENT_KEY
   description: The SSL client key (Optional)
+  defaultValue: ''
 - name: ROOT_CERT
   description: The SSL root certificate (Optional)
+  defaultValue: ''
 commands:
   update: hasura-ndc-postgres update
 cliPlugin:

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
@@ -10,11 +10,11 @@ supportedEnvironmentVariables:
   description: The PostgreSQL connection URI
   defaultValue: postgresql://read_only_user:readonlyuser@35.236.11.122:5432/v3-docs-sample-app
 - name: CLIENT_CERT
-  description: The SSL client certificate
+  description: The SSL client certificate (Optional)
 - name: CLIENT_KEY
-  description: The SSL client key
+  description: The SSL client key (Optional)
 - name: ROOT_CERT
-  description: The SSL root certificate
+  description: The SSL root certificate (Optional)
 commands:
   update: hasura-ndc-postgres update
 cliPlugin:

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
@@ -11,10 +11,13 @@ supportedEnvironmentVariables:
   defaultValue: postgresql://read_only_user:readonlyuser@35.236.11.122:5432/v3-docs-sample-app
 - name: CLIENT_CERT
   description: The SSL client certificate (Optional)
+  defaultValue: ''
 - name: CLIENT_KEY
   description: The SSL client key (Optional)
+  defaultValue: ''
 - name: ROOT_CERT
   description: The SSL root certificate (Optional)
+  defaultValue: ''
 commands:
   update: hasura-ndc-postgres update
 cliPlugin:

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
@@ -10,11 +10,11 @@ supportedEnvironmentVariables:
   description: The PostgreSQL connection URI
   defaultValue: postgresql://read_only_user:readonlyuser@35.236.11.122:5432/v3-docs-sample-app
 - name: CLIENT_CERT
-  description: The SSL client certificate
+  description: The SSL client certificate (Optional)
 - name: CLIENT_KEY
-  description: The SSL client key
+  description: The SSL client key (Optional)
 - name: ROOT_CERT
-  description: The SSL root certificate
+  description: The SSL root certificate (Optional)
 commands:
   update: hasura-ndc-postgres update
 cliPlugin:

--- a/crates/configuration/src/connect.rs
+++ b/crates/configuration/src/connect.rs
@@ -68,7 +68,7 @@ fn read_ssl_info(environment: impl Environment) -> SslInfo {
             None
         }
         (_, Some(key)) if !key.is_empty() => {
-            tracing::warn!("SSL client key set without key. Ignoring.");
+            tracing::warn!("SSL client key set without certificate. Ignoring.");
             None
         }
         _ => None,

--- a/crates/configuration/src/connect.rs
+++ b/crates/configuration/src/connect.rs
@@ -24,25 +24,33 @@ pub fn get_connect_options(
 
     let ssl = read_ssl_info(environment);
 
-    // Add ssl info if present.
-    Ok(match ssl {
+    // Add ssl client info if present.
+    let connect_options = match ssl.client {
         None => connect_options,
-        Some(secret) => connect_options
-            .ssl_client_cert_from_pem(secret.certificate)
-            .ssl_client_key_from_pem(secret.key)
-            .ssl_root_cert_from_pem(secret.root_certificate),
+        Some(client) => connect_options
+            .ssl_client_cert_from_pem(client.certificate)
+            .ssl_client_key_from_pem(client.key),
+    };
+    // Add ssl root certificate if present.
+    Ok(match ssl.root_certificate {
+        None => connect_options,
+        Some(root_certificate) => connect_options.ssl_root_cert_from_pem(root_certificate),
     })
 }
 
+/// SSL certificate information.
+struct SslInfo {
+    client: Option<SslClientInfo>,
+    root_certificate: Option<Vec<u8>>,
+}
 /// SSL client certificate information.
 struct SslClientInfo {
     certificate: String,
     key: String,
-    root_certificate: Vec<u8>,
 }
 
 /// Read ssl certificate and key from the environment.
-fn read_ssl_info(environment: impl Environment) -> Option<SslClientInfo> {
+fn read_ssl_info(environment: impl Environment) -> SslInfo {
     // read ssl info
     let certificate = environment.read(&Variable::from("CLIENT_CERT")).ok();
     let key = environment.read(&Variable::from("CLIENT_KEY")).ok();
@@ -51,16 +59,28 @@ fn read_ssl_info(environment: impl Environment) -> Option<SslClientInfo> {
         .ok()
         .map(|text| text.as_bytes().to_vec());
 
-    match (certificate, key, root_certificate) {
-        (Some(certificate), Some(key), Some(root_certificate))
-            if !certificate.is_empty() && !key.is_empty() && !root_certificate.is_empty() =>
-        {
-            Some(SslClientInfo {
-                certificate,
-                key,
-                root_certificate,
-            })
+    let client = match (certificate, key) {
+        (Some(certificate), Some(key)) if !certificate.is_empty() && !key.is_empty() => {
+            Some(SslClientInfo { certificate, key })
+        }
+        (Some(certificate), None) if !certificate.is_empty() => {
+            tracing::warn!("SSL client certificate set without key. Ignoring.");
+            None
+        }
+        (_, Some(key)) if !key.is_empty() => {
+            tracing::warn!("SSL client key set without key. Ignoring.");
+            None
         }
         _ => None,
+    };
+
+    let root_certificate = match root_certificate {
+        Some(root_certificate) if !root_certificate.is_empty() => Some(root_certificate),
+        _ => None,
+    };
+
+    SslInfo {
+        client,
+        root_certificate,
     }
 }


### PR DESCRIPTION
### What

We want to be able to set the ssl root certificate without setting the ssl client certificate information. We want to be able to set the two independently.

### How

- Split the SslClientInfo to two Optionals and rename to SslInfo. Now they can be set independently.
