### PR TITLE
Fix Cockroach Native Query problem

### DIFF
--- a/crates/configuration/src/version4/native_operations.rs
+++ b/crates/configuration/src/version4/native_operations.rs
@@ -173,7 +173,7 @@ pub async fn oids_to_typenames(
     for row in rows {
         let schema_name: String = row.schema_name;
         let type_name: String = row.type_name;
-        let oid: i64 = row.oid.into();
+        let oid: i64 = row.oid;
 
         let mut found = false;
         for (scalar_type_name, info) in &configuration.metadata.scalar_types.0 {

--- a/crates/configuration/src/version4/native_operations.rs
+++ b/crates/configuration/src/version4/native_operations.rs
@@ -207,9 +207,9 @@ const OID_QUERY: &str = "
 SELECT
   typnamespace::regnamespace::text as schema_name,
   typname as type_name,
-  oid::integer
+  oid::INT8
 FROM pg_type
-WHERE oid in (SELECT unnest($1))
+WHERE oid::INT8 in (SELECT unnest($1::INT8[]))
 ";
 
 /// Representation of a result row returned from the oid lookup query.
@@ -217,5 +217,5 @@ WHERE oid in (SELECT unnest($1))
 struct OidQueryRow {
     schema_name: String,
     type_name: String,
-    oid: i32,
+    oid: i64,
 }

--- a/crates/configuration/src/version5/native_operations.rs
+++ b/crates/configuration/src/version5/native_operations.rs
@@ -178,7 +178,7 @@ pub async fn oids_to_typenames(
     for row in rows {
         let schema_name: String = row.schema_name;
         let type_name: String = row.type_name;
-        let oid: i64 = row.oid.into();
+        let oid: i64 = row.oid;
 
         let mut found = false;
         for (scalar_type_name, info) in &configuration.metadata.types.scalar.0 {

--- a/crates/configuration/src/version5/native_operations.rs
+++ b/crates/configuration/src/version5/native_operations.rs
@@ -212,9 +212,9 @@ const OID_QUERY: &str = "
 SELECT
   typnamespace::regnamespace::text as schema_name,
   typname as type_name,
-  oid::integer
+  oid::INT8
 FROM pg_type
-WHERE oid in (SELECT unnest($1))
+WHERE oid::INT8 in (SELECT unnest($1::INT8[]))
 ";
 
 /// Representation of a result row returned from the oid lookup query.
@@ -222,5 +222,5 @@ WHERE oid in (SELECT unnest($1))
 struct OidQueryRow {
     schema_name: String,
     type_name: String,
-    oid: i32,
+    oid: i64,
 }


### PR DESCRIPTION
### What

Native query tracking fails for CockroachDB because OIDs are 64-bit (despite what the documentation says). However, if we just change the type to `i64`, then the vanilla Postgres native query setup fails because `sqlx` requires each type in Rust to correspond to a specific Postgres type, and thus we can't do some sort of dynamic switching.

### How

We cast absolutely everything to `i64` explicitly in the query. The fact that this works seems to be accidental: because the input type becomes irrelevant, Cockroach determines a different type for `oid` than Postgres, and both are happy. `sqlx` bases its types on information from the database, so it's also happy.

I have tested this with tracking a native query in both Cockroach and Postgres, and both seem to be happy.