### PR TITLE
Replace RootAndCurrentTables with TableScope, which keeps track of any tables in scope for an exists, instead of only root and current.

### DIFF
--- a/crates/query-engine/translation/src/translation/error.rs
+++ b/crates/query-engine/translation/src/translation/error.rs
@@ -63,6 +63,11 @@ pub enum Error {
         scalar: models::ScalarTypeName,
         function: models::AggregateFunctionName,
     },
+    ScopeOutOfBounds {
+        current_collection_name: String,
+        tables_in_scope_names: Vec<String>,
+        scope: usize,
+    },
 }
 
 /// Capabilities we don't currently support.
@@ -237,6 +242,26 @@ impl std::fmt::Display for Error {
                 f,
                 "Missing single column aggregate function {function:?} for scalar type {scalar:?}"
             ),
+            Error::ScopeOutOfBounds {
+                current_collection_name,
+                tables_in_scope_names,
+                scope,
+            } => {
+                write!(
+                    f,
+                    "Scope {scope} out of bounds. Current collection is {current_collection_name}. Collections in scope: ["
+                )?;
+                let mut first = true;
+                for collection in tables_in_scope_names {
+                    if first {
+                        first = false;
+                    } else {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{collection}")?;
+                }
+                write!(f, "].")
+            }
         }
     }
 }

--- a/crates/query-engine/translation/src/translation/helpers.rs
+++ b/crates/query-engine/translation/src/translation/helpers.rs
@@ -1,6 +1,6 @@
 //! Helpers for processing requests and building SQL.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 
 use ndc_models as models;
 
@@ -47,16 +47,68 @@ pub struct NativeQueryInfo {
     pub alias: sql::ast::TableAlias,
 }
 
-/// For the root table in the query, and for the current table we are processing,
+/// For the current table we are processing, and all ancestor table up to the closest Query,
 /// We'd like to track what is their reference in the query (the name we can use to address them,
 /// an alias we generate), and what is their name in the metadata (so we can get
 /// their information such as which columns are available for that table).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RootAndCurrentTables {
-    /// The root (top-most) table in the query.
-    pub root_table: TableSourceAndReference,
+pub struct TableScope {
     /// The current table we are processing.
-    pub current_table: TableSourceAndReference,
+    current_table: TableSourceAndReference,
+    /// Tables in scope. Index 0 corresponds to scope 1, which is the table immediately above the current table in the exists chain.
+    tables_in_scope: VecDeque<TableSourceAndReference>,
+}
+
+impl TableScope {
+    /// Create a scope from a Query. There will be no tables available through scopes
+    pub fn new(current_table: TableSourceAndReference) -> Self {
+        Self {
+            current_table,
+            tables_in_scope: VecDeque::new(),
+        }
+    }
+    /// Create a scope from an exists expression or path. The ancestor tables up until the closest query will stay in scope
+    #[must_use]
+    pub fn new_from_scope(&self, current_table: TableSourceAndReference) -> Self {
+        let TableScope {
+            current_table: parent_table,
+            tables_in_scope,
+        } = self;
+        let mut tables_in_scope = tables_in_scope.clone();
+        tables_in_scope.push_front(parent_table.clone());
+        Self {
+            current_table,
+            tables_in_scope,
+        }
+    }
+    /// Get the table source and reference for the current table
+    pub fn current_table(&self) -> &TableSourceAndReference {
+        &self.current_table
+    }
+    /// Get the table source and reference for a table in scope.
+    /// The scope is an index, where 0 is the current table, 1 is the parent, and so on
+    /// Errors if the scope is out of bounds
+    pub fn scoped_table(&self, scope: &Option<usize>) -> Result<&TableSourceAndReference, Error> {
+        if let Some(scope) = scope {
+            if *scope > 0 && *scope <= self.tables_in_scope.len() {
+                Ok(&self.tables_in_scope[scope - 1])
+            } else if *scope == 0 {
+                Ok(&self.current_table)
+            } else {
+                Err(Error::ScopeOutOfBounds {
+                    current_collection_name: self.current_table.source.name_for_alias(),
+                    tables_in_scope_names: self
+                        .tables_in_scope
+                        .iter()
+                        .map(|c| c.source.name_for_alias())
+                        .collect(),
+                    scope: *scope,
+                })
+            }
+        } else {
+            Ok(&self.current_table)
+        }
+    }
 }
 
 /// For a table in the query, We'd like to track what is its reference in the query

--- a/crates/query-engine/translation/src/translation/mutation/v2/delete.rs
+++ b/crates/query-engine/translation/src/translation/mutation/v2/delete.rs
@@ -156,10 +156,7 @@ pub fn translate(
             let predicate_expression = filtering::translate(
                 env,
                 state,
-                &helpers::RootAndCurrentTables {
-                    root_table: table_name_and_reference.clone(),
-                    current_table: table_name_and_reference,
-                },
+                &helpers::TableScope::new(table_name_and_reference),
                 &predicate,
             )?;
 

--- a/crates/query-engine/translation/src/translation/mutation/v2/insert.rs
+++ b/crates/query-engine/translation/src/translation/mutation/v2/insert.rs
@@ -245,10 +245,7 @@ pub fn translate(
     let predicate_expression = filtering::translate(
         env,
         state,
-        &helpers::RootAndCurrentTables {
-            root_table: table_name_and_reference.clone(),
-            current_table: table_name_and_reference,
-        },
+        &helpers::TableScope::new(table_name_and_reference),
         &predicate,
     )?;
 

--- a/crates/query-engine/translation/src/translation/mutation/v2/update.rs
+++ b/crates/query-engine/translation/src/translation/mutation/v2/update.rs
@@ -151,10 +151,7 @@ pub fn translate(
                 })
                 .collect::<Result<Vec<sql::ast::Expression>, Error>>()?;
 
-            let root_and_current_tables = helpers::RootAndCurrentTables {
-                root_table: table_name_and_reference.clone(),
-                current_table: table_name_and_reference,
-            };
+            let root_and_current_tables = helpers::TableScope::new(table_name_and_reference);
 
             // Set default constrainst
             let default_constraint = default_constraint();

--- a/crates/query-engine/translation/src/translation/query/root.rs
+++ b/crates/query-engine/translation/src/translation/query/root.rs
@@ -14,7 +14,7 @@ use super::sorting;
 use crate::translation::error::Error;
 use crate::translation::helpers::TableSource;
 use crate::translation::helpers::{
-    CollectionInfo, Env, RootAndCurrentTables, State, TableSourceAndReference,
+    CollectionInfo, Env, State, TableScope, TableSourceAndReference,
 };
 use query_engine_sql::sql;
 
@@ -174,25 +174,18 @@ pub fn translate_query_part(
     select: &mut sql::ast::Select,
 ) -> Result<(), Error> {
     // the root table and the current table are the same at this point
-    let root_and_current_tables = RootAndCurrentTables {
-        root_table: current_table.clone(),
-        current_table: current_table.clone(),
-    };
+    let current_table_scope = TableScope::new(current_table.clone());
 
     // translate order_by
-    let (order_by, order_by_joins) = sorting::translate(
-        env,
-        state,
-        &root_and_current_tables,
-        query.order_by.as_ref(),
-    )?;
+    let (order_by, order_by_joins) =
+        sorting::translate(env, state, &current_table_scope, query.order_by.as_ref())?;
 
     select.joins.extend(order_by_joins);
 
     // translate where
     let filter = match &query.predicate {
         None => Ok(sql::helpers::true_expr()),
-        Some(predicate) => filtering::translate(env, state, &root_and_current_tables, predicate),
+        Some(predicate) => filtering::translate(env, state, &current_table_scope, predicate),
     }?;
 
     // Apply a join predicate if we want one.

--- a/crates/query-engine/translation/src/translation/query/root.rs
+++ b/crates/query-engine/translation/src/translation/query/root.rs
@@ -173,7 +173,6 @@ pub fn translate_query_part(
     query: &models::Query,
     select: &mut sql::ast::Select,
 ) -> Result<(), Error> {
-    // the root table and the current table are the same at this point
     let current_table_scope = TableScope::new(current_table.clone());
 
     // translate order_by

--- a/crates/query-engine/translation/src/translation/query/sorting.rs
+++ b/crates/query-engine/translation/src/translation/query/sorting.rs
@@ -10,7 +10,7 @@ use super::relationships;
 use super::root;
 use crate::translation::error::Error;
 use crate::translation::helpers::{
-    wrap_in_field_path, Env, FieldPath, FieldsInfo, RootAndCurrentTables, State, TableSource,
+    wrap_in_field_path, Env, FieldPath, FieldsInfo, State, TableScope, TableSource,
     TableSourceAndReference,
 };
 use query_engine_sql::sql;
@@ -22,7 +22,7 @@ use query_engine_sql::sql;
 pub fn translate(
     env: &Env,
     state: &mut State,
-    root_and_current_tables: &RootAndCurrentTables,
+    current_table_scope: &TableScope,
     order_by: Option<&models::OrderBy>,
 ) -> Result<(sql::ast::OrderBy, Vec<sql::ast::Join>), Error> {
     let mut joins: Vec<sql::ast::Join> = vec![];
@@ -40,7 +40,7 @@ pub fn translate(
                     translate_order_by_target_group(
                         env,
                         state,
-                        root_and_current_tables,
+                        current_table_scope,
                         element_group,
                         &mut joins,
                     )
@@ -267,16 +267,12 @@ fn group_elements(elements: &[models::OrderByElement]) -> Vec<OrderByElementGrou
 fn translate_order_by_target_group(
     env: &Env,
     state: &mut State,
-    root_and_current_tables: &RootAndCurrentTables,
+    current_table_scope: &TableScope,
     element_group: &OrderByElementGroup,
     joins: &mut Vec<sql::ast::Join>,
 ) -> Result<Vec<(usize, sql::ast::OrderByElement)>, Error> {
-    let column_or_relationship_select = build_select_and_joins_for_order_by_group(
-        env,
-        state,
-        root_and_current_tables,
-        element_group,
-    )?;
+    let column_or_relationship_select =
+        build_select_and_joins_for_order_by_group(env, state, current_table_scope, element_group)?;
 
     match column_or_relationship_select {
         // The column is from the source table, we just need to query it directly.
@@ -303,8 +299,8 @@ fn translate_order_by_target_group(
         ColumnsOrSelect::Select { columns, select } => {
             // Give it a nice unique alias.
             let table_alias = state.make_order_by_table_alias(
-                root_and_current_tables
-                    .current_table
+                current_table_scope
+                    .current_table()
                     .source
                     .name_for_alias()
                     .as_str(),
@@ -381,7 +377,7 @@ enum ColumnsOrSelect {
 fn build_select_and_joins_for_order_by_group(
     env: &Env,
     state: &mut State,
-    root_and_current_tables: &RootAndCurrentTables,
+    current_table_scope: &TableScope,
     element_group: &OrderByElementGroup,
 ) -> Result<ColumnsOrSelect, Error> {
     // We want to build a select query where "Track" is the root table, and "Artist"."Name"
@@ -415,26 +411,22 @@ fn build_select_and_joins_for_order_by_group(
             }
             OrderByElementGroup::Columns { .. } => {
                 // If the path is empty, we don't need to build a query, just return the columns.
-                let table =
-                    env.lookup_fields_info(&root_and_current_tables.current_table.source)?;
-                let columns = translate_targets(
-                    &table,
-                    &root_and_current_tables.current_table,
-                    element_group,
-                )?
-                .into_iter()
-                .map(|column| {
-                    (
-                        column.index,
-                        column.direction,
-                        column.field_path,
-                        sql::ast::ColumnReference::AliasedColumn {
-                            table: root_and_current_tables.current_table.reference.clone(),
-                            column: column.alias,
-                        },
-                    )
-                })
-                .collect();
+                let table = env.lookup_fields_info(&current_table_scope.current_table().source)?;
+                let columns =
+                    translate_targets(&table, current_table_scope.current_table(), element_group)?
+                        .into_iter()
+                        .map(|column| {
+                            (
+                                column.index,
+                                column.direction,
+                                column.field_path,
+                                sql::ast::ColumnReference::AliasedColumn {
+                                    table: current_table_scope.current_table().reference.clone(),
+                                    column: column.alias,
+                                },
+                            )
+                        })
+                        .collect();
                 Ok(ColumnsOrSelect::Columns(columns))
             }
         }
@@ -448,7 +440,7 @@ fn build_select_and_joins_for_order_by_group(
         // from the next join, we need to select these.
         let (last_table, cols) = path.iter().enumerate().try_fold(
             (
-                root_and_current_tables.current_table.clone(),
+                current_table_scope.clone(),
                 // this is a dummy value that will be ignored, since we only care about returning
                 // the columns from the last table.
                 PathElementSelectColumns::RelationshipColumns(vec![]),
@@ -456,7 +448,6 @@ fn build_select_and_joins_for_order_by_group(
             |(last_table, _), (index, path_element)| {
                 process_path_element_for_order_by_targets(
                     (env, state),
-                    root_and_current_tables,
                     element_group,
                     &mut joins,
                     (last_table, (index, path_element)),
@@ -479,7 +470,7 @@ fn build_select_and_joins_for_order_by_group(
                             (select_expr.alias.clone(), {
                                 let column = sql::ast::Expression::ColumnReference(
                                     sql::ast::ColumnReference::AliasedColumn {
-                                        table: last_table.reference.clone(),
+                                        table: last_table.current_table().reference.clone(),
                                         column: select_expr.alias.clone(),
                                     },
                                 );
@@ -601,14 +592,13 @@ struct OrderByRelationshipColumn {
 /// from the next join, we need to select these.
 fn process_path_element_for_order_by_targets(
     (env, state): (&Env, &mut State),
-    root_and_current_tables: &RootAndCurrentTables,
     element_group: &OrderByElementGroup,
     // to get the information about this path element we need to select from the relevant table
     // and join with the previous table. We add a new join to this list of joins.
     joins: &mut Vec<sql::ast::LeftOuterJoinLateral>,
     // the table we are joining with, the current path element and its index.
-    (last_table, (index, path_element)): (TableSourceAndReference, (usize, &models::PathElement)),
-) -> Result<(TableSourceAndReference, PathElementSelectColumns), Error> {
+    (last_table_scope, (index, path_element)): (TableScope, (usize, &models::PathElement)),
+) -> Result<(TableScope, PathElementSelectColumns), Error> {
     // examine the path elements' relationship.
     let relationship = env.lookup_relationship(&path_element.relationship)?;
 
@@ -622,6 +612,9 @@ fn process_path_element_for_order_by_targets(
         &target_collection_alias,
         &path_element.arguments,
     )?;
+
+    // PathElement acts as a root for table scopes, and named scopes cannot be used to access other path elements or the root.
+    let current_table_scope = TableScope::new(table.clone());
 
     let path = element_group.path();
 
@@ -677,14 +670,11 @@ fn process_path_element_for_order_by_targets(
     let select = select_for_path_element(
         env,
         state,
-        &RootAndCurrentTables {
-            root_table: root_and_current_tables.root_table.clone(),
-            current_table: last_table,
-        },
+        &last_table_scope,
         relationship,
         path_element.predicate.as_deref(),
         sql::ast::SelectList::SelectList(select_cols.aliases_and_expressions()),
-        (table.clone(), from_clause),
+        (table, from_clause),
     )?;
 
     // build a join from it, and
@@ -697,7 +687,7 @@ fn process_path_element_for_order_by_targets(
     joins.push(join);
 
     // return the required columns for this table's join and the last table we found.
-    Ok((table, select_cols))
+    Ok((current_table_scope, select_cols))
 }
 
 /// Take an element group and convert all of the elements we want to select
@@ -841,7 +831,7 @@ fn from_clause_for_path_element(
 fn select_for_path_element(
     env: &Env,
     state: &mut State,
-    root_and_current_tables: &RootAndCurrentTables,
+    current_table_scope: &TableScope,
     relationship: &models::Relationship,
     predicate: Option<&models::Expression>,
     select_list: sql::ast::SelectList,
@@ -852,16 +842,14 @@ fn select_for_path_element(
     select.select_list = select_list;
     select.from = Some(from_clause);
 
-    let predicate_tables = RootAndCurrentTables {
-        root_table: root_and_current_tables.root_table.clone(),
-        current_table: join_table,
-    };
+    // path elements get a fresh scope each, and cannot use named scopes to access other tables in the path
+    let predicate_tables = TableScope::new(join_table);
 
     // generate a condition for this join.
     let join_condition = relationships::translate_column_mapping(
         env,
-        &root_and_current_tables.current_table,
-        &predicate_tables.current_table.reference,
+        current_table_scope.current_table(),
+        &predicate_tables.current_table().reference,
         sql::helpers::empty_where(),
         relationship,
     )?;

--- a/crates/query-engine/translation/tests/snapshots/tests__it_select_where_unrelated_exists.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__it_select_where_unrelated_exists.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/query-engine/translation/tests/tests.rs
 expression: result
+snapshot_kind: text
 ---
 SELECT
   coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
@@ -29,7 +30,7 @@ FROM
                     (
                       "%1_artist"."Name" = cast($1 as "pg_catalog"."varchar")
                     )
-                    AND ("%0_album"."ArtistId" = "%1_artist"."ArtistId")
+                    AND ("%1_artist"."ArtistId" = "%0_album"."ArtistId")
                   )
               )
           ) AS "%3_rows"


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

<!-- What is this PR trying to accomplish (and why, if it's not obvious)? -->

`ComparisonTarget::RootCollectionColumn` was removed, to be replaced by [named scopes](https://github.com/hasura/ndc-spec/blob/36855ff20dcbd7d129427794aee9746b895390af/rfcs/0015-named-scopes.md).

This PR implements the replacement functionality.

<!-- Consider: do we need to add a changelog entry? -->

### How

<!-- How is it trying to accomplish it (what are the implementation steps)? -->

This PR replaces RootAndCurrentTables, with TableScope, a struct that keeps track of the current table and any tables in scope for exists expression.

See the accompanying review for details on the code itself.
