### PR TITLE
Remove mold suggestion in `.envrc.example`

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -7,7 +7,4 @@
 use flake
 
 # enable incremental compilation
-export CARGO_INCREMENTAL='true'
-
-# use `mold` as your linker, for faster linking (only on Linux)
-export RUSTFLAGS='-C link-arg=-fuse-ld=mold'
+# export CARGO_INCREMENTAL='true'


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

It's totally reasonable that a user would just copy `.envrc.example` to `.envrc` and then get going, however this means we try and use `mold`, which we do not install in the Nix flake, and does not work on MacOS. Let's make the default path as conservative and likely to work as possible.

### How

Remove `mold` advice from `.envrc.example`, make `CARGO_INCREMENTAL` flag opt in.
