### PR TITLE
Automatically create PRs to bump versions in ndc-postgres

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -5,11 +5,11 @@ on:
         description: "What we want the new version to be"
         required: true
 
-name: Deploy process
+name: Bump version
 
 jobs:
-  deploy:
-    name: Deploy
+  bump_version_pr:
+    name: Create version bump PR
     runs-on: ubuntu-latest
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -26,8 +26,8 @@ jobs:
 
       - run: ./scripts/new-version.sh ${{ github.event.inputs.new_version }}
 
+      # TODO: auto-merge when we feel confident.
       - uses: peter-evans/create-pull-request@v6
         with:
           title: Bump version to ${{ github.event.inputs.new_version }}
           body: This bumps the version in `Cargo.toml` and updates `changelog.md`.
-          team-reviewers: hasura/api-pg

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install `just`
+        uses: extractions/setup-just@v2
+
       - run: ./scripts/new-version.sh ${{ github.event.inputs.new_version }}
 
       - run: cat Cargo.toml

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,7 +9,7 @@ name: Deploy process
 
 jobs:
   deploy:
-    name: cargo audit
+    name: Deploy
     runs-on: ubuntu-latest
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,6 +19,12 @@ jobs:
       - name: Install `just`
         uses: extractions/setup-just@v2
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "build" # share the cache across jobs
+          save-if: false
+
       - run: ./scripts/new-version.sh ${{ github.event.inputs.new_version }}
 
       - run: cat Cargo.toml
+      - run: cat changelog.md

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,5 +26,8 @@ jobs:
 
       - run: ./scripts/new-version.sh ${{ github.event.inputs.new_version }}
 
-      - run: cat Cargo.toml
-      - run: cat changelog.md
+      - uses: peter-evans/create-pull-request@v6
+        with:
+          title: Bump version to ${{ github.event.inputs.new_version }}
+          body: This bumps the version in `Cargo.toml` and updates `changelog.md`.
+          team-reviewers: hasura/api-pg

--- a/scripts/new-version.sh
+++ b/scripts/new-version.sh
@@ -17,6 +17,6 @@ echo "Updating version to v$NEW_VERSION"
 
 sed -i "s/package.version = .*/package.version = \"${NEW_VERSION}\"/" Cargo.toml
 
-just test
+cargo build # TODO: change this back
 
 runghc scripts/changelog.hs "changelog.md" "${DATE_TODAY}" "${NEW_VERSION}"

--- a/scripts/new-version.sh
+++ b/scripts/new-version.sh
@@ -17,6 +17,6 @@ echo "Updating version to v$NEW_VERSION"
 
 sed -i "s/package.version = .*/package.version = \"${NEW_VERSION}\"/" Cargo.toml
 
-cargo build # TODO: change this back
+just test
 
 runghc scripts/changelog.hs "changelog.md" "${DATE_TODAY}" "${NEW_VERSION}"


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

<!-- What is this PR trying to accomplish (and why, if it's not obvious)? -->

<!-- Consider: do we need to add a changelog entry? -->

This PR adds a `bump-version.yaml` workflow that can be manually triggered in the `Actions` tab. When triggered and given a new version of `ndc-postgres`, a PR will be generated that bumps `ndc-postgres` to that version. In practice, this means:

* Updating the `Cargo.toml` file and associated lock file.
* Moving everything in `changelog.md` from `Unreleased` to a section with the appropriate version title, and creating a new, blank `Unreleased` section.

### How

<!-- How is it trying to accomplish it (what are the implementation steps)? -->
GitHub actions, including a fancy new action we found to create pull requests against the repo.
