### PR TITLE
Fix invalid joins when the order by relationship predicate is null

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,9 @@
 
 ### Fixed
 
+- Predicates in relationships using in ordering (usually supplied by the engine's permission system) would fail to join the related tables correctly if the predicate was null.
+  [#655](https://github.com/hasura/ndc-postgres/pull/655)
+
 ## [v1.2.0] - 2024-10-25
 
 ### Added

--- a/crates/query-engine/translation/tests/goldenfiles/sorting_by_nested_relationship_column/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/sorting_by_nested_relationship_column/request.json
@@ -19,18 +19,12 @@
               {
                 "relationship": "TrackAlbum",
                 "arguments": {},
-                "predicate": {
-                  "type": "and",
-                  "expressions": []
-                }
+                "predicate": null
               },
               {
                 "relationship": "AlbumArtist",
                 "arguments": {},
-                "predicate": {
-                  "type": "and",
-                  "expressions": []
-                }
+                "predicate": null
               }
             ]
           }

--- a/crates/query-engine/translation/tests/goldenfiles/sorting_by_nested_relationship_column_with_predicate/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/sorting_by_nested_relationship_column_with_predicate/request.json
@@ -41,10 +41,7 @@
               {
                 "relationship": "AlbumArtist",
                 "arguments": {},
-                "predicate": {
-                  "type": "and",
-                  "expressions": []
-                }
+                "predicate": null
               }
             ]
           }

--- a/crates/query-engine/translation/tests/goldenfiles/sorting_by_nested_relationship_count/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/sorting_by_nested_relationship_count/request.json
@@ -19,10 +19,7 @@
               {
                 "relationship": "ArtistAlbum",
                 "arguments": {},
-                "predicate": {
-                  "type": "and",
-                  "expressions": []
-                }
+                "predicate": null
               }
             ]
           },

--- a/crates/query-engine/translation/tests/goldenfiles/sorting_by_recursive_relationship_column/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/sorting_by_recursive_relationship_column/request.json
@@ -19,18 +19,12 @@
               {
                 "relationship": "CompanyCEO",
                 "arguments": {},
-                "predicate": {
-                  "type": "and",
-                  "expressions": []
-                }
+                "predicate": null
               },
               {
                 "relationship": "PersonParent",
                 "arguments": {},
-                "predicate": {
-                  "type": "and",
-                  "expressions": []
-                }
+                "predicate": null
               }
             ]
           }

--- a/crates/query-engine/translation/tests/goldenfiles/sorting_by_relationship_column/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/sorting_by_relationship_column/request.json
@@ -21,10 +21,7 @@
               {
                 "relationship": "AlbumArtist",
                 "arguments": {},
-                "predicate": {
-                  "type": "and",
-                  "expressions": []
-                }
+                "predicate": null
               }
             ]
           }

--- a/crates/query-engine/translation/tests/goldenfiles/sorting_by_relationship_column_with_true_predicate/configuration.json
+++ b/crates/query-engine/translation/tests/goldenfiles/sorting_by_relationship_column_with_true_predicate/configuration.json
@@ -1,0 +1,86 @@
+{
+  "version": "4",
+  "metadata": {
+    "tables": {
+      "Album": {
+        "schemaName": "public",
+        "tableName": "Album",
+        "columns": {
+          "AlbumId": {
+            "name": "AlbumId",
+            "type": {
+              "scalarType": "int4"
+            },
+            "nullable": "nullable",
+            "description": null
+          },
+          "ArtistId": {
+            "name": "ArtistId",
+            "type": {
+              "scalarType": "int4"
+            },
+            "nullable": "nullable",
+            "description": null
+          },
+          "Title": {
+            "name": "Title",
+            "type": {
+              "scalarType": "varchar"
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "uniquenessConstraints": {},
+        "foreignRelations": {},
+        "description": null
+      },
+      "Artist": {
+        "schemaName": "public",
+        "tableName": "Artist",
+        "columns": {
+          "ArtistId": {
+            "name": "ArtistId",
+            "type": {
+              "scalarType": "int4"
+            },
+            "nullable": "nullable",
+            "description": null
+          },
+          "Name": {
+            "name": "Name",
+            "type": {
+              "scalarType": "varchar"
+            },
+            "nullable": "nullable",
+            "description": null
+          }
+        },
+        "uniquenessConstraints": {},
+        "foreignRelations": {},
+        "description": null
+      }
+    },
+    "scalarTypes": {
+      "int4": {
+        "typeName": "int4",
+        "schemaName": "pg_catalog",
+        "description": null,
+        "aggregateFunctions": {},
+        "comparisonOperators": {},
+        "typeRepresentation": null
+      },
+      "varchar": {
+        "typeName": "varchar",
+        "schemaName": "pg_catalog",
+        "description": null,
+        "aggregateFunctions": {},
+        "comparisonOperators": {},
+        "typeRepresentation": null
+      }
+    },
+    "compositeTypes": {},
+    "nativeQueries": {}
+  },
+  "mutationsVersion": null
+}

--- a/crates/query-engine/translation/tests/goldenfiles/sorting_by_relationship_column_with_true_predicate/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/sorting_by_relationship_column_with_true_predicate/request.json
@@ -1,25 +1,30 @@
 {
-  "collection": "Artist",
+  "collection": "Album",
   "query": {
     "fields": {
       "Name": {
         "type": "column",
-        "column": "Name",
+        "column": "Title",
         "arguments": {}
       }
     },
     "limit": 5,
+    "offset": 3,
     "order_by": {
       "elements": [
         {
-          "order_direction": "desc",
+          "order_direction": "asc",
           "target": {
-            "type": "star_count_aggregate",
+            "type": "column",
+            "name": "Name",
             "path": [
               {
-                "relationship": "ArtistAlbums",
+                "relationship": "AlbumArtist",
                 "arguments": {},
-                "predicate": null
+                "predicate": {
+                  "type": "and",
+                  "expressions": []
+                }
               }
             ]
           }
@@ -29,12 +34,12 @@
   },
   "arguments": {},
   "collection_relationships": {
-    "ArtistAlbums": {
+    "AlbumArtist": {
       "column_mapping": {
         "ArtistId": "ArtistId"
       },
-      "relationship_type": "array",
-      "target_collection": "Album",
+      "relationship_type": "object",
+      "target_collection": "Artist",
       "arguments": {}
     }
   }

--- a/crates/query-engine/translation/tests/snapshots/tests__sorting_by_relationship_column_with_true_predicate.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__sorting_by_relationship_column_with_true_predicate.snap
@@ -1,0 +1,44 @@
+---
+source: crates/query-engine/translation/tests/tests.rs
+expression: result
+---
+SELECT
+  coalesce(json_agg(row_to_json("%3_universe")), '[]') AS "universe"
+FROM
+  (
+    SELECT
+      *
+    FROM
+      (
+        SELECT
+          coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
+        FROM
+          (
+            SELECT
+              "%0_Album"."Title" AS "Name"
+            FROM
+              "public"."Album" AS "%0_Album"
+              LEFT OUTER JOIN LATERAL (
+                SELECT
+                  "%1_ORDER_PART_Artist"."Name" AS "Name"
+                FROM
+                  (
+                    SELECT
+                      "%1_ORDER_PART_Artist"."Name" AS "Name"
+                    FROM
+                      "public"."Artist" AS "%1_ORDER_PART_Artist"
+                    WHERE
+                      (
+                        "%0_Album"."ArtistId" = "%1_ORDER_PART_Artist"."ArtistId"
+                      )
+                  ) AS "%1_ORDER_PART_Artist"
+              ) AS "%2_ORDER_FOR_Album" ON ('true')
+            ORDER BY
+              "%2_ORDER_FOR_Album"."Name" ASC
+            LIMIT
+              5 OFFSET 3
+          ) AS "%4_rows"
+      ) AS "%4_rows"
+  ) AS "%3_universe";
+
+{}

--- a/crates/query-engine/translation/tests/tests.rs
+++ b/crates/query-engine/translation/tests/tests.rs
@@ -260,6 +260,14 @@ async fn sorting_by_relationship_column() {
 }
 
 #[tokio::test]
+async fn sorting_by_relationship_column_with_true_predicate() {
+    let result = common::test_translation("sorting_by_relationship_column_with_true_predicate")
+        .await
+        .unwrap();
+    insta::assert_snapshot!(result);
+}
+
+#[tokio::test]
 async fn sorting_by_nested_relationship_column() {
     let result = common::test_translation("sorting_by_nested_relationship_column")
         .await


### PR DESCRIPTION
### What
If a relationship used in an order by specified a null predicate, the SQL generator would fail to add the join conditions when joining the related table into the query. This would result in an incorrect cross product between the table and the related table.

### How

If the relationship predicate is null, we now correctly add the table's join conditions.

Existing tests that assumed all predicates would contain an always true expression have been changed to contain a null predicate and an extra test has been added to cover receiving an always true predicate (to make sure that still works).

Fixes ENG-1386