### PR TITLE
Add internal TimescaleDB schemas to `default_excluded_schemas`

### DIFF
--- a/crates/configuration/src/version3/options.rs
+++ b/crates/configuration/src/version3/options.rs
@@ -59,6 +59,15 @@ fn default_excluded_schemas() -> Vec<String> {
         // From Citus
         "columnar".to_string(),
         "columnar_internal".to_string(),
+        // from TimescaleDB
+        "_timescaledb_catalog".to_string(),
+        "_timescaledb_functions".to_string(),
+        "_timescaledb_internal".to_string(),
+        "_timescaledb_cache".to_string(),
+        "_timescaledb_config".to_string(),
+        "timescaledb_experimental".to_string(),
+        "timescaledb_information".to_string(),
+        "_timescaledb_debug".to_string(),
     ]
 }
 

--- a/crates/configuration/src/version4/options.rs
+++ b/crates/configuration/src/version4/options.rs
@@ -65,6 +65,15 @@ fn default_excluded_schemas() -> Vec<String> {
         // From Citus
         "columnar".to_string(),
         "columnar_internal".to_string(),
+        // from TimescaleDB
+        "_timescaledb_catalog".to_string(),
+        "_timescaledb_functions".to_string(),
+        "_timescaledb_internal".to_string(),
+        "_timescaledb_cache".to_string(),
+        "_timescaledb_config".to_string(),
+        "timescaledb_experimental".to_string(),
+        "timescaledb_information".to_string(),
+        "_timescaledb_debug".to_string(),
     ]
 }
 

--- a/crates/configuration/src/version5/options.rs
+++ b/crates/configuration/src/version5/options.rs
@@ -65,6 +65,15 @@ fn default_excluded_schemas() -> Vec<String> {
         // From Citus
         "columnar".to_string(),
         "columnar_internal".to_string(),
+        // from TimescaleDB
+        "_timescaledb_catalog".to_string(),
+        "_timescaledb_functions".to_string(),
+        "_timescaledb_internal".to_string(),
+        "_timescaledb_cache".to_string(),
+        "_timescaledb_config".to_string(),
+        "timescaledb_experimental".to_string(),
+        "timescaledb_information".to_string(),
+        "_timescaledb_debug".to_string(),
     ]
 }
 

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__cli_version3_tests__postgres_current_only_configure_initial_configuration_is_unchanged.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__cli_version3_tests__postgres_current_only_configure_initial_configuration_is_unchanged.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/tests/databases-tests/src/postgres/cli_version3_tests.rs
 expression: default_configuration
-snapshot_kind: text
 ---
 {
   "version": "3",
@@ -2526,7 +2525,15 @@ snapshot_kind: text
       "tiger",
       "crdb_internal",
       "columnar",
-      "columnar_internal"
+      "columnar_internal",
+      "_timescaledb_catalog",
+      "_timescaledb_functions",
+      "_timescaledb_internal",
+      "_timescaledb_cache",
+      "_timescaledb_config",
+      "timescaledb_experimental",
+      "timescaledb_information",
+      "_timescaledb_debug"
     ],
     "unqualifiedSchemasForTables": [
       "public"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__cli_version4_tests__postgres_current_only_configure_initial_configuration_is_unchanged.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__cli_version4_tests__postgres_current_only_configure_initial_configuration_is_unchanged.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/tests/databases-tests/src/postgres/cli_version4_tests.rs
 expression: default_configuration
-snapshot_kind: text
 ---
 {
   "version": "4",
@@ -2852,7 +2851,15 @@ snapshot_kind: text
       "tiger",
       "crdb_internal",
       "columnar",
-      "columnar_internal"
+      "columnar_internal",
+      "_timescaledb_catalog",
+      "_timescaledb_functions",
+      "_timescaledb_internal",
+      "_timescaledb_cache",
+      "_timescaledb_config",
+      "timescaledb_experimental",
+      "timescaledb_information",
+      "_timescaledb_debug"
     ],
     "unqualifiedSchemasForTables": [
       "public"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__cli_version5_tests__postgres_current_only_configure_initial_configuration_is_unchanged.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__cli_version5_tests__postgres_current_only_configure_initial_configuration_is_unchanged.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/tests/databases-tests/src/postgres/cli_version5_tests.rs
 expression: default_configuration
-snapshot_kind: text
 ---
 {
   "version": "5",
@@ -2881,7 +2880,15 @@ snapshot_kind: text
       "tiger",
       "crdb_internal",
       "columnar",
-      "columnar_internal"
+      "columnar_internal",
+      "_timescaledb_catalog",
+      "_timescaledb_functions",
+      "_timescaledb_internal",
+      "_timescaledb_cache",
+      "_timescaledb_config",
+      "timescaledb_experimental",
+      "timescaledb_information",
+      "_timescaledb_debug"
     ],
     "unqualifiedSchemasForTables": [
       "public"


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

Introspection for TimescaleDB breaks by default because it tries to read these internal schema, let's include them by default.

Source of names: https://github.com/timescale/timescaledb/blob/main/sql/pre_install/schemas.sql#L7

### How

Add to `default_excluded_schemas` in configuration versions 3, 4 and 5.
