### PR TITLE
In update-multitenant-deb workflow, update reference to the hasura/api-pg group to hasura/engine

### DIFF
--- a/.github/workflows/update-multitenant-dep.yaml
+++ b/.github/workflows/update-multitenant-dep.yaml
@@ -79,7 +79,7 @@ jobs:
             --title "dep update: update ndc-postgres to $LATEST_SHORT_SHA" \
             --head "$BRANCH_NAME" \
             --base "main" \
-            --reviewer "hasura/api-pg"
+            --reviewer "hasura/engine"
 
       # scream into Slack if something goes wrong
       - name: Report Status


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

hasura/api-pg group was renamed to hasura/engine

<!-- What is this PR trying to accomplish (and why, if it's not obvious)? -->

<!-- Consider: do we need to add a changelog entry? -->

### How

This PR updates the update-multitenant-dep workflow to use the new group name

<!-- How is it trying to accomplish it (what are the implementation steps)? -->
