### PR TITLE
Install working cargo machete version in Github Actions

### DIFF
--- a/.github/workflows/cargo-machete.yaml
+++ b/.github/workflows/cargo-machete.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: install tools
         run: |
           rustup show
-          cargo install cargo-machete
+          cargo install cargo-machete@0.7.0 # Need Rust 2024 edition before we can upgrade this
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

Newest Cargo Machete doesn't work on our version of `rustc`, pin to an old one.
