### PR TITLE
Fixed inconsistent handling of missing vs null in mutations and native operations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,10 @@
 
 ### Fixed
 
+- Native operations will now interpret missing arguments as null values for that argument, instead of causing an error.
+- Pre and post-check arguments in v2 mutations can now either be missing or null and both will be interpreted as an always true predicate. Previously a null value would have caused an error.
+- In v2 update mutations update columns explicitly set to null (as opposed to being missing or being set with their `_set` value object) are now correctly interpreted as "no update should be made to that column", instead of causing an error.
+
 ## [v2.0.0] - 2025-01-09
 
 ### Changed

--- a/crates/query-engine/translation/tests/goldenfiles/mutations/v2_update_by_id/configuration.json
+++ b/crates/query-engine/translation/tests/goldenfiles/mutations/v2_update_by_id/configuration.json
@@ -1,0 +1,382 @@
+{
+  "version": "5",
+  "$schema": "../../../../../../../static/configuration.schema.json",
+  "connectionSettings": {
+    "connectionUri": {
+      "variable": "CONNECTION_URI"
+    },
+    "poolSettings": {
+      "maxConnections": 50,
+      "poolTimeout": 30,
+      "idleTimeout": 180,
+      "checkConnectionAfterIdle": 60,
+      "connectionLifetime": 600
+    },
+    "isolationLevel": "ReadCommitted"
+  },
+  "metadata": {
+    "tables": {
+      "Dog": {
+        "schemaName": "public",
+        "tableName": "Dog",
+        "columns": {
+          "adopter_name": {
+            "name": "adopter_name",
+            "type": {
+              "scalarType": "varchar"
+            },
+            "nullable": "nullable",
+            "description": null
+          },
+          "height_cm": {
+            "name": "height_cm",
+            "type": {
+              "scalarType": "numeric"
+            },
+            "nullable": "nonNullable",
+            "hasDefault": "hasDefault",
+            "description": null
+          },
+          "height_in": {
+            "name": "height_in",
+            "type": {
+              "scalarType": "numeric"
+            },
+            "nullable": "nullable",
+            "hasDefault": "hasDefault",
+            "isGenerated": "stored",
+            "description": null
+          },
+          "id": {
+            "name": "id",
+            "type": {
+              "scalarType": "int8"
+            },
+            "nullable": "nonNullable",
+            "isIdentity": "identityAlways",
+            "description": null
+          }
+        },
+        "uniquenessConstraints": {
+          "PK_Dog": ["id"]
+        },
+        "foreignRelations": {},
+        "description": null
+      }
+    },
+    "types": {
+      "scalar": {
+        "int4": {
+          "typeName": "int4",
+          "schemaName": "pg_catalog",
+          "description": null,
+          "aggregateFunctions": {},
+          "comparisonOperators": {},
+          "typeRepresentation": "int32"
+        },
+        "int8": {
+          "typeName": "int8",
+          "schemaName": "pg_catalog",
+          "description": null,
+          "aggregateFunctions": {},
+          "comparisonOperators": {},
+          "typeRepresentation": "int64"
+        },
+        "numeric": {
+          "typeName": "numeric",
+          "schemaName": "pg_catalog",
+          "description": null,
+          "aggregateFunctions": {},
+          "comparisonOperators": {},
+          "typeRepresentation": "bigDecimalAsString"
+        },
+        "varchar": {
+          "typeName": "varchar",
+          "schemaName": "pg_catalog",
+          "description": null,
+          "aggregateFunctions": {},
+          "comparisonOperators": {},
+          "typeRepresentation": "string"
+        }
+      },
+      "composite": {}
+    },
+    "nativeOperations": {
+      "queries": {},
+      "mutations": {}
+    }
+  },
+  "introspectionOptions": {
+    "excludedSchemas": [
+      "information_schema",
+      "pg_catalog",
+      "tiger",
+      "crdb_internal",
+      "columnar",
+      "columnar_internal"
+    ],
+    "unqualifiedSchemasForTables": ["public"],
+    "unqualifiedSchemasForTypesAndProcedures": [
+      "public",
+      "pg_catalog",
+      "tiger"
+    ],
+    "comparisonOperatorMapping": [
+      {
+        "operatorName": "=",
+        "exposedName": "_eq",
+        "operatorKind": "equal"
+      },
+      {
+        "operatorName": "<=",
+        "exposedName": "_lte",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": ">",
+        "exposedName": "_gt",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": ">=",
+        "exposedName": "_gte",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "<",
+        "exposedName": "_lt",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "<>",
+        "exposedName": "_neq",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "!=",
+        "exposedName": "_neq",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "LIKE",
+        "exposedName": "_like",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "NOT LIKE",
+        "exposedName": "_nlike",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "ILIKE",
+        "exposedName": "_ilike",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "NOT ILIKE",
+        "exposedName": "_nilike",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "SIMILAR TO",
+        "exposedName": "_similar",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "NOT SIMILAR TO",
+        "exposedName": "_nsimilar",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "~~",
+        "exposedName": "_like",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "!~~",
+        "exposedName": "_nlike",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "~~*",
+        "exposedName": "_ilike",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "!~~*",
+        "exposedName": "_nilike",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "~",
+        "exposedName": "_regex",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "!~",
+        "exposedName": "_nregex",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "~*",
+        "exposedName": "_iregex",
+        "operatorKind": "custom"
+      },
+      {
+        "operatorName": "!~*",
+        "exposedName": "_niregex",
+        "operatorKind": "custom"
+      }
+    ],
+    "introspectPrefixFunctionComparisonOperators": [
+      "box_above",
+      "box_below",
+      "box_contain",
+      "box_contain_pt",
+      "box_contained",
+      "box_left",
+      "box_overabove",
+      "box_overbelow",
+      "box_overlap",
+      "box_overleft",
+      "box_overright",
+      "box_right",
+      "box_same",
+      "circle_above",
+      "circle_below",
+      "circle_contain",
+      "circle_contain_pt",
+      "circle_contained",
+      "circle_left",
+      "circle_overabove",
+      "circle_overbelow",
+      "circle_overlap",
+      "circle_overleft",
+      "circle_overright",
+      "circle_right",
+      "circle_same",
+      "contains_2d",
+      "equals",
+      "geography_overlaps",
+      "geometry_above",
+      "geometry_below",
+      "geometry_contained_3d",
+      "geometry_contains",
+      "geometry_contains_3d",
+      "geometry_contains_nd",
+      "geometry_left",
+      "geometry_overabove",
+      "geometry_overbelow",
+      "geometry_overlaps",
+      "geometry_overlaps_3d",
+      "geometry_overlaps_nd",
+      "geometry_overleft",
+      "geometry_overright",
+      "geometry_right",
+      "geometry_same",
+      "geometry_same_3d",
+      "geometry_same_nd",
+      "geometry_within",
+      "geometry_within_nd",
+      "inet_same_family",
+      "inter_lb",
+      "inter_sb",
+      "inter_sl",
+      "is_contained_2d",
+      "ishorizontal",
+      "isparallel",
+      "isperp",
+      "isvertical",
+      "jsonb_contained",
+      "jsonb_contains",
+      "jsonb_exists",
+      "jsonb_path_exists_opr",
+      "jsonb_path_match_opr",
+      "line_intersect",
+      "line_parallel",
+      "line_perp",
+      "lseg_intersect",
+      "lseg_parallel",
+      "lseg_perp",
+      "network_overlap",
+      "network_sub",
+      "network_sup",
+      "on_pb",
+      "on_pl",
+      "on_ppath",
+      "on_ps",
+      "on_sb",
+      "on_sl",
+      "overlaps_2d",
+      "path_contain_pt",
+      "path_inter",
+      "point_above",
+      "point_below",
+      "point_horiz",
+      "point_left",
+      "point_right",
+      "point_vert",
+      "poly_above",
+      "poly_below",
+      "poly_contain",
+      "poly_contain_pt",
+      "poly_contained",
+      "poly_left",
+      "poly_overabove",
+      "poly_overbelow",
+      "poly_overlap",
+      "poly_overleft",
+      "poly_overright",
+      "poly_right",
+      "poly_same",
+      "pt_contained_poly",
+      "st_3dintersects",
+      "st_contains",
+      "st_containsproperly",
+      "st_coveredby",
+      "st_covers",
+      "st_crosses",
+      "st_disjoint",
+      "st_equals",
+      "st_intersects",
+      "st_isvalid",
+      "st_orderingequals",
+      "st_overlaps",
+      "st_relatematch",
+      "st_touches",
+      "st_within",
+      "starts_with",
+      "ts_match_qv",
+      "ts_match_tq",
+      "ts_match_tt",
+      "ts_match_vq",
+      "tsq_mcontained",
+      "tsq_mcontains",
+      "xmlexists",
+      "xmlvalidate",
+      "xpath_exists"
+    ],
+    "typeRepresentations": {
+      "bit": "string",
+      "bool": "boolean",
+      "bpchar": "string",
+      "char": "string",
+      "date": "date",
+      "float4": "float32",
+      "float8": "float64",
+      "int2": "int16",
+      "int4": "int32",
+      "int8": "int64AsString",
+      "numeric": "bigDecimalAsString",
+      "text": "string",
+      "time": "time",
+      "timestamp": "timestamp",
+      "timestamptz": "timestamptz",
+      "timetz": "timetz",
+      "uuid": "uUID",
+      "varchar": "string"
+    }
+  },
+  "mutationsVersion": "v2",
+  "mutationsPrefix": null
+}

--- a/crates/query-engine/translation/tests/goldenfiles/mutations/v2_update_by_id/request.json
+++ b/crates/query-engine/translation/tests/goldenfiles/mutations/v2_update_by_id/request.json
@@ -3,25 +3,15 @@
   "operations": [
     {
       "type": "procedure",
-      "name": "v2_insert_Artist",
+      "name": "v2_update_Dog_by_id",
       "arguments": {
-        "objects": [
-          {
-            "name": "Olympians",
-            "id": 276
-          },
-          {
-            "name": "The Other Band"
-          },
-          {
-            "name": "The Null Band",
-            "id": null
-          }
-        ],
-        "post_check": {
-          "type": "or",
-          "expressions": []
-        }
+        "key_id": 10,
+        "update_columns": {
+          "height_cm": { "_set": 100 },
+          "height_in": { "_set": null },
+          "adopter_name": null
+        },
+        "post_check": null
       },
       "fields": {
         "type": "object",
@@ -39,13 +29,13 @@
               "fields": {
                 "type": "object",
                 "fields": {
-                  "artist_id": {
+                  "id": {
                     "type": "column",
                     "column": "id"
                   },
-                  "name": {
+                  "adopter_name": {
                     "type": "column",
-                    "column": "name"
+                    "column": "adopter_name"
                   }
                 }
               }

--- a/crates/query-engine/translation/tests/snapshots/tests__mutations__v2_insert.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__mutations__v2_insert.snap
@@ -10,13 +10,17 @@ WITH "%0_generated_mutation" AS (
     "public"."Artist"("ArtistId", "Name")
   VALUES
     (276, cast($1 as "pg_catalog"."varchar")),
-    (DEFAULT, cast($2 as "pg_catalog"."varchar")) RETURNING *,
+    (DEFAULT, cast($2 as "pg_catalog"."varchar")),
+    (
+      cast(null as "pg_catalog"."int4"),
+      cast($3 as "pg_catalog"."varchar")
+    ) RETURNING *,
     false AS "%check__constraint"
 )
 SELECT
   (
     SELECT
-      json_build_object('result', row_to_json("%4_universe"), 'type', $3) AS "universe"
+      json_build_object('result', row_to_json("%4_universe"), 'type', $4) AS "universe"
     FROM
       (
         SELECT
@@ -59,4 +63,4 @@ SELECT
 
 COMMIT;
 
-[[(1, String("Olympians")), (2, String("The Other Band")), (3, String("procedure"))]]
+[[(1, String("Olympians")), (2, String("The Other Band")), (3, String("The Null Band")), (4, String("procedure"))]]

--- a/crates/query-engine/translation/tests/snapshots/tests__mutations__v2_update_by_id.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__mutations__v2_update_by_id.snap
@@ -1,0 +1,64 @@
+---
+source: crates/query-engine/translation/tests/tests.rs
+expression: result
+---
+BEGIN
+ISOLATION LEVEL READ COMMITTED READ WRITE;
+
+WITH "%0_generated_mutation" AS (
+  UPDATE
+    "public"."Dog"
+  SET
+    "height_cm" = 100,
+    "height_in" = cast(null as "pg_catalog"."numeric")
+  WHERE
+    ("public"."Dog"."id" = 10) RETURNING *,
+    true AS "%check__constraint"
+)
+SELECT
+  (
+    SELECT
+      json_build_object('result', row_to_json("%4_universe"), 'type', $1) AS "universe"
+    FROM
+      (
+        SELECT
+          *
+        FROM
+          (
+            SELECT
+              coalesce(json_agg(row_to_json("%5_returning")), '[]') AS "returning"
+            FROM
+              (
+                SELECT
+                  "%1_Dog"."id" AS "id",
+                  "%1_Dog"."adopter_name" AS "adopter_name"
+                FROM
+                  "%0_generated_mutation" AS "%1_Dog"
+              ) AS "%5_returning"
+          ) AS "%5_returning"
+          CROSS JOIN (
+            SELECT
+              COUNT(*) AS "affected_rows"
+            FROM
+              (
+                SELECT
+                  "%2_Dog".*
+                FROM
+                  "%0_generated_mutation" AS "%2_Dog"
+              ) AS "%3_Dog"
+          ) AS "%6_aggregates"
+      ) AS "%4_universe"
+  ) AS "%results",
+  (
+    SELECT
+      coalesce(
+        bool_and("%7_v2_update_Dog_by_id"."%check__constraint"),
+        true
+      ) AS "%check__constraint"
+    FROM
+      "%0_generated_mutation" AS "%7_v2_update_Dog_by_id"
+  ) AS "%check__constraint";
+
+COMMIT;
+
+[[(1, String("procedure"))]]

--- a/crates/query-engine/translation/tests/tests.rs
+++ b/crates/query-engine/translation/tests/tests.rs
@@ -430,4 +430,13 @@ mod mutations {
                 .unwrap();
         insta::assert_snapshot!(result);
     }
+
+    #[tokio::test]
+    async fn v2_update_by_id() {
+        let result =
+            common::test_mutation_translation(IsolationLevel::default(), "v2_update_by_id")
+                .await
+                .unwrap();
+        insta::assert_snapshot!(result);
+    }
 }

--- a/crates/tests/databases-tests/src/postgres/mutation_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/mutation_tests.rs
@@ -187,6 +187,46 @@ mod basic {
 
         insta::assert_json_snapshot!(result);
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn v2_update_no_checks() {
+        let ndc_metadata =
+            FreshDeployment::create(common::CONNECTION_URI, common::CHINOOK_NDC_METADATA_PATH)
+                .await
+                .unwrap();
+
+        let router = tests_common::router::create_router(
+            &ndc_metadata.ndc_metadata_path,
+            &ndc_metadata.connection_uri,
+        )
+        .await;
+
+        let mutation_result = run_mutation(router.clone(), "v2_update_no_checks").await;
+
+        let result = mutation_result;
+
+        insta::assert_json_snapshot!(result);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn native_opration_insert_genre() {
+        let ndc_metadata =
+            FreshDeployment::create(common::CONNECTION_URI, common::CHINOOK_NDC_METADATA_PATH)
+                .await
+                .unwrap();
+
+        let result = run_mutation(
+            tests_common::router::create_router(
+                &ndc_metadata.ndc_metadata_path,
+                &ndc_metadata.connection_uri,
+            )
+            .await,
+            "native_operation_insert_genre",
+        )
+        .await;
+
+        insta::assert_json_snapshot!(result);
+    }
 }
 
 #[cfg(test)]

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__native_opration_insert_genre.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__native_opration_insert_genre.snap
@@ -1,0 +1,44 @@
+---
+source: crates/tests/databases-tests/src/postgres/mutation_tests.rs
+expression: result
+---
+{
+  "operation_results": [
+    {
+      "type": "procedure",
+      "result": {
+        "returning": [
+          {
+            "genre_id": 100,
+            "name": "Liquid Drum & Bass"
+          }
+        ],
+        "affectedRows": 1
+      }
+    },
+    {
+      "type": "procedure",
+      "result": {
+        "returning": [
+          {
+            "genre_id": 101,
+            "name": null
+          }
+        ],
+        "affectedRows": 1
+      }
+    },
+    {
+      "type": "procedure",
+      "result": {
+        "returning": [
+          {
+            "genre_id": 102,
+            "name": null
+          }
+        ],
+        "affectedRows": 1
+      }
+    }
+  ]
+}

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__v2_insert_custom_dog.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__v2_insert_custom_dog.snap
@@ -46,6 +46,12 @@ expression: result
       "result": {
         "affected_rows": 1
       }
+    },
+    {
+      "type": "procedure",
+      "result": {
+        "affected_rows": 1
+      }
     }
   ]
 }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__v2_update_no_checks.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__mutation_tests__basic__v2_update_no_checks.snap
@@ -1,0 +1,32 @@
+---
+source: crates/tests/databases-tests/src/postgres/mutation_tests.rs
+expression: result
+---
+{
+  "operation_results": [
+    {
+      "type": "procedure",
+      "result": {
+        "returning": [
+          {
+            "ArtistId": 8,
+            "Name": "Audiofreedom"
+          }
+        ],
+        "affected_rows": 1
+      }
+    },
+    {
+      "type": "procedure",
+      "result": {
+        "returning": [
+          {
+            "ArtistId": 8,
+            "Name": "Audiofreedom"
+          }
+        ],
+        "affected_rows": 1
+      }
+    }
+  ]
+}

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/tests/databases-tests/src/postgres/schema_tests.rs
 expression: result
-snapshot_kind: text
 ---
 {
   "scalar_types": {
@@ -5174,6 +5173,47 @@ snapshot_kind: text
         }
       }
     },
+    "insert_genre": {
+      "fields": {
+        "GenreId": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "Name": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        }
+      }
+    },
+    "insert_genre_response": {
+      "description": "Responses from the 'insert_genre' procedure",
+      "fields": {
+        "affected_rows": {
+          "description": "The number of rows affected by the mutation",
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "returning": {
+          "description": "Data from rows affected by the mutation",
+          "type": {
+            "type": "array",
+            "element_type": {
+              "type": "named",
+              "name": "insert_genre"
+            }
+          }
+        }
+      }
+    },
     "insert_group_leader_object": {
       "fields": {
         "characters": {
@@ -9949,6 +9989,30 @@ snapshot_kind: text
       "result_type": {
         "type": "named",
         "name": "insert_artist_response"
+      }
+    },
+    {
+      "name": "insert_genre",
+      "arguments": {
+        "id": {
+          "type": {
+            "type": "named",
+            "name": "int4"
+          }
+        },
+        "name": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "varchar"
+            }
+          }
+        }
+      },
+      "result_type": {
+        "type": "named",
+        "name": "insert_genre_response"
       }
     },
     {

--- a/crates/tests/tests-common/goldenfiles/mutations/native_operation_insert_genre.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/native_operation_insert_genre.json
@@ -3,16 +3,15 @@
   "operations": [
     {
       "type": "procedure",
-      "name": "delete_PlaylistTrack_by_PlaylistId_and_TrackId",
+      "name": "insert_genre",
       "arguments": {
-        "key_TrackId": 90,
-        "key_PlaylistId": 8,
-        "pre_check": null
+        "id": 100,
+        "name": "Liquid Drum & Bass"
       },
       "fields": {
         "type": "object",
         "fields": {
-          "affected_rows": {
+          "affectedRows": {
             "column": "affected_rows",
             "type": "column"
           },
@@ -24,13 +23,13 @@
               "fields": {
                 "type": "object",
                 "fields": {
-                  "playlist_id": {
+                  "genre_id": {
                     "type": "column",
-                    "column": "PlaylistId"
+                    "column": "GenreId"
                   },
-                  "track_id": {
+                  "name": {
                     "type": "column",
-                    "column": "TrackId"
+                    "column": "Name"
                   }
                 }
               }
@@ -41,26 +40,15 @@
     },
     {
       "type": "procedure",
-      "name": "update_PlaylistTrack_by_PlaylistId_and_TrackId",
+      "name": "insert_genre",
       "arguments": {
-        "key_TrackId": 89,
-        "key_PlaylistId": 1,
-        "update_columns": {
-          "PlaylistId": { "_set": 7 }
-        },
-        "pre_check": {
-          "type": "and",
-          "expressions": []
-        },
-        "post_check": {
-          "type": "and",
-          "expressions": []
-        }
+        "id": 101,
+        "name": null
       },
       "fields": {
         "type": "object",
         "fields": {
-          "affected_rows": {
+          "affectedRows": {
             "column": "affected_rows",
             "type": "column"
           },
@@ -72,13 +60,49 @@
               "fields": {
                 "type": "object",
                 "fields": {
-                  "track_id": {
+                  "genre_id": {
                     "type": "column",
-                    "column": "TrackId"
+                    "column": "GenreId"
                   },
-                  "playlist_id": {
+                  "name": {
                     "type": "column",
-                    "column": "PlaylistId"
+                    "column": "Name"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "procedure",
+      "name": "insert_genre",
+      "arguments": {
+        "id": 102
+      },
+      "fields": {
+        "type": "object",
+        "fields": {
+          "affectedRows": {
+            "column": "affected_rows",
+            "type": "column"
+          },
+          "returning": {
+            "type": "column",
+            "column": "returning",
+            "fields": {
+              "type": "array",
+              "fields": {
+                "type": "object",
+                "fields": {
+                  "genre_id": {
+                    "type": "column",
+                    "column": "GenreId"
+                  },
+                  "name": {
+                    "type": "column",
+                    "column": "Name"
                   }
                 }
               }

--- a/crates/tests/tests-common/goldenfiles/mutations/v2_insert_custom_dog.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/v2_insert_custom_dog.json
@@ -134,10 +134,30 @@
             "birthday": "2024-02-14"
           }
         ],
-        "post_check": {
-          "type": "and",
-          "expressions": []
+        "post_check": null
+      },
+      "fields": {
+        "type": "object",
+        "fields": {
+          "affected_rows": {
+            "column": "affected_rows",
+            "type": "column"
+          }
         }
+      }
+    },
+    {
+      "type": "procedure",
+      "name": "insert_custom_dog",
+      "arguments": {
+        "objects": [
+          {
+            "name": "Rover",
+            "height_cm": 250,
+            "adopter_name": "Simon",
+            "birthday": "2025-01-01"
+          }
+        ]
       },
       "fields": {
         "type": "object",

--- a/crates/tests/tests-common/goldenfiles/mutations/v2_update_defaults.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/v2_update_defaults.json
@@ -62,7 +62,8 @@
         "key_id": 3,
         "update_columns": {
           "name": { "_set": "Winston" },
-          "height_cm": { "_set": 700 }
+          "height_cm": { "_set": 700 },
+          "height_in": null
         },
         "pre_check": {
           "type": "unary_comparison_operator",

--- a/crates/tests/tests-common/goldenfiles/mutations/v2_update_no_checks.json
+++ b/crates/tests/tests-common/goldenfiles/mutations/v2_update_no_checks.json
@@ -3,11 +3,14 @@
   "operations": [
     {
       "type": "procedure",
-      "name": "delete_PlaylistTrack_by_PlaylistId_and_TrackId",
+      "name": "update_Artist_by_ArtistId",
       "arguments": {
-        "key_TrackId": 90,
-        "key_PlaylistId": 8,
-        "pre_check": null
+        "key_ArtistId": 8,
+        "update_columns": {
+          "Name": { "_set": "Audiofreedom" }
+        },
+        "pre_check": null,
+        "post_check": null
       },
       "fields": {
         "type": "object",
@@ -24,13 +27,13 @@
               "fields": {
                 "type": "object",
                 "fields": {
-                  "playlist_id": {
+                  "ArtistId": {
                     "type": "column",
-                    "column": "PlaylistId"
+                    "column": "ArtistId"
                   },
-                  "track_id": {
+                  "Name": {
                     "type": "column",
-                    "column": "TrackId"
+                    "column": "Name"
                   }
                 }
               }
@@ -41,20 +44,11 @@
     },
     {
       "type": "procedure",
-      "name": "update_PlaylistTrack_by_PlaylistId_and_TrackId",
+      "name": "update_Artist_by_ArtistId",
       "arguments": {
-        "key_TrackId": 89,
-        "key_PlaylistId": 1,
+        "key_ArtistId": 8,
         "update_columns": {
-          "PlaylistId": { "_set": 7 }
-        },
-        "pre_check": {
-          "type": "and",
-          "expressions": []
-        },
-        "post_check": {
-          "type": "and",
-          "expressions": []
+          "Name": { "_set": "Audiofreedom" }
         }
       },
       "fields": {
@@ -72,13 +66,13 @@
               "fields": {
                 "type": "object",
                 "fields": {
-                  "track_id": {
+                  "ArtistId": {
                     "type": "column",
-                    "column": "TrackId"
+                    "column": "ArtistId"
                   },
-                  "playlist_id": {
+                  "Name": {
                     "type": "column",
-                    "column": "PlaylistId"
+                    "column": "Name"
                   }
                 }
               }

--- a/static/postgres/v5-configuration/configuration.json
+++ b/static/postgres/v5-configuration/configuration.json
@@ -4177,6 +4177,48 @@
             }
           },
           "description": null
+        },
+        "insert_genre": {
+          "sql": {
+            "inline": "INSERT INTO public.\"Genre\" VALUES ({{id}}, {{name}}) RETURNING *"
+          },
+          "columns": {
+            "GenreId": {
+              "name": "GenreId",
+              "type": {
+                "scalarType": "int4"
+              },
+              "nullable": "nonNullable",
+              "description": null
+            },
+            "Name": {
+              "name": "Name",
+              "type": {
+                "scalarType": "varchar"
+              },
+              "nullable": "nullable",
+              "description": null
+            }
+          },
+          "arguments": {
+            "id": {
+              "name": "id",
+              "type": {
+                "scalarType": "int4"
+              },
+              "nullable": "nonNullable",
+              "description": null
+            },
+            "name": {
+              "name": "name",
+              "type": {
+                "scalarType": "varchar"
+              },
+              "nullable": "nullable",
+              "description": null
+            }
+          },
+          "description": null
         }
       }
     }


### PR DESCRIPTION
### What
This PR fixes inconsistent handling of missing arguments/object properties in native operations and v2 mutations. In particular:
- Native operations will now interpret missing arguments as null values for that argument, instead of causing an error.
- Pre and post-check arguments in v2 mutations can now either be missing or null and both will be interpreted as an always true predicate. Previously a null value would have caused an error.
- In v2 update mutations update columns explicitly set to null (as opposed to being missing or being set with their `_set` value object) are now correctly interpreted as "no update should be made to that column", instead of causing an error.

### How
When reading arguments for native operations in `crates/query-engine/translation/src/translation/query/native_queries.rs`, we check if the argument type is nullable and if it is and the argument is missing, we assume a null value for the argument. If the argument type is not nullable, then we return an error as before, since we can't assume null.

Pre and post-check arguments are now deserialized using the new `get_nullable_predicate_argument` function in `crates/query-engine/translation/src/translation/mutation/v2/common.rs`. This function allows for both missing and null properties and in both cases coalesces them into the always true predicate.

For v2 update mutations update columns, we now handle the case where the column property is null and treat it as a no-op (see `parse_update_columns`)

