### PR TITLE
Save a Docker image if the `upload-engine-docker` is included

### DIFF
--- a/.github/workflows/ship.yaml
+++ b/.github/workflows/ship.yaml
@@ -50,10 +50,12 @@ jobs:
     needs:
       - nix-build
     runs-on: ubuntu-latest
-    # Only run on the `main` branch or version tags.
-    # Note we currently tag the image with 'latest', so will want to stop doing
-    # so if we run this on PR branches, etc.
-    if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    # Only run on the `main` branch, version tags, or when the
+    # `upload-engine-docker` label is found
+    if: |
+      github.ref == 'refs/heads/main'
+        || startsWith(github.ref, 'refs/tags/v')
+        || ${{ github.event.label.name == 'upload-engine-docker' }}
     permissions:
       contents: read
       id-token: write

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -49,7 +49,6 @@ function run {
 #
 # Additionally sets a branch tag assuming this is the latest tag for the given
 # branch. The branch tag has the form: dev-main
-# Also sets the 'latest' tag
 # Also sets a tag with just the branch short hash
 function set_dev_tags {
     local branch="$1"
@@ -61,7 +60,7 @@ function set_dev_tags {
     local short_hash
     short_hash="$(git rev-parse --short=9 HEAD)"
     version="${branch_prefix}-${short_hash}"
-    export docker_tags=("$version" "$branch_prefix" "$short_hash" "latest")
+    export docker_tags=("$version" "$branch_prefix" "$short_hash")
 }
 
 # The Github workflow passes a ref of the form refs/heads/<branch name> or
@@ -71,8 +70,7 @@ function set_dev_tags {
 # If a tag name does not start with a "v" it is assumed to not be a release tag
 # so the function sets an empty array.
 #
-# If the input does look like a release tag, set the tag name as the sole docker
-# tag.
+# If the input does look like a release tag, set the tag name plus 'latest'
 #
 # If the input is a branch, set docker tags via `set_dev_tags`.
 function set_docker_tags {
@@ -85,7 +83,11 @@ function set_docker_tags {
         local branch="${BASH_REMATCH[1]}"
         set_dev_tags "$branch"
     else
-        export docker_tags=("latest")
+      # if we create an image for a random commit,
+      # just tag it with the Git short SHA
+      local short_hash
+      short_hash="$(git rev-parse --short=9 HEAD)"
+      export docker_tags=("$short_hash")
     fi
 }
 


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

Add a Github label `upload-engine-docker` that allows us to create a build. Previously we added `latest` tag to all commits, we stop this and only add it when creating a Docker image for a version tag.
