### PR TITLE
add native toolchain definition to connector metadata

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -138,12 +138,12 @@ async fn initialize(with_metadata: bool, context: Context<impl Environment>) -> 
             native_toolchain_definition: Some(NativeToolchainDefinition {
                 commands: vec![
                     ("start".to_string(), metadata::CommandDefinition::ShellScript {
-                        bash: "#!/usr/bin/env bash\nset -eu -o pipefail\nHASURA_CONFIGURATION_DIRECTORY=\"$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH\" ndc-postgres serve".to_string(),
-                        powershell: "$ErrorActionPreference = \"Stop\"\n$env:HASURA_CONFIGURATION_DIRECTORY=\"$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH\"; & ndc-postgres.exe serve".to_string(),
+                        bash: "#!/usr/bin/env bash\nset -eu -o pipefail\nHASURA_CONFIGURATION_DIRECTORY=\"$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH\" \"$HASURA_DDN_NATIVE_CONNECTOR_DIR/ndc-postgres\" serve".to_string(),
+                        powershell: "$ErrorActionPreference = \"Stop\"\n$env:HASURA_CONFIGURATION_DIRECTORY=\"$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH\"; & \"$env:HASURA_DDN_NATIVE_CONNECTOR_DIR\\ndc-postgres.exe\" serve".to_string(),
                     }),
                     ("update".to_string(), metadata::CommandDefinition::ShellScript {
-                        bash: "#!/usr/bin/env bash\nset -eu -o pipefail\n\"$HOME/.ddn/plugins/store/ndc-postgres/$POSTGRES_VERSION/hasura-ndc-postgres\" update".to_string(),
-                        powershell: "$ErrorActionPreference = \"Stop\"\n& \"$env:USERPROFILE\\.ddn\\plugins\\store\\ndc-postgres\\$env:POSTGRES_VERSION\\hasura-ndc-postgres.exe\" update".to_string(),
+                        bash: "#!/usr/bin/env bash\nset -eu -o pipefail\n\"$HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR/hasura-ndc-postgres\" update".to_string(),
+                        powershell: "$ErrorActionPreference = \"Stop\"\n& \"$env:HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR\\hasura-ndc-postgres.exe\" update".to_string(),
                     }),
                 ].into_iter().collect(),
             })

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -9,6 +9,7 @@ mod native_operations;
 use std::path::PathBuf;
 
 use clap::Subcommand;
+use metadata::NativeToolchainDefinition;
 use tokio::fs;
 
 use ndc_postgres_configuration as configuration;
@@ -134,6 +135,20 @@ async fn initialize(with_metadata: bool, context: Context<impl Environment>) -> 
                 action: metadata::DockerComposeWatchAction::SyncAndRestart,
                 ignore: vec![],
             }],
+            native_toolchain_definition: Some(NativeToolchainDefinition {
+                commands: vec![
+                    ("start".to_string(), metadata::CommandDefinition {
+                        command_type: metadata::CommandType::ShellScript,
+                        bash: "#!/usr/bin/env bash\nset -eu -o pipefail\nHASURA_CONFIGURATION_DIRECTORY=\"$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH\" ndc-postgres serve".to_string(),
+                        powershell: String::new(),
+                    }),
+                    ("update".to_string(), metadata::CommandDefinition {
+                        command_type: metadata::CommandType::ShellScript,
+                        bash: "#!/usr/bin/env bash\nset -eu -o pipefail\n\"$HOME/.ddn/plugins/bin/hasura-ndc_postgres\" update".to_string(),
+                        powershell: String::new(),
+                    }),
+                ].into_iter().collect(),
+            })
         };
 
         fs::write(metadata_file, serde_yaml::to_string(&metadata)?).await?;

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -137,13 +137,12 @@ async fn initialize(with_metadata: bool, context: Context<impl Environment>) -> 
             }],
             native_toolchain_definition: Some(NativeToolchainDefinition {
                 commands: vec![
-                    ("start".to_string(), metadata::CommandDefinition {
-                        command_type: metadata::CommandType::ShellScript,
+                    ("start".to_string(), metadata::CommandDefinition::ShellScript {
                         bash: "#!/usr/bin/env bash\nset -eu -o pipefail\nHASURA_CONFIGURATION_DIRECTORY=\"$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH\" ndc-postgres serve".to_string(),
                         powershell: String::new(),
+
                     }),
-                    ("update".to_string(), metadata::CommandDefinition {
-                        command_type: metadata::CommandType::ShellScript,
+                    ("update".to_string(), metadata::CommandDefinition::ShellScript {
                         bash: "#!/usr/bin/env bash\nset -eu -o pipefail\n\"$HOME/.ddn/plugins/bin/hasura-ndc_postgres\" update".to_string(),
                         powershell: String::new(),
                     }),

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -139,12 +139,11 @@ async fn initialize(with_metadata: bool, context: Context<impl Environment>) -> 
                 commands: vec![
                     ("start".to_string(), metadata::CommandDefinition::ShellScript {
                         bash: "#!/usr/bin/env bash\nset -eu -o pipefail\nHASURA_CONFIGURATION_DIRECTORY=\"$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH\" ndc-postgres serve".to_string(),
-                        powershell: String::new(),
-
+                        powershell: "$ErrorActionPreference = \"Stop\"\n$env:HASURA_CONFIGURATION_DIRECTORY=\"$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH\"; & ndc-postgres.exe serve".to_string(),
                     }),
                     ("update".to_string(), metadata::CommandDefinition::ShellScript {
-                        bash: "#!/usr/bin/env bash\nset -eu -o pipefail\n\"$HOME/.ddn/plugins/bin/hasura-ndc_postgres\" update".to_string(),
-                        powershell: String::new(),
+                        bash: "#!/usr/bin/env bash\nset -eu -o pipefail\n\"$HOME/.ddn/plugins/store/ndc-postgres/$POSTGRES_VERSION/hasura-ndc-postgres\" update".to_string(),
+                        powershell: "$ErrorActionPreference = \"Stop\"\n& \"$env:USERPROFILE\\.ddn\\plugins\\store\\ndc-postgres\\$env:POSTGRES_VERSION\\hasura-ndc-postgres.exe\" update".to_string(),
                     }),
                 ].into_iter().collect(),
             })

--- a/crates/cli/src/metadata.rs
+++ b/crates/cli/src/metadata.rs
@@ -2,6 +2,8 @@
 //!
 //! See https://github.com/hasura/ndc-hub/blob/main/rfcs/0001-packaging.md#connector-definition.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -14,6 +16,8 @@ pub struct ConnectorMetadataDefinition {
     pub cli_plugin: Option<CliPluginDefinition>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub docker_compose_watch: DockerComposeWatch,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub native_toolchain_definition: Option<NativeToolchainDefinition>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -74,4 +78,26 @@ pub enum DockerComposeWatchAction {
     Sync,
     #[serde(rename = "sync+restart")]
     SyncAndRestart,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeToolchainDefinition {
+    pub commands: BTreeMap<CommandName, CommandDefinition>,
+}
+
+pub type CommandName = String;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommandDefinition {
+    #[serde(rename = "type")]
+    pub command_type: CommandType,
+    pub bash: String,
+    pub powershell: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum CommandType {
+    ShellScript,
 }

--- a/crates/cli/src/metadata.rs
+++ b/crates/cli/src/metadata.rs
@@ -92,13 +92,10 @@ pub type CommandName = String;
 #[serde(rename_all = "PascalCase", tag = "type")]
 pub enum CommandDefinition {
     #[serde(rename_all = "camelCase")]
-    ShellScript {
-        bash: String,
-        powershell: String,
-    },
+    ShellScript { bash: String, powershell: String },
     #[serde(rename_all = "camelCase")]
     DockerizedCommand {
         docker_image: String,
         command_args: Vec<String>,
-    }
+    },
 }

--- a/crates/cli/src/metadata.rs
+++ b/crates/cli/src/metadata.rs
@@ -89,15 +89,16 @@ pub struct NativeToolchainDefinition {
 pub type CommandName = String;
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CommandDefinition {
-    #[serde(rename = "type")]
-    pub command_type: CommandType,
-    pub bash: String,
-    pub powershell: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub enum CommandType {
-    ShellScript,
+#[serde(rename_all = "PascalCase", tag = "type")]
+pub enum CommandDefinition {
+    #[serde(rename_all = "camelCase")]
+    ShellScript {
+        bash: String,
+        powershell: String,
+    },
+    #[serde(rename_all = "camelCase")]
+    DockerizedCommand {
+        docker_image: String,
+        command_args: Vec<String>,
+    }
 }

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
@@ -27,3 +27,19 @@ dockerComposeWatch:
 - path: ./
   target: /etc/connector
   action: sync+restart
+nativeToolchainDefinition:
+  commands:
+    start:
+      type: ShellScript
+      bash: |-
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        HASURA_CONFIGURATION_DIRECTORY="$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH" ndc-postgres serve
+      powershell: ''
+    update:
+      type: ShellScript
+      bash: |-
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        "$HOME/.ddn/plugins/bin/hasura-ndc_postgres" update
+      powershell: ''

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
@@ -34,16 +34,16 @@ nativeToolchainDefinition:
       bash: |-
         #!/usr/bin/env bash
         set -eu -o pipefail
-        HASURA_CONFIGURATION_DIRECTORY="$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH" ndc-postgres serve
+        HASURA_CONFIGURATION_DIRECTORY="$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH" "$HASURA_DDN_NATIVE_CONNECTOR_DIR/ndc-postgres" serve
       powershell: |-
         $ErrorActionPreference = "Stop"
-        $env:HASURA_CONFIGURATION_DIRECTORY="$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH"; & ndc-postgres.exe serve
+        $env:HASURA_CONFIGURATION_DIRECTORY="$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH"; & "$env:HASURA_DDN_NATIVE_CONNECTOR_DIR\ndc-postgres.exe" serve
     update:
       type: ShellScript
       bash: |-
         #!/usr/bin/env bash
         set -eu -o pipefail
-        "$HOME/.ddn/plugins/store/ndc-postgres/$POSTGRES_VERSION/hasura-ndc-postgres" update
+        "$HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR/hasura-ndc-postgres" update
       powershell: |-
         $ErrorActionPreference = "Stop"
-        & "$env:USERPROFILE\.ddn\plugins\store\ndc-postgres\$env:POSTGRES_VERSION\hasura-ndc-postgres.exe" update
+        & "$env:HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR\hasura-ndc-postgres.exe" update

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata.snap
@@ -35,11 +35,15 @@ nativeToolchainDefinition:
         #!/usr/bin/env bash
         set -eu -o pipefail
         HASURA_CONFIGURATION_DIRECTORY="$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH" ndc-postgres serve
-      powershell: ''
+      powershell: |-
+        $ErrorActionPreference = "Stop"
+        $env:HASURA_CONFIGURATION_DIRECTORY="$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH"; & ndc-postgres.exe serve
     update:
       type: ShellScript
       bash: |-
         #!/usr/bin/env bash
         set -eu -o pipefail
-        "$HOME/.ddn/plugins/bin/hasura-ndc_postgres" update
-      powershell: ''
+        "$HOME/.ddn/plugins/store/ndc-postgres/$POSTGRES_VERSION/hasura-ndc-postgres" update
+      powershell: |-
+        $ErrorActionPreference = "Stop"
+        & "$env:USERPROFILE\.ddn\plugins\store\ndc-postgres\$env:POSTGRES_VERSION\hasura-ndc-postgres.exe" update

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
@@ -27,3 +27,19 @@ dockerComposeWatch:
 - path: ./
   target: /etc/connector
   action: sync+restart
+nativeToolchainDefinition:
+  commands:
+    start:
+      type: ShellScript
+      bash: |-
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        HASURA_CONFIGURATION_DIRECTORY="$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH" ndc-postgres serve
+      powershell: ''
+    update:
+      type: ShellScript
+      bash: |-
+        #!/usr/bin/env bash
+        set -eu -o pipefail
+        "$HOME/.ddn/plugins/bin/hasura-ndc_postgres" update
+      powershell: ''

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
@@ -34,16 +34,16 @@ nativeToolchainDefinition:
       bash: |-
         #!/usr/bin/env bash
         set -eu -o pipefail
-        HASURA_CONFIGURATION_DIRECTORY="$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH" ndc-postgres serve
+        HASURA_CONFIGURATION_DIRECTORY="$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH" "$HASURA_DDN_NATIVE_CONNECTOR_DIR/ndc-postgres" serve
       powershell: |-
         $ErrorActionPreference = "Stop"
-        $env:HASURA_CONFIGURATION_DIRECTORY="$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH"; & ndc-postgres.exe serve
+        $env:HASURA_CONFIGURATION_DIRECTORY="$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH"; & "$env:HASURA_DDN_NATIVE_CONNECTOR_DIR\ndc-postgres.exe" serve
     update:
       type: ShellScript
       bash: |-
         #!/usr/bin/env bash
         set -eu -o pipefail
-        "$HOME/.ddn/plugins/store/ndc-postgres/$POSTGRES_VERSION/hasura-ndc-postgres" update
+        "$HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR/hasura-ndc-postgres" update
       powershell: |-
         $ErrorActionPreference = "Stop"
-        & "$env:USERPROFILE\.ddn\plugins\store\ndc-postgres\$env:POSTGRES_VERSION\hasura-ndc-postgres.exe" update
+        & "$env:HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR\hasura-ndc-postgres.exe" update

--- a/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
+++ b/crates/cli/tests/snapshots/initialize_tests__initialize_directory_with_metadata_and_release_version.snap
@@ -35,11 +35,15 @@ nativeToolchainDefinition:
         #!/usr/bin/env bash
         set -eu -o pipefail
         HASURA_CONFIGURATION_DIRECTORY="$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH" ndc-postgres serve
-      powershell: ''
+      powershell: |-
+        $ErrorActionPreference = "Stop"
+        $env:HASURA_CONFIGURATION_DIRECTORY="$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH"; & ndc-postgres.exe serve
     update:
       type: ShellScript
       bash: |-
         #!/usr/bin/env bash
         set -eu -o pipefail
-        "$HOME/.ddn/plugins/bin/hasura-ndc_postgres" update
-      powershell: ''
+        "$HOME/.ddn/plugins/store/ndc-postgres/$POSTGRES_VERSION/hasura-ndc-postgres" update
+      powershell: |-
+        $ErrorActionPreference = "Stop"
+        & "$env:USERPROFILE\.ddn\plugins\store\ndc-postgres\$env:POSTGRES_VERSION\hasura-ndc-postgres.exe" update


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

This PR adds the native toolchain definition to the connector metadata.

It also adds two commands in the initial metadata generated by the CLI:
```yaml
nativeToolchainDefinition:
  commands:
    start:
      type: ShellScript
      bash: |-
        #!/usr/bin/env bash
        set -eu -o pipefail
        HASURA_CONFIGURATION_DIRECTORY="$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH" "$HASURA_DDN_NATIVE_CONNECTOR_DIR/ndc-postgres" serve
      powershell: |-
        $ErrorActionPreference = "Stop"
        $env:HASURA_CONFIGURATION_DIRECTORY="$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH"; & "$env:HASURA_DDN_NATIVE_CONNECTOR_DIR\ndc-postgres.exe" serve
    update:
      type: ShellScript
      bash: |-
        #!/usr/bin/env bash
        set -eu -o pipefail
        "$HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR/hasura-ndc-postgres" update
      powershell: |-
        $ErrorActionPreference = "Stop"
        & "$env:HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR\hasura-ndc-postgres.exe" update
```

<details>
<summary>Click here for the CLI command output</summary>

```
❯ ndc-postgres-cli initialize --with-metadata
❯ cat .hasura-connector/connector-metadata.yaml
packagingDefinition:
  type: PrebuiltDockerImage
  dockerImage: ghcr.io/hasura/ndc-postgres:343b8b3
supportedEnvironmentVariables:
- name: CONNECTION_URI
  description: The PostgreSQL connection URI
  defaultValue: postgresql://read_only_user:readonlyuser@35.236.11.122:5432/v3-docs-sample-app
- name: CLIENT_CERT
  description: The SSL client certificate (Optional)
  defaultValue: ''
- name: CLIENT_KEY
  description: The SSL client key (Optional)
  defaultValue: ''
- name: ROOT_CERT
  description: The SSL root certificate (Optional)
  defaultValue: ''
commands:
  update: hasura-ndc-postgres update
cliPlugin:
  name: ndc-postgres
  version: 343b8b3
dockerComposeWatch:
- path: ./
  target: /etc/connector
  action: sync+restart
nativeToolchainDefinition:
  commands:
    start:
      type: ShellScript
      bash: |-
        #!/usr/bin/env bash
        set -eu -o pipefail
        HASURA_CONFIGURATION_DIRECTORY="$HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH" "$HASURA_DDN_NATIVE_CONNECTOR_DIR/ndc-postgres" serve
      powershell: |-
        $ErrorActionPreference = "Stop"
        $env:HASURA_CONFIGURATION_DIRECTORY="$env:HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH"; & "$env:HASURA_DDN_NATIVE_CONNECTOR_DIR\ndc-postgres.exe" serve
    update:
      type: ShellScript
      bash: |-
        #!/usr/bin/env bash
        set -eu -o pipefail
        "$HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR/hasura-ndc-postgres" update
      powershell: |-
        $ErrorActionPreference = "Stop"
        & "$env:HASURA_DDN_NATIVE_CONNECTOR_PLUGIN_DIR\hasura-ndc-postgres.exe" update
```

</details>

### How

<!-- How is it trying to accomplish it (what are the implementation steps)? -->
