### PR TITLE
More automatic deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,21 @@
+on:
+  workflow_dispatch:
+    inputs:
+      new_version:
+        description: "What we want the new version to be"
+        required: true
+
+name: Deploy process
+
+jobs:
+  deploy:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: ./scripts/new-version.sh ${{ github.event.inputs.new_version }}
+
+      - run: cat Cargo.toml


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

We'd like to start automating the deployment of `ndc-postgres` and friends, which means we need to introduce some scripts to GitHub actions. However, it looks like we need to merge at least this boilerplate in order to start playing with these actions in branches.

### How

<!-- How is it trying to accomplish it (what are the implementation steps)? -->
