### PR TITLE
Enable mutations v2 by default

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Enabled point mutations by default for newly generated configuration.
+
 ### Changed
 
 ### Fixed

--- a/crates/configuration/src/version5/mod.rs
+++ b/crates/configuration/src/version5/mod.rs
@@ -67,9 +67,7 @@ impl ParsedConfiguration {
             connection_settings: connection_settings::DatabaseConnectionSettings::empty(),
             metadata: metadata::Metadata::default(),
             introspection_options: options::IntrospectionOptions::default(),
-            // we'll change this to `Some(MutationsVersions::V1)` when we
-            // want to "release" this behaviour
-            mutations_version: None,
+            mutations_version: Some(metadata::mutations::MutationsVersion::V2),
         }
     }
 

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__cli_version5_tests__postgres_current_only_configure_initial_configuration_is_unchanged.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__cli_version5_tests__postgres_current_only_configure_initial_configuration_is_unchanged.snap
@@ -3123,5 +3123,5 @@ expression: default_configuration
       "varchar": "string"
     }
   },
-  "mutationsVersion": null
+  "mutationsVersion": "v2"
 }


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

Generated point mutations have been an opt-in feature for a while. Now we advertise them in the Postgres getting started docs, it's probably time to say they are generally available. This won't affect existing configurations (a missing value still means "no generated mutations please".

### How

Change the default.
