### PR TITLE
Update to Rust v1.80.1.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,7 +268,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "object",
  "rustc-demangle",
 ]
@@ -759,12 +765,12 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "flate2"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
+checksum = "9c0596c1eac1f9e04ed902702e9878208b336edc9d6fddc8a48387349bab3666"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.0",
 ]
 
 [[package]]
@@ -1409,6 +1415,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]
@@ -3541,9 +3556,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-properties"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291"
+checksum = "52ea75f83c0137a9b98608359a5f1af8144876eb67bcb1ce837368e906a9f524"
 
 [[package]]
 name = "unicode-segmentation"

--- a/crates/query-engine/execution/src/database_info.rs
+++ b/crates/query-engine/execution/src/database_info.rs
@@ -29,8 +29,11 @@ pub struct DatabaseInfo {
 pub struct DatabaseVersion {
     /// The database system version, as reported by `SELECT version()`.
     /// This is typically a long string of unspecified format, e.g.
+    ///
     /// > PostgreSQL 16.0 (Debian 16.0-1.pgdg120+1) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
+    ///
     /// or:
+    ///
     /// > CockroachDB CCL v22.2.14 (aarch64-unknown-linux-gnu, built 2023/09/14 19:23:08, go1.19.6)
     pub string: Option<String>,
     /// The database system version, in the libpq format, as reported by `SHOW server_version_num`.

--- a/crates/query-engine/sql/src/sql/ast.rs
+++ b/crates/query-engine/sql/src/sql/ast.rs
@@ -366,12 +366,12 @@ pub enum Value {
 /// This has a few quirks:
 ///
 /// * Array types need to be quoted as `"type name"[]` and _not_ `"type name[]"`. Therefore we
-/// track whether a scalar type is supposed to be an array.
+///   track whether a scalar type is supposed to be an array.
 ///
 /// * Quoting of type name identifiers is only supported for the actual type names recorded in
-/// `pg_type`, and _not_ the SQL standard type names. This means that `character varying` is an
-/// acceptable type name, but `"character varying"` is _not_ (Unless of course you do `CREATE TYPE
-/// "character varying" AS (..)`. Spicy).
+///   `pg_type`, and _not_ the SQL standard type names. This means that `character varying` is an
+///   acceptable type name, but `"character varying"` is _not_ (Unless of course you do `CREATE TYPE
+///   "character varying" AS (..)`. Spicy).
 #[derive(Debug, Clone, PartialEq)]
 pub enum ScalarType {
     BaseType(ScalarTypeName),

--- a/crates/query-engine/sql/src/sql/helpers.rs
+++ b/crates/query-engine/sql/src/sql/helpers.rs
@@ -583,8 +583,8 @@ pub fn select_row_as_json(
 /// - `json_agg` aggregates the json objects to a json array.
 /// - `coalesce(<thing>, <otherwise>)` returns `<thing>` if it is not null, and `<otherwise>` if it is null.
 /// - `json_build_object('__value', <thing>)` wraps `<thing>` in an object as a value to the key '__value'
-/// as expected in ndc-spec:
-/// <https://hasura.github.io/ndc-spec/specification/mutations/procedures.html#requirements>
+///   as expected in ndc-spec:
+///   <https://hasura.github.io/ndc-spec/specification/mutations/procedures.html#requirements>
 pub fn select_rows_as_json_for_mutation(
     row_select: Select,
     column_alias: ColumnAlias,

--- a/crates/query-engine/translation/src/translation/mutation/v2/mod.rs
+++ b/crates/query-engine/translation/src/translation/mutation/v2/mod.rs
@@ -6,22 +6,27 @@
 //! * We generate delete, insert and update procedures for each table.
 //!
 //! * A single insert procedure is generated per table of the form:
+//!
 //!   > v2_insert_<table>(
 //!   >     objects: [<object>],
 //!   >     post_check: <boolexpr>
 //!   > )
+//!
 //!   It allows us to insert multiple objects and include a post check for permissions.
 //!
 //! * A delete procedure is generated per table X unique constraint of the form:
+//!
 //!   > v2_delete_<table>_by_<column_and_...>(
 //!   >     key_<column1>: <value>,
 //!   >     key_<column2>: <value>,
 //!   >     ...,
 //!   >     pre_check: <boolexpr>
 //!   > )
+//!
 //!   It allows us to delete a single row using the uniqueness constraint, and contains a boolexpr for permissions.
 //!
 //! * An update procedure is generated per table X unique constraint of the form:
+//!
 //!   > v2_update_<table>_by_<column_and_...>(
 //!   >     key_<column1>: <value>,
 //!   >     key_<column2>: <value>,
@@ -30,6 +35,7 @@
 //!   >     pre_check: <boolexpr>,
 //!   >     post_check: <boolexpr>
 //!   > )
+//!
 //!   It allows us to update a single row using the uniqueness constraint by updating the relevant columns,
 //!   and contains a pre check and post check for permissions.
 //!

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715274763,
-        "narHash": "sha256-3Iv1PGHJn9sV3HO4FlOVaaztOxa9uGLfOmUWrH7v7+A=",
+        "lastModified": 1724006180,
+        "narHash": "sha256-PVxPj0Ga2fMYMtcT9ARCthF+4U71YkOT7ZjgD/vf1Aw=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "27025ab71bdca30e7ed0a16c88fd74c5970fc7f5",
+        "rev": "7ce92819802bc583b7e82ebc08013a530f22209f",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715859993,
-        "narHash": "sha256-vLp62qr+t+Kzp4HsLgIlSiGaBF4R28VPUasWhF1RCnA=",
+        "lastModified": 1724273822,
+        "narHash": "sha256-n5qhX3XieaqLYoyxSuTcXMOBLIGN+t1HfB0mms+Q+eM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2eef017af08b91e353849dfe58436684e169b71d",
+        "rev": "c1350d7b9d4b04131cf2979e77fec9bfa47213a4",
         "type": "github"
       },
       "original": {
@@ -63,19 +63,16 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1715825775,
-        "narHash": "sha256-7np2/EEr5Xm8IuKWQ43q8AA1Lb6Us2BW6rYMxGrInIg=",
+        "lastModified": 1724206841,
+        "narHash": "sha256-L8dKaX4T3k+TR2fEHCfGbH4UXdspovz/pj87iai9qmc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "55f468b3d49c5d3321e85f2f9b1158476a2a90fb",
+        "rev": "45e98fbd62c32e5927e952d2833fa1ba4fb35a61",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,6 @@
       url = "github:oxalica/rust-overlay";
       inputs = {
         nixpkgs.follows = "nixpkgs";
-        flake-utils.follows = "flake-utils";
       };
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -109,6 +109,7 @@
               pkgs.moreutils
 
               # Rust
+              pkgs.bacon
               pkgs.cargo-audit
               pkgs.cargo-edit
               pkgs.cargo-expand

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.80.1"
 profile = "default"  # see https://rust-lang.github.io/rustup/concepts/profiles.html
 components = ["rust-analyzer", "rust-src"]  # see https://rust-lang.github.io/rustup/concepts/components.html


### PR DESCRIPTION
### What

Upgrade to the latest version of Rust.

### How

I modified `rust-toolchain.toml`, ran `cargo update`, and fixed some new lint warnings around docs.