### PR TITLE
Add subquery to separate where clause from lateral joins used for relationships

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- improved SQL generation to faciliate efficient use of indices in cockroachdb
+
 ### Fixed
 
 ## [v2.0.0] - 2025-01-09

--- a/crates/query-engine/translation/tests/snapshots/tests__aggregate_limit_offset_order_by.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__aggregate_limit_offset_order_by.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%3_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%4_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,39 +11,39 @@ FROM
     FROM
       (
         SELECT
-          coalesce(row_to_json("%5_aggregates"), '[]') AS "aggregates"
+          coalesce(row_to_json("%6_aggregates"), '[]') AS "aggregates"
         FROM
           (
             SELECT
-              min("%2_Invoice"."BillingState") AS "BillingState__min",
-              max("%2_Invoice"."BillingState") AS "BillingState__max",
-              COUNT(DISTINCT "%2_Invoice"."BillingState") AS "BillingState__count_distinct",
-              min("%2_Invoice"."InvoiceId") AS "InvoiceId_min",
-              max("%2_Invoice"."InvoiceId") AS "InvoiceId_max",
-              COUNT("%2_Invoice"."InvoiceId") AS "InvoiceId_count",
-              min("%2_Invoice"."Total") AS "Total__min",
-              max("%2_Invoice"."Total") AS "Total__max",
-              sum("%2_Invoice"."Total") AS "Total__sum",
-              stddev("%2_Invoice"."Total") AS "Total__stddev",
+              min("%3_Invoice"."BillingState") AS "BillingState__min",
+              max("%3_Invoice"."BillingState") AS "BillingState__max",
+              COUNT(DISTINCT "%3_Invoice"."BillingState") AS "BillingState__count_distinct",
+              min("%3_Invoice"."InvoiceId") AS "InvoiceId_min",
+              max("%3_Invoice"."InvoiceId") AS "InvoiceId_max",
+              COUNT("%3_Invoice"."InvoiceId") AS "InvoiceId_count",
+              min("%3_Invoice"."Total") AS "Total__min",
+              max("%3_Invoice"."Total") AS "Total__max",
+              sum("%3_Invoice"."Total") AS "Total__sum",
+              stddev("%3_Invoice"."Total") AS "Total__stddev",
               COUNT(*) AS "count_all"
             FROM
               (
                 SELECT
-                  "%1_Invoice".*
+                  "%2_Invoice".*
                 FROM
-                  "public"."Invoice" AS "%1_Invoice"
+                  "public"."Invoice" AS "%2_Invoice"
                 WHERE
                   (
-                    "%1_Invoice"."BillingCountry" = cast($1 as "pg_catalog"."varchar")
+                    "%2_Invoice"."BillingCountry" = cast($1 as "pg_catalog"."varchar")
                   )
                 ORDER BY
-                  "%1_Invoice"."InvoiceId" ASC
+                  "%2_Invoice"."InvoiceId" ASC
                 LIMIT
                   10 OFFSET 5
-              ) AS "%2_Invoice"
-          ) AS "%5_aggregates"
-      ) AS "%5_aggregates"
-  ) AS "%3_universe";
+              ) AS "%3_Invoice"
+          ) AS "%6_aggregates"
+      ) AS "%6_aggregates"
+  ) AS "%4_universe";
 
 {
     1: String(

--- a/crates/query-engine/translation/tests/snapshots/tests__dup_array_relationship.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__dup_array_relationship.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%9_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%12_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,17 +11,24 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%10_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%13_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%1_RELATIONSHIP_albums"."albums" AS "albums",
-              "%2_RELATIONSHIP_Albums"."Albums" AS "Albums"
+              "%2_RELATIONSHIP_albums"."albums" AS "albums",
+              "%3_RELATIONSHIP_Albums"."Albums" AS "Albums"
             FROM
-              "public"."Artist" AS "%0_Artist"
+              (
+                SELECT
+                  "%0_Artist".*
+                FROM
+                  "public"."Artist" AS "%0_Artist"
+                LIMIT
+                  5
+              ) AS "%1_Artist"
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  row_to_json("%1_RELATIONSHIP_albums") AS "albums"
+                  row_to_json("%2_RELATIONSHIP_albums") AS "albums"
                 FROM
                   (
                     SELECT
@@ -29,22 +36,27 @@ FROM
                     FROM
                       (
                         SELECT
-                          coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
+                          coalesce(json_agg(row_to_json("%6_rows")), '[]') AS "rows"
                         FROM
                           (
                             SELECT
-                              "%3_Album"."Title" AS "title"
+                              "%5_Album"."Title" AS "title"
                             FROM
-                              "public"."Album" AS "%3_Album"
-                            WHERE
-                              ("%0_Artist"."ArtistId" = "%3_Album"."ArtistId")
-                          ) AS "%4_rows"
-                      ) AS "%4_rows"
-                  ) AS "%1_RELATIONSHIP_albums"
-              ) AS "%1_RELATIONSHIP_albums" ON ('true')
+                              (
+                                SELECT
+                                  "%4_Album".*
+                                FROM
+                                  "public"."Album" AS "%4_Album"
+                                WHERE
+                                  ("%1_Artist"."ArtistId" = "%4_Album"."ArtistId")
+                              ) AS "%5_Album"
+                          ) AS "%6_rows"
+                      ) AS "%6_rows"
+                  ) AS "%2_RELATIONSHIP_albums"
+              ) AS "%2_RELATIONSHIP_albums" ON ('true')
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  row_to_json("%2_RELATIONSHIP_Albums") AS "Albums"
+                  row_to_json("%3_RELATIONSHIP_Albums") AS "Albums"
                 FROM
                   (
                     SELECT
@@ -52,23 +64,26 @@ FROM
                     FROM
                       (
                         SELECT
-                          coalesce(json_agg(row_to_json("%7_rows")), '[]') AS "rows"
+                          coalesce(json_agg(row_to_json("%10_rows")), '[]') AS "rows"
                         FROM
                           (
                             SELECT
-                              "%6_Album"."Title" AS "title"
+                              "%9_Album"."Title" AS "title"
                             FROM
-                              "public"."Album" AS "%6_Album"
-                            WHERE
-                              ("%0_Artist"."ArtistId" = "%6_Album"."ArtistId")
-                          ) AS "%7_rows"
-                      ) AS "%7_rows"
-                  ) AS "%2_RELATIONSHIP_Albums"
-              ) AS "%2_RELATIONSHIP_Albums" ON ('true')
-            LIMIT
-              5
-          ) AS "%10_rows"
-      ) AS "%10_rows"
-  ) AS "%9_universe";
+                              (
+                                SELECT
+                                  "%8_Album".*
+                                FROM
+                                  "public"."Album" AS "%8_Album"
+                                WHERE
+                                  ("%1_Artist"."ArtistId" = "%8_Album"."ArtistId")
+                              ) AS "%9_Album"
+                          ) AS "%10_rows"
+                      ) AS "%10_rows"
+                  ) AS "%3_RELATIONSHIP_Albums"
+              ) AS "%3_RELATIONSHIP_Albums" ON ('true')
+          ) AS "%13_rows"
+      ) AS "%13_rows"
+  ) AS "%12_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__it_aggregate_count_albums.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__it_aggregate_count_albums.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%3_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%4_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,20 +11,25 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Album"."Title" AS "Title"
+              "%1_Album"."Title" AS "Title"
             FROM
-              "public"."Album" AS "%0_Album"
-            LIMIT
-              5 OFFSET 3
-          ) AS "%4_rows"
-      ) AS "%4_rows"
+              (
+                SELECT
+                  "%0_Album".*
+                FROM
+                  "public"."Album" AS "%0_Album"
+                LIMIT
+                  5 OFFSET 3
+              ) AS "%1_Album"
+          ) AS "%5_rows"
+      ) AS "%5_rows"
       CROSS JOIN (
         SELECT
-          coalesce(row_to_json("%5_aggregates"), '[]') AS "aggregates"
+          coalesce(row_to_json("%6_aggregates"), '[]') AS "aggregates"
         FROM
           (
             SELECT
@@ -32,14 +37,14 @@ FROM
             FROM
               (
                 SELECT
-                  "%1_Album".*
+                  "%2_Album".*
                 FROM
-                  "public"."Album" AS "%1_Album"
+                  "public"."Album" AS "%2_Album"
                 LIMIT
                   5 OFFSET 3
-              ) AS "%2_Album"
-          ) AS "%5_aggregates"
-      ) AS "%5_aggregates"
-  ) AS "%3_universe";
+              ) AS "%3_Album"
+          ) AS "%6_aggregates"
+      ) AS "%6_aggregates"
+  ) AS "%4_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__it_aggregate_distinct_albums.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__it_aggregate_distinct_albums.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%3_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%4_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,20 +11,20 @@ FROM
     FROM
       (
         SELECT
-          coalesce(row_to_json("%5_aggregates"), '[]') AS "aggregates"
+          coalesce(row_to_json("%6_aggregates"), '[]') AS "aggregates"
         FROM
           (
             SELECT
-              COUNT(DISTINCT "%2_Album"."ArtistId") AS "how_many_distinct_artist_ids"
+              COUNT(DISTINCT "%3_Album"."ArtistId") AS "how_many_distinct_artist_ids"
             FROM
               (
                 SELECT
-                  "%1_Album".*
+                  "%2_Album".*
                 FROM
-                  "public"."Album" AS "%1_Album"
-              ) AS "%2_Album"
-          ) AS "%5_aggregates"
-      ) AS "%5_aggregates"
-  ) AS "%3_universe";
+                  "public"."Album" AS "%2_Album"
+              ) AS "%3_Album"
+          ) AS "%6_aggregates"
+      ) AS "%6_aggregates"
+  ) AS "%4_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__it_aggregate_function_albums.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__it_aggregate_function_albums.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%3_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%4_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,20 +11,20 @@ FROM
     FROM
       (
         SELECT
-          coalesce(row_to_json("%5_aggregates"), '[]') AS "aggregates"
+          coalesce(row_to_json("%6_aggregates"), '[]') AS "aggregates"
         FROM
           (
             SELECT
-              max("%2_Album"."ArtistId") AS "max_artist_id"
+              max("%3_Album"."ArtistId") AS "max_artist_id"
             FROM
               (
                 SELECT
-                  "%1_Album".*
+                  "%2_Album".*
                 FROM
-                  "public"."Album" AS "%1_Album"
-              ) AS "%2_Album"
-          ) AS "%5_aggregates"
-      ) AS "%5_aggregates"
-  ) AS "%3_universe";
+                  "public"."Album" AS "%2_Album"
+              ) AS "%3_Album"
+          ) AS "%6_aggregates"
+      ) AS "%6_aggregates"
+  ) AS "%4_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__it_converts_select_with_limit.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__it_converts_select_with_limit.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%1_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,17 +11,22 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%2_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Album"."Title" AS "Title"
+              "%1_Album"."Title" AS "Title"
             FROM
-              "public"."Album" AS "%0_Album"
-            LIMIT
-              5 OFFSET 3
-          ) AS "%2_rows"
-      ) AS "%2_rows"
-  ) AS "%1_universe";
+              (
+                SELECT
+                  "%0_Album".*
+                FROM
+                  "public"."Album" AS "%0_Album"
+                LIMIT
+                  5 OFFSET 3
+              ) AS "%1_Album"
+          ) AS "%3_rows"
+      ) AS "%3_rows"
+  ) AS "%2_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__it_select_where_in_variable.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__it_select_where_in_variable.snap
@@ -3,16 +3,16 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg("%8_universe_agg"."universe"), '[]') AS "universe"
+  coalesce(json_agg("%9_universe_agg"."universe"), '[]') AS "universe"
 FROM
   (
     SELECT
-      row_to_json("%5_universe") AS "universe"
+      row_to_json("%6_universe") AS "universe"
     FROM
       jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" "int4", "%variables" "jsonb")
       CROSS JOIN LATERAL (
         WITH "%2_NATIVE_QUERY_array_series" AS (
-          WITH "%9_NATIVE_QUERY_array_series" AS (
+          WITH "%10_NATIVE_QUERY_array_series" AS (
             SELECT
               3 as three,
               array_agg(arr.series) AS series
@@ -27,33 +27,37 @@ FROM
                       SELECT
                         *
                       FROM
-                        "%9_NATIVE_QUERY_array_series" AS "%10_NATIVE_QUERY_array_series"
+                        "%10_NATIVE_QUERY_array_series" AS "%11_NATIVE_QUERY_array_series"
                     )
                     SELECT
                       *
                     FROM
                       (
                         SELECT
-                          coalesce(json_agg(row_to_json("%6_rows")), '[]') AS "rows"
+                          coalesce(json_agg(row_to_json("%7_rows")), '[]') AS "rows"
                         FROM
                           (
                             SELECT
-                              "%1_array_series"."series" AS "series"
+                              "%5_array_series"."series" AS "series"
                             FROM
-                              "%2_NATIVE_QUERY_array_series" AS "%1_array_series"
-                            WHERE
                               (
-                                "%1_array_series"."three" IN (
-                                  SELECT
-                                    "%4_in_subquery"."value" AS "value"
-                                  FROM
-                                    UNNEST(
-                                      (
-                                        SELECT
-                                          array_agg(
-                                            cast(
-                                              (
-                                                "%3_array"."element" #>> cast(ARRAY [] as "text"[])) as "pg_catalog"."int4")) AS "element" FROM jsonb_array_elements(("%0_%variables_table"."%variables" -> $4)) AS "%3_array"("element"))) AS "%4_in_subquery"("value")))) AS "%6_rows") AS "%6_rows") AS "%5_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%8_universe_agg";
+                                SELECT
+                                  "%1_array_series".*
+                                FROM
+                                  "%2_NATIVE_QUERY_array_series" AS "%1_array_series"
+                                WHERE
+                                  (
+                                    "%1_array_series"."three" IN (
+                                      SELECT
+                                        "%4_in_subquery"."value" AS "value"
+                                      FROM
+                                        UNNEST(
+                                          (
+                                            SELECT
+                                              array_agg(
+                                                cast(
+                                                  (
+                                                    "%3_array"."element" #>> cast(ARRAY [] as "text"[])) as "pg_catalog"."int4")) AS "element" FROM jsonb_array_elements(("%0_%variables_table"."%variables" -> $4)) AS "%3_array"("element"))) AS "%4_in_subquery"("value")))) AS "%5_array_series") AS "%7_rows") AS "%7_rows") AS "%6_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%9_universe_agg";
 
 {
     1: Variable(

--- a/crates/query-engine/translation/tests/snapshots/tests__it_select_where_not_null.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__it_select_where_not_null.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%1_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,19 +11,24 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%2_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Album"."Title" AS "Title"
+              "%1_Album"."Title" AS "Title"
             FROM
-              "public"."Album" AS "%0_Album"
-            WHERE
-              NOT ("%0_Album"."AlbumId" IS NULL)
-            LIMIT
-              5 OFFSET 100
-          ) AS "%2_rows"
-      ) AS "%2_rows"
-  ) AS "%1_universe";
+              (
+                SELECT
+                  "%0_Album".*
+                FROM
+                  "public"."Album" AS "%0_Album"
+                WHERE
+                  NOT ("%0_Album"."AlbumId" IS NULL)
+                LIMIT
+                  5 OFFSET 100
+              ) AS "%1_Album"
+          ) AS "%3_rows"
+      ) AS "%3_rows"
+  ) AS "%2_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__it_select_where_prefix_function.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__it_select_where_prefix_function.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%1_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,17 +11,22 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%2_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Album"."AlbumId" AS "Id"
+              "%1_Album"."AlbumId" AS "Id"
             FROM
-              "public"."Album" AS "%0_Album"
-            WHERE
-              some_prefix_function("%0_Album"."AlbumId", 10)
-          ) AS "%2_rows"
-      ) AS "%2_rows"
-  ) AS "%1_universe";
+              (
+                SELECT
+                  "%0_Album".*
+                FROM
+                  "public"."Album" AS "%0_Album"
+                WHERE
+                  some_prefix_function("%0_Album"."AlbumId", 10)
+              ) AS "%1_Album"
+          ) AS "%3_rows"
+      ) AS "%3_rows"
+  ) AS "%2_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__it_select_where_related_exists.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__it_select_where_related_exists.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%6_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%8_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,17 +11,36 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%7_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%9_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_artist"."Name" AS "title",
-              "%1_RELATIONSHIP_albums"."albums" AS "albums"
+              "%2_artist"."Name" AS "title",
+              "%3_RELATIONSHIP_albums"."albums" AS "albums"
             FROM
-              "public"."Artist" AS "%0_artist"
+              (
+                SELECT
+                  "%0_artist".*
+                FROM
+                  "public"."Artist" AS "%0_artist"
+                WHERE
+                  EXISTS (
+                    SELECT
+                      1 AS "one"
+                    FROM
+                      "public"."Album" AS "%1_album"
+                    WHERE
+                      (
+                        (
+                          "%1_album"."Title" LIKE cast($1 as "pg_catalog"."varchar")
+                        )
+                        AND ("%0_artist"."ArtistId" = "%1_album"."ArtistId")
+                      )
+                  )
+              ) AS "%2_artist"
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  row_to_json("%1_RELATIONSHIP_albums") AS "albums"
+                  row_to_json("%3_RELATIONSHIP_albums") AS "albums"
                 FROM
                   (
                     SELECT
@@ -29,36 +48,27 @@ FROM
                     FROM
                       (
                         SELECT
-                          coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
+                          coalesce(json_agg(row_to_json("%6_rows")), '[]') AS "rows"
                         FROM
                           (
                             SELECT
-                              "%3_album"."Title" AS "title"
+                              "%5_album"."Title" AS "title"
                             FROM
-                              "public"."Album" AS "%3_album"
-                            WHERE
-                              ("%0_artist"."ArtistId" = "%3_album"."ArtistId")
-                          ) AS "%4_rows"
-                      ) AS "%4_rows"
-                  ) AS "%1_RELATIONSHIP_albums"
-              ) AS "%1_RELATIONSHIP_albums" ON ('true')
-            WHERE
-              EXISTS (
-                SELECT
-                  1 AS "one"
-                FROM
-                  "public"."Album" AS "%2_album"
-                WHERE
-                  (
-                    (
-                      "%2_album"."Title" LIKE cast($1 as "pg_catalog"."varchar")
-                    )
-                    AND ("%0_artist"."ArtistId" = "%2_album"."ArtistId")
-                  )
-              )
-          ) AS "%7_rows"
-      ) AS "%7_rows"
-  ) AS "%6_universe";
+                              (
+                                SELECT
+                                  "%4_album".*
+                                FROM
+                                  "public"."Album" AS "%4_album"
+                                WHERE
+                                  ("%2_artist"."ArtistId" = "%4_album"."ArtistId")
+                              ) AS "%5_album"
+                          ) AS "%6_rows"
+                      ) AS "%6_rows"
+                  ) AS "%3_RELATIONSHIP_albums"
+              ) AS "%3_RELATIONSHIP_albums" ON ('true')
+          ) AS "%9_rows"
+      ) AS "%9_rows"
+  ) AS "%8_universe";
 
 {
     1: String(

--- a/crates/query-engine/translation/tests/snapshots/tests__it_select_where_string.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__it_select_where_string.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%1_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,23 +11,28 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%2_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Album"."AlbumId" AS "AlbumId"
+              "%1_Album"."AlbumId" AS "AlbumId"
             FROM
-              "public"."Album" AS "%0_Album"
-            WHERE
               (
-                "%0_Album"."Title" IN (
-                  cast($1 as "pg_catalog"."varchar"),
-                  cast($2 as "pg_catalog"."varchar")
-                )
-              )
-          ) AS "%2_rows"
-      ) AS "%2_rows"
-  ) AS "%1_universe";
+                SELECT
+                  "%0_Album".*
+                FROM
+                  "public"."Album" AS "%0_Album"
+                WHERE
+                  (
+                    "%0_Album"."Title" IN (
+                      cast($1 as "pg_catalog"."varchar"),
+                      cast($2 as "pg_catalog"."varchar")
+                    )
+                  )
+              ) AS "%1_Album"
+          ) AS "%3_rows"
+      ) AS "%3_rows"
+  ) AS "%2_universe";
 
 {
     1: String(

--- a/crates/query-engine/translation/tests/snapshots/tests__it_select_where_unrelated_exists.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__it_select_where_unrelated_exists.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%3_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,30 +11,35 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_album"."Title" AS "title"
+              "%2_album"."Title" AS "title"
             FROM
-              "public"."Album" AS "%0_album"
-            WHERE
-              EXISTS (
+              (
                 SELECT
-                  1 AS "one"
+                  "%0_album".*
                 FROM
-                  "public"."Artist" AS "%1_artist"
+                  "public"."Album" AS "%0_album"
                 WHERE
-                  (
-                    (
-                      "%1_artist"."Name" = cast($1 as "pg_catalog"."varchar")
-                    )
-                    AND ("%0_album"."ArtistId" = "%1_artist"."ArtistId")
+                  EXISTS (
+                    SELECT
+                      1 AS "one"
+                    FROM
+                      "public"."Artist" AS "%1_artist"
+                    WHERE
+                      (
+                        (
+                          "%1_artist"."Name" = cast($1 as "pg_catalog"."varchar")
+                        )
+                        AND ("%0_album"."ArtistId" = "%1_artist"."ArtistId")
+                      )
                   )
-              )
-          ) AS "%3_rows"
-      ) AS "%3_rows"
-  ) AS "%2_universe";
+              ) AS "%2_album"
+          ) AS "%4_rows"
+      ) AS "%4_rows"
+  ) AS "%3_universe";
 
 {
     1: String(

--- a/crates/query-engine/translation/tests/snapshots/tests__it_simple_array_relationship.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__it_simple_array_relationship.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%5_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%7_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,16 +11,23 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%6_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%8_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%1_RELATIONSHIP_Albums"."Albums" AS "Albums"
+              "%2_RELATIONSHIP_Albums"."Albums" AS "Albums"
             FROM
-              "public"."Artist" AS "%0_Artist"
+              (
+                SELECT
+                  "%0_Artist".*
+                FROM
+                  "public"."Artist" AS "%0_Artist"
+                LIMIT
+                  5
+              ) AS "%1_Artist"
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  row_to_json("%1_RELATIONSHIP_Albums") AS "Albums"
+                  row_to_json("%2_RELATIONSHIP_Albums") AS "Albums"
                 FROM
                   (
                     SELECT
@@ -28,23 +35,26 @@ FROM
                     FROM
                       (
                         SELECT
-                          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
+                          coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
                         FROM
                           (
                             SELECT
-                              "%2_Album"."Title" AS "title"
+                              "%4_Album"."Title" AS "title"
                             FROM
-                              "public"."Album" AS "%2_Album"
-                            WHERE
-                              ("%0_Artist"."ArtistId" = "%2_Album"."ArtistId")
-                          ) AS "%3_rows"
-                      ) AS "%3_rows"
-                  ) AS "%1_RELATIONSHIP_Albums"
-              ) AS "%1_RELATIONSHIP_Albums" ON ('true')
-            LIMIT
-              5
-          ) AS "%6_rows"
-      ) AS "%6_rows"
-  ) AS "%5_universe";
+                              (
+                                SELECT
+                                  "%3_Album".*
+                                FROM
+                                  "public"."Album" AS "%3_Album"
+                                WHERE
+                                  ("%1_Artist"."ArtistId" = "%3_Album"."ArtistId")
+                              ) AS "%4_Album"
+                          ) AS "%5_rows"
+                      ) AS "%5_rows"
+                  ) AS "%2_RELATIONSHIP_Albums"
+              ) AS "%2_RELATIONSHIP_Albums" ON ('true')
+          ) AS "%8_rows"
+      ) AS "%8_rows"
+  ) AS "%7_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__it_simple_object_relationship.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__it_simple_object_relationship.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%5_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%7_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,16 +11,23 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%6_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%8_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%1_RELATIONSHIP_Artist"."Artist" AS "Artist"
+              "%2_RELATIONSHIP_Artist"."Artist" AS "Artist"
             FROM
-              "public"."Album" AS "%0_Album"
+              (
+                SELECT
+                  "%0_Album".*
+                FROM
+                  "public"."Album" AS "%0_Album"
+                LIMIT
+                  5
+              ) AS "%1_Album"
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  row_to_json("%1_RELATIONSHIP_Artist") AS "Artist"
+                  row_to_json("%2_RELATIONSHIP_Artist") AS "Artist"
                 FROM
                   (
                     SELECT
@@ -28,23 +35,26 @@ FROM
                     FROM
                       (
                         SELECT
-                          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
+                          coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
                         FROM
                           (
                             SELECT
-                              "%2_Artist"."Name" AS "Name"
+                              "%4_Artist"."Name" AS "Name"
                             FROM
-                              "public"."Artist" AS "%2_Artist"
-                            WHERE
-                              ("%0_Album"."ArtistId" = "%2_Artist"."ArtistId")
-                          ) AS "%3_rows"
-                      ) AS "%3_rows"
-                  ) AS "%1_RELATIONSHIP_Artist"
-              ) AS "%1_RELATIONSHIP_Artist" ON ('true')
-            LIMIT
-              5
-          ) AS "%6_rows"
-      ) AS "%6_rows"
-  ) AS "%5_universe";
+                              (
+                                SELECT
+                                  "%3_Artist".*
+                                FROM
+                                  "public"."Artist" AS "%3_Artist"
+                                WHERE
+                                  ("%1_Album"."ArtistId" = "%3_Artist"."ArtistId")
+                              ) AS "%4_Artist"
+                          ) AS "%5_rows"
+                      ) AS "%5_rows"
+                  ) AS "%2_RELATIONSHIP_Artist"
+              ) AS "%2_RELATIONSHIP_Artist" ON ('true')
+          ) AS "%8_rows"
+      ) AS "%8_rows"
+  ) AS "%7_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__mutations__simple.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__mutations__simple.snap
@@ -12,7 +12,7 @@ WITH "%0_NATIVE_QUERY_delete_playlist_track" AS (
     "TrackId" = 90 RETURNING *
 )
 SELECT
-  json_build_object('result', row_to_json("%4_universe"), 'type', $1) AS "universe"
+  json_build_object('result', row_to_json("%5_universe"), 'type', $1) AS "universe"
 FROM
   (
     SELECT
@@ -20,27 +20,32 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%5_returning")), '[]') AS "returning"
+          coalesce(json_agg(row_to_json("%6_returning")), '[]') AS "returning"
         FROM
           (
             SELECT
-              "%1_delete_playlist_track"."PlaylistId" AS "playlist_id"
+              "%2_delete_playlist_track"."PlaylistId" AS "playlist_id"
             FROM
-              "%0_NATIVE_QUERY_delete_playlist_track" AS "%1_delete_playlist_track"
-          ) AS "%5_returning"
-      ) AS "%5_returning"
+              (
+                SELECT
+                  "%1_delete_playlist_track".*
+                FROM
+                  "%0_NATIVE_QUERY_delete_playlist_track" AS "%1_delete_playlist_track"
+              ) AS "%2_delete_playlist_track"
+          ) AS "%6_returning"
+      ) AS "%6_returning"
       CROSS JOIN (
         SELECT
           COUNT(*) AS "affected_rows"
         FROM
           (
             SELECT
-              "%2_delete_playlist_track".*
+              "%3_delete_playlist_track".*
             FROM
-              "%0_NATIVE_QUERY_delete_playlist_track" AS "%2_delete_playlist_track"
-          ) AS "%3_delete_playlist_track"
-      ) AS "%6_aggregates"
-  ) AS "%4_universe";
+              "%0_NATIVE_QUERY_delete_playlist_track" AS "%3_delete_playlist_track"
+          ) AS "%4_delete_playlist_track"
+      ) AS "%7_aggregates"
+  ) AS "%5_universe";
 
 COMMIT;
 

--- a/crates/query-engine/translation/tests/snapshots/tests__mutations__v2_insert.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__mutations__v2_insert.snap
@@ -16,7 +16,7 @@ WITH "%0_generated_mutation" AS (
 SELECT
   (
     SELECT
-      json_build_object('result', row_to_json("%4_universe"), 'type', $3) AS "universe"
+      json_build_object('result', row_to_json("%5_universe"), 'type', $3) AS "universe"
     FROM
       (
         SELECT
@@ -24,37 +24,42 @@ SELECT
         FROM
           (
             SELECT
-              coalesce(json_agg(row_to_json("%5_returning")), '[]') AS "returning"
+              coalesce(json_agg(row_to_json("%6_returning")), '[]') AS "returning"
             FROM
               (
                 SELECT
-                  "%1_Artist"."ArtistId" AS "artist_id",
-                  "%1_Artist"."Name" AS "name"
+                  "%2_Artist"."ArtistId" AS "artist_id",
+                  "%2_Artist"."Name" AS "name"
                 FROM
-                  "%0_generated_mutation" AS "%1_Artist"
-              ) AS "%5_returning"
-          ) AS "%5_returning"
+                  (
+                    SELECT
+                      "%1_Artist".*
+                    FROM
+                      "%0_generated_mutation" AS "%1_Artist"
+                  ) AS "%2_Artist"
+              ) AS "%6_returning"
+          ) AS "%6_returning"
           CROSS JOIN (
             SELECT
               COUNT(*) AS "affected_rows"
             FROM
               (
                 SELECT
-                  "%2_Artist".*
+                  "%3_Artist".*
                 FROM
-                  "%0_generated_mutation" AS "%2_Artist"
-              ) AS "%3_Artist"
-          ) AS "%6_aggregates"
-      ) AS "%4_universe"
+                  "%0_generated_mutation" AS "%3_Artist"
+              ) AS "%4_Artist"
+          ) AS "%7_aggregates"
+      ) AS "%5_universe"
   ) AS "%results",
   (
     SELECT
       coalesce(
-        bool_and("%7_v2_insert_Artist"."%check__constraint"),
+        bool_and("%8_v2_insert_Artist"."%check__constraint"),
         true
       ) AS "%check__constraint"
     FROM
-      "%0_generated_mutation" AS "%7_v2_insert_Artist"
+      "%0_generated_mutation" AS "%8_v2_insert_Artist"
   ) AS "%check__constraint";
 
 COMMIT;

--- a/crates/query-engine/translation/tests/snapshots/tests__mutations__v2_insert.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__mutations__v2_insert.snap
@@ -20,7 +20,7 @@ WITH "%0_generated_mutation" AS (
 SELECT
   (
     SELECT
-      json_build_object('result', row_to_json("%5_universe"), 'type', $3) AS "universe"
+      json_build_object('result', row_to_json("%5_universe"), 'type', $4) AS "universe"
     FROM
       (
         SELECT

--- a/crates/query-engine/translation/tests/snapshots/tests__mutations__v2_insert_empty_objects.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__mutations__v2_insert_empty_objects.snap
@@ -16,7 +16,7 @@ WITH "%0_generated_mutation" AS (
 SELECT
   (
     SELECT
-      json_build_object('result', row_to_json("%4_universe"), 'type', $1) AS "universe"
+      json_build_object('result', row_to_json("%5_universe"), 'type', $1) AS "universe"
     FROM
       (
         SELECT
@@ -24,37 +24,42 @@ SELECT
         FROM
           (
             SELECT
-              coalesce(json_agg(row_to_json("%5_returning")), '[]') AS "returning"
+              coalesce(json_agg(row_to_json("%6_returning")), '[]') AS "returning"
             FROM
               (
                 SELECT
-                  "%1_Dog"."id" AS "id",
-                  "%1_Dog"."adopter_name" AS "adopter_name"
+                  "%2_Dog"."id" AS "id",
+                  "%2_Dog"."adopter_name" AS "adopter_name"
                 FROM
-                  "%0_generated_mutation" AS "%1_Dog"
-              ) AS "%5_returning"
-          ) AS "%5_returning"
+                  (
+                    SELECT
+                      "%1_Dog".*
+                    FROM
+                      "%0_generated_mutation" AS "%1_Dog"
+                  ) AS "%2_Dog"
+              ) AS "%6_returning"
+          ) AS "%6_returning"
           CROSS JOIN (
             SELECT
               COUNT(*) AS "affected_rows"
             FROM
               (
                 SELECT
-                  "%2_Dog".*
+                  "%3_Dog".*
                 FROM
-                  "%0_generated_mutation" AS "%2_Dog"
-              ) AS "%3_Dog"
-          ) AS "%6_aggregates"
-      ) AS "%4_universe"
+                  "%0_generated_mutation" AS "%3_Dog"
+              ) AS "%4_Dog"
+          ) AS "%7_aggregates"
+      ) AS "%5_universe"
   ) AS "%results",
   (
     SELECT
       coalesce(
-        bool_and("%7_v2_insert_Dog"."%check__constraint"),
+        bool_and("%8_v2_insert_Dog"."%check__constraint"),
         true
       ) AS "%check__constraint"
     FROM
-      "%0_generated_mutation" AS "%7_v2_insert_Dog"
+      "%0_generated_mutation" AS "%8_v2_insert_Dog"
   ) AS "%check__constraint";
 
 COMMIT;

--- a/crates/query-engine/translation/tests/snapshots/tests__mutations__v2_update_by_id.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__mutations__v2_update_by_id.snap
@@ -18,7 +18,7 @@ WITH "%0_generated_mutation" AS (
 SELECT
   (
     SELECT
-      json_build_object('result', row_to_json("%4_universe"), 'type', $1) AS "universe"
+      json_build_object('result', row_to_json("%5_universe"), 'type', $1) AS "universe"
     FROM
       (
         SELECT
@@ -26,37 +26,42 @@ SELECT
         FROM
           (
             SELECT
-              coalesce(json_agg(row_to_json("%5_returning")), '[]') AS "returning"
+              coalesce(json_agg(row_to_json("%6_returning")), '[]') AS "returning"
             FROM
               (
                 SELECT
-                  "%1_Dog"."id" AS "id",
-                  "%1_Dog"."adopter_name" AS "adopter_name"
+                  "%2_Dog"."id" AS "id",
+                  "%2_Dog"."adopter_name" AS "adopter_name"
                 FROM
-                  "%0_generated_mutation" AS "%1_Dog"
-              ) AS "%5_returning"
-          ) AS "%5_returning"
+                  (
+                    SELECT
+                      "%1_Dog".*
+                    FROM
+                      "%0_generated_mutation" AS "%1_Dog"
+                  ) AS "%2_Dog"
+              ) AS "%6_returning"
+          ) AS "%6_returning"
           CROSS JOIN (
             SELECT
               COUNT(*) AS "affected_rows"
             FROM
               (
                 SELECT
-                  "%2_Dog".*
+                  "%3_Dog".*
                 FROM
-                  "%0_generated_mutation" AS "%2_Dog"
-              ) AS "%3_Dog"
-          ) AS "%6_aggregates"
-      ) AS "%4_universe"
+                  "%0_generated_mutation" AS "%3_Dog"
+              ) AS "%4_Dog"
+          ) AS "%7_aggregates"
+      ) AS "%5_universe"
   ) AS "%results",
   (
     SELECT
       coalesce(
-        bool_and("%7_v2_update_Dog_by_id"."%check__constraint"),
+        bool_and("%8_v2_update_Dog_by_id"."%check__constraint"),
         true
       ) AS "%check__constraint"
     FROM
-      "%0_generated_mutation" AS "%7_v2_update_Dog_by_id"
+      "%0_generated_mutation" AS "%8_v2_update_Dog_by_id"
   ) AS "%check__constraint";
 
 COMMIT;

--- a/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 WITH "%1_NATIVE_QUERY_artist" AS (
-  WITH "%6_NATIVE_QUERY_artist" AS (
+  WITH "%7_NATIVE_QUERY_artist" AS (
     SELECT
       *
     FROM
@@ -12,10 +12,10 @@ WITH "%1_NATIVE_QUERY_artist" AS (
   SELECT
     *
   FROM
-    "%6_NATIVE_QUERY_artist" AS "%7_NATIVE_QUERY_artist"
+    "%7_NATIVE_QUERY_artist" AS "%8_NATIVE_QUERY_artist"
 )
 SELECT
-  coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%3_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -23,15 +23,20 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_artist"."Name" AS "Name"
+              "%2_artist"."Name" AS "Name"
             FROM
-              "%1_NATIVE_QUERY_artist" AS "%0_artist"
-          ) AS "%3_rows"
-      ) AS "%3_rows"
-  ) AS "%2_universe";
+              (
+                SELECT
+                  "%0_artist".*
+                FROM
+                  "%1_NATIVE_QUERY_artist" AS "%0_artist"
+              ) AS "%2_artist"
+          ) AS "%4_rows"
+      ) AS "%4_rows"
+  ) AS "%3_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_by_id.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_by_id.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 WITH "%1_NATIVE_QUERY_artist_by_id" AS (
-  WITH "%6_NATIVE_QUERY_artist_by_id" AS (
+  WITH "%7_NATIVE_QUERY_artist_by_id" AS (
     SELECT
       *
     FROM
@@ -14,10 +14,10 @@ WITH "%1_NATIVE_QUERY_artist_by_id" AS (
   SELECT
     *
   FROM
-    "%6_NATIVE_QUERY_artist_by_id" AS "%7_NATIVE_QUERY_artist_by_id"
+    "%7_NATIVE_QUERY_artist_by_id" AS "%8_NATIVE_QUERY_artist_by_id"
 )
 SELECT
-  coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%3_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -25,15 +25,20 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_artist_by_id"."Name" AS "Name"
+              "%2_artist_by_id"."Name" AS "Name"
             FROM
-              "%1_NATIVE_QUERY_artist_by_id" AS "%0_artist_by_id"
-          ) AS "%3_rows"
-      ) AS "%3_rows"
-  ) AS "%2_universe";
+              (
+                SELECT
+                  "%0_artist_by_id".*
+                FROM
+                  "%1_NATIVE_QUERY_artist_by_id" AS "%0_artist_by_id"
+              ) AS "%2_artist_by_id"
+          ) AS "%4_rows"
+      ) AS "%4_rows"
+  ) AS "%3_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_by_name.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_by_name.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 WITH "%1_NATIVE_QUERY_artist_by_name" AS (
-  WITH "%6_NATIVE_QUERY_artist_by_name" AS (
+  WITH "%7_NATIVE_QUERY_artist_by_name" AS (
     SELECT
       *
     FROM
@@ -14,10 +14,10 @@ WITH "%1_NATIVE_QUERY_artist_by_name" AS (
   SELECT
     *
   FROM
-    "%6_NATIVE_QUERY_artist_by_name" AS "%7_NATIVE_QUERY_artist_by_name"
+    "%7_NATIVE_QUERY_artist_by_name" AS "%8_NATIVE_QUERY_artist_by_name"
 )
 SELECT
-  coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%3_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -25,16 +25,21 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_artist_by_name"."ArtistId" AS "Id"
+              "%2_artist_by_name"."ArtistId" AS "Id"
             FROM
-              "%1_NATIVE_QUERY_artist_by_name" AS "%0_artist_by_name"
-          ) AS "%3_rows"
-      ) AS "%3_rows"
-  ) AS "%2_universe";
+              (
+                SELECT
+                  "%0_artist_by_name".*
+                FROM
+                  "%1_NATIVE_QUERY_artist_by_name" AS "%0_artist_by_name"
+              ) AS "%2_artist_by_name"
+          ) AS "%4_rows"
+      ) AS "%4_rows"
+  ) AS "%3_universe";
 
 {
     1: String(

--- a/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_with_album_by_title.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_with_album_by_title.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 WITH "%1_NATIVE_QUERY_artist" AS (
-  WITH "%11_NATIVE_QUERY_artist" AS (
+  WITH "%13_NATIVE_QUERY_artist" AS (
     SELECT
       *
     FROM
@@ -12,10 +12,10 @@ WITH "%1_NATIVE_QUERY_artist" AS (
   SELECT
     *
   FROM
-    "%11_NATIVE_QUERY_artist" AS "%12_NATIVE_QUERY_artist"
+    "%13_NATIVE_QUERY_artist" AS "%14_NATIVE_QUERY_artist"
 ),
-"%4_NATIVE_QUERY_album_by_title" AS (
-  WITH "%13_NATIVE_QUERY_album_by_title" AS (
+"%5_NATIVE_QUERY_album_by_title" AS (
+  WITH "%15_NATIVE_QUERY_album_by_title" AS (
     SELECT
       *
     FROM
@@ -26,10 +26,10 @@ WITH "%1_NATIVE_QUERY_artist" AS (
   SELECT
     *
   FROM
-    "%13_NATIVE_QUERY_album_by_title" AS "%14_NATIVE_QUERY_album_by_title"
+    "%15_NATIVE_QUERY_album_by_title" AS "%16_NATIVE_QUERY_album_by_title"
 )
 SELECT
-  coalesce(json_agg(row_to_json("%7_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%9_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -37,17 +37,26 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%8_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%10_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_artist"."Name" AS "Name",
-              "%2_RELATIONSHIP_Albums"."Albums" AS "Albums"
+              "%2_artist"."Name" AS "Name",
+              "%3_RELATIONSHIP_Albums"."Albums" AS "Albums"
             FROM
-              "%1_NATIVE_QUERY_artist" AS "%0_artist"
+              (
+                SELECT
+                  "%0_artist".*
+                FROM
+                  "%1_NATIVE_QUERY_artist" AS "%0_artist"
+                ORDER BY
+                  "%0_artist"."ArtistId" ASC
+                LIMIT
+                  5
+              ) AS "%2_artist"
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  row_to_json("%2_RELATIONSHIP_Albums") AS "Albums"
+                  row_to_json("%3_RELATIONSHIP_Albums") AS "Albums"
                 FROM
                   (
                     SELECT
@@ -55,28 +64,29 @@ FROM
                     FROM
                       (
                         SELECT
-                          coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
+                          coalesce(json_agg(row_to_json("%7_rows")), '[]') AS "rows"
                         FROM
                           (
                             SELECT
-                              "%3_album_by_title"."Title" AS "title"
+                              "%6_album_by_title"."Title" AS "title"
                             FROM
-                              "%4_NATIVE_QUERY_album_by_title" AS "%3_album_by_title"
-                            WHERE
                               (
-                                "%0_artist"."ArtistId" = "%3_album_by_title"."ArtistId"
-                              )
-                          ) AS "%5_rows"
-                      ) AS "%5_rows"
-                  ) AS "%2_RELATIONSHIP_Albums"
-              ) AS "%2_RELATIONSHIP_Albums" ON ('true')
-            ORDER BY
-              "%0_artist"."ArtistId" ASC
-            LIMIT
-              5
-          ) AS "%8_rows"
-      ) AS "%8_rows"
-  ) AS "%7_universe";
+                                SELECT
+                                  "%4_album_by_title".*
+                                FROM
+                                  "%5_NATIVE_QUERY_album_by_title" AS "%4_album_by_title"
+                                WHERE
+                                  (
+                                    "%2_artist"."ArtistId" = "%4_album_by_title"."ArtistId"
+                                  )
+                              ) AS "%6_album_by_title"
+                          ) AS "%7_rows"
+                      ) AS "%7_rows"
+                  ) AS "%3_RELATIONSHIP_Albums"
+              ) AS "%3_RELATIONSHIP_Albums" ON ('true')
+          ) AS "%10_rows"
+      ) AS "%10_rows"
+  ) AS "%9_universe";
 
 {
     1: String(

--- a/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_with_album_by_title_relationship_arguments.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_with_album_by_title_relationship_arguments.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 WITH "%1_NATIVE_QUERY_artist" AS (
-  WITH "%11_NATIVE_QUERY_artist" AS (
+  WITH "%13_NATIVE_QUERY_artist" AS (
     SELECT
       *
     FROM
@@ -12,10 +12,10 @@ WITH "%1_NATIVE_QUERY_artist" AS (
   SELECT
     *
   FROM
-    "%11_NATIVE_QUERY_artist" AS "%12_NATIVE_QUERY_artist"
+    "%13_NATIVE_QUERY_artist" AS "%14_NATIVE_QUERY_artist"
 ),
-"%4_NATIVE_QUERY_album_by_title" AS (
-  WITH "%13_NATIVE_QUERY_album_by_title" AS (
+"%5_NATIVE_QUERY_album_by_title" AS (
+  WITH "%15_NATIVE_QUERY_album_by_title" AS (
     SELECT
       *
     FROM
@@ -27,10 +27,10 @@ WITH "%1_NATIVE_QUERY_artist" AS (
   SELECT
     *
   FROM
-    "%13_NATIVE_QUERY_album_by_title" AS "%14_NATIVE_QUERY_album_by_title"
+    "%15_NATIVE_QUERY_album_by_title" AS "%16_NATIVE_QUERY_album_by_title"
 )
 SELECT
-  coalesce(json_agg(row_to_json("%7_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%9_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -38,17 +38,26 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%8_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%10_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_artist"."Name" AS "Name",
-              "%2_RELATIONSHIP_Albums"."Albums" AS "Albums"
+              "%2_artist"."Name" AS "Name",
+              "%3_RELATIONSHIP_Albums"."Albums" AS "Albums"
             FROM
-              "%1_NATIVE_QUERY_artist" AS "%0_artist"
+              (
+                SELECT
+                  "%0_artist".*
+                FROM
+                  "%1_NATIVE_QUERY_artist" AS "%0_artist"
+                ORDER BY
+                  "%0_artist"."ArtistId" ASC
+                LIMIT
+                  5
+              ) AS "%2_artist"
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  row_to_json("%2_RELATIONSHIP_Albums") AS "Albums"
+                  row_to_json("%3_RELATIONSHIP_Albums") AS "Albums"
                 FROM
                   (
                     SELECT
@@ -56,30 +65,31 @@ FROM
                     FROM
                       (
                         SELECT
-                          coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
+                          coalesce(json_agg(row_to_json("%7_rows")), '[]') AS "rows"
                         FROM
                           (
                             SELECT
-                              "%3_album_by_title"."Title" AS "title"
+                              "%6_album_by_title"."Title" AS "title"
                             FROM
-                              "%4_NATIVE_QUERY_album_by_title" AS "%3_album_by_title"
-                            WHERE
                               (
-                                "%0_artist"."ArtistId" = "%3_album_by_title"."ArtistId"
-                              )
-                            ORDER BY
-                              "%3_album_by_title"."AlbumId" ASC
-                          ) AS "%5_rows"
-                      ) AS "%5_rows"
-                  ) AS "%2_RELATIONSHIP_Albums"
-              ) AS "%2_RELATIONSHIP_Albums" ON ('true')
-            ORDER BY
-              "%0_artist"."ArtistId" ASC
-            LIMIT
-              5
-          ) AS "%8_rows"
-      ) AS "%8_rows"
-  ) AS "%7_universe";
+                                SELECT
+                                  "%4_album_by_title".*
+                                FROM
+                                  "%5_NATIVE_QUERY_album_by_title" AS "%4_album_by_title"
+                                WHERE
+                                  (
+                                    "%2_artist"."ArtistId" = "%4_album_by_title"."ArtistId"
+                                  )
+                                ORDER BY
+                                  "%4_album_by_title"."AlbumId" ASC
+                              ) AS "%6_album_by_title"
+                          ) AS "%7_rows"
+                      ) AS "%7_rows"
+                  ) AS "%3_RELATIONSHIP_Albums"
+              ) AS "%3_RELATIONSHIP_Albums" ON ('true')
+          ) AS "%10_rows"
+      ) AS "%10_rows"
+  ) AS "%9_universe";
 
 {
     1: String(

--- a/crates/query-engine/translation/tests/snapshots/tests__nested_aggregates.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__nested_aggregates.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%7_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%9_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,17 +11,24 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%8_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%10_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Artist"."Name" AS "Name",
-              "%1_RELATIONSHIP_Albums"."Albums" AS "Albums"
+              "%1_Artist"."Name" AS "Name",
+              "%2_RELATIONSHIP_Albums"."Albums" AS "Albums"
             FROM
-              "public"."Artist" AS "%0_Artist"
+              (
+                SELECT
+                  "%0_Artist".*
+                FROM
+                  "public"."Artist" AS "%0_Artist"
+                LIMIT
+                  5 OFFSET 1
+              ) AS "%1_Artist"
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  row_to_json("%1_RELATIONSHIP_Albums") AS "Albums"
+                  row_to_json("%2_RELATIONSHIP_Albums") AS "Albums"
                 FROM
                   (
                     SELECT
@@ -29,24 +36,11 @@ FROM
                     FROM
                       (
                         SELECT
-                          coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
+                          coalesce(json_agg(row_to_json("%7_rows")), '[]') AS "rows"
                         FROM
                           (
                             SELECT
-                              "%2_Album"."Title" AS "Title"
-                            FROM
-                              "public"."Album" AS "%2_Album"
-                            WHERE
-                              ("%0_Artist"."ArtistId" = "%2_Album"."ArtistId")
-                          ) AS "%5_rows"
-                      ) AS "%5_rows"
-                      CROSS JOIN (
-                        SELECT
-                          coalesce(row_to_json("%6_aggregates"), '[]') AS "aggregates"
-                        FROM
-                          (
-                            SELECT
-                              COUNT(*) AS "how_many_albums"
+                              "%4_Album"."Title" AS "Title"
                             FROM
                               (
                                 SELECT
@@ -54,16 +48,32 @@ FROM
                                 FROM
                                   "public"."Album" AS "%3_Album"
                                 WHERE
-                                  ("%0_Artist"."ArtistId" = "%3_Album"."ArtistId")
+                                  ("%1_Artist"."ArtistId" = "%3_Album"."ArtistId")
                               ) AS "%4_Album"
-                          ) AS "%6_aggregates"
-                      ) AS "%6_aggregates"
-                  ) AS "%1_RELATIONSHIP_Albums"
-              ) AS "%1_RELATIONSHIP_Albums" ON ('true')
-            LIMIT
-              5 OFFSET 1
-          ) AS "%8_rows"
-      ) AS "%8_rows"
-  ) AS "%7_universe";
+                          ) AS "%7_rows"
+                      ) AS "%7_rows"
+                      CROSS JOIN (
+                        SELECT
+                          coalesce(row_to_json("%8_aggregates"), '[]') AS "aggregates"
+                        FROM
+                          (
+                            SELECT
+                              COUNT(*) AS "how_many_albums"
+                            FROM
+                              (
+                                SELECT
+                                  "%5_Album".*
+                                FROM
+                                  "public"."Album" AS "%5_Album"
+                                WHERE
+                                  ("%1_Artist"."ArtistId" = "%5_Album"."ArtistId")
+                              ) AS "%6_Album"
+                          ) AS "%8_aggregates"
+                      ) AS "%8_aggregates"
+                  ) AS "%2_RELATIONSHIP_Albums"
+              ) AS "%2_RELATIONSHIP_Albums" ON ('true')
+          ) AS "%10_rows"
+      ) AS "%10_rows"
+  ) AS "%9_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__nested_array_relationships.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__nested_array_relationships.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%9_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%12_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,16 +11,21 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%10_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%13_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%1_RELATIONSHIP_Albums"."Albums" AS "Albums"
+              "%2_RELATIONSHIP_Albums"."Albums" AS "Albums"
             FROM
-              "public"."Artist" AS "%0_Artist"
+              (
+                SELECT
+                  "%0_Artist".*
+                FROM
+                  "public"."Artist" AS "%0_Artist"
+              ) AS "%1_Artist"
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  row_to_json("%1_RELATIONSHIP_Albums") AS "Albums"
+                  row_to_json("%2_RELATIONSHIP_Albums") AS "Albums"
                 FROM
                   (
                     SELECT
@@ -28,16 +33,23 @@ FROM
                     FROM
                       (
                         SELECT
-                          coalesce(json_agg(row_to_json("%7_rows")), '[]') AS "rows"
+                          coalesce(json_agg(row_to_json("%10_rows")), '[]') AS "rows"
                         FROM
                           (
                             SELECT
-                              "%3_RELATIONSHIP_Tracks"."Tracks" AS "Tracks"
+                              "%5_RELATIONSHIP_Tracks"."Tracks" AS "Tracks"
                             FROM
-                              "public"."Album" AS "%2_Album"
+                              (
+                                SELECT
+                                  "%3_Album".*
+                                FROM
+                                  "public"."Album" AS "%3_Album"
+                                WHERE
+                                  ("%1_Artist"."ArtistId" = "%3_Album"."ArtistId")
+                              ) AS "%4_Album"
                               LEFT OUTER JOIN LATERAL (
                                 SELECT
-                                  row_to_json("%3_RELATIONSHIP_Tracks") AS "Tracks"
+                                  row_to_json("%5_RELATIONSHIP_Tracks") AS "Tracks"
                                 FROM
                                   (
                                     SELECT
@@ -45,27 +57,30 @@ FROM
                                     FROM
                                       (
                                         SELECT
-                                          coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
+                                          coalesce(json_agg(row_to_json("%8_rows")), '[]') AS "rows"
                                         FROM
                                           (
                                             SELECT
-                                              "%4_Track"."Name" AS "name"
+                                              "%7_Track"."Name" AS "name"
                                             FROM
-                                              "public"."Track" AS "%4_Track"
-                                            WHERE
-                                              ("%2_Album"."AlbumId" = "%4_Track"."AlbumId")
-                                          ) AS "%5_rows"
-                                      ) AS "%5_rows"
-                                  ) AS "%3_RELATIONSHIP_Tracks"
-                              ) AS "%3_RELATIONSHIP_Tracks" ON ('true')
-                            WHERE
-                              ("%0_Artist"."ArtistId" = "%2_Album"."ArtistId")
-                          ) AS "%7_rows"
-                      ) AS "%7_rows"
-                  ) AS "%1_RELATIONSHIP_Albums"
-              ) AS "%1_RELATIONSHIP_Albums" ON ('true')
-          ) AS "%10_rows"
-      ) AS "%10_rows"
-  ) AS "%9_universe";
+                                              (
+                                                SELECT
+                                                  "%6_Track".*
+                                                FROM
+                                                  "public"."Track" AS "%6_Track"
+                                                WHERE
+                                                  ("%4_Album"."AlbumId" = "%6_Track"."AlbumId")
+                                              ) AS "%7_Track"
+                                          ) AS "%8_rows"
+                                      ) AS "%8_rows"
+                                  ) AS "%5_RELATIONSHIP_Tracks"
+                              ) AS "%5_RELATIONSHIP_Tracks" ON ('true')
+                          ) AS "%10_rows"
+                      ) AS "%10_rows"
+                  ) AS "%2_RELATIONSHIP_Albums"
+              ) AS "%2_RELATIONSHIP_Albums" ON ('true')
+          ) AS "%13_rows"
+      ) AS "%13_rows"
+  ) AS "%12_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__nested_recursive_relationship.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__nested_recursive_relationship.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%9_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%12_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,16 +11,21 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%10_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%13_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%1_RELATIONSHIP_Albums"."Albums" AS "Albums"
+              "%2_RELATIONSHIP_Albums"."Albums" AS "Albums"
             FROM
-              "public"."Artist" AS "%0_Artist"
+              (
+                SELECT
+                  "%0_Artist".*
+                FROM
+                  "public"."Artist" AS "%0_Artist"
+              ) AS "%1_Artist"
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  row_to_json("%1_RELATIONSHIP_Albums") AS "Albums"
+                  row_to_json("%2_RELATIONSHIP_Albums") AS "Albums"
                 FROM
                   (
                     SELECT
@@ -28,16 +33,23 @@ FROM
                     FROM
                       (
                         SELECT
-                          coalesce(json_agg(row_to_json("%7_rows")), '[]') AS "rows"
+                          coalesce(json_agg(row_to_json("%10_rows")), '[]') AS "rows"
                         FROM
                           (
                             SELECT
-                              "%3_RELATIONSHIP_Artist"."Artist" AS "Artist"
+                              "%5_RELATIONSHIP_Artist"."Artist" AS "Artist"
                             FROM
-                              "public"."Album" AS "%2_Album"
+                              (
+                                SELECT
+                                  "%3_Album".*
+                                FROM
+                                  "public"."Album" AS "%3_Album"
+                                WHERE
+                                  ("%1_Artist"."ArtistId" = "%3_Album"."ArtistId")
+                              ) AS "%4_Album"
                               LEFT OUTER JOIN LATERAL (
                                 SELECT
-                                  row_to_json("%3_RELATIONSHIP_Artist") AS "Artist"
+                                  row_to_json("%5_RELATIONSHIP_Artist") AS "Artist"
                                 FROM
                                   (
                                     SELECT
@@ -45,27 +57,30 @@ FROM
                                     FROM
                                       (
                                         SELECT
-                                          coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
+                                          coalesce(json_agg(row_to_json("%8_rows")), '[]') AS "rows"
                                         FROM
                                           (
                                             SELECT
-                                              "%4_Artist"."Name" AS "name"
+                                              "%7_Artist"."Name" AS "name"
                                             FROM
-                                              "public"."Artist" AS "%4_Artist"
-                                            WHERE
-                                              ("%2_Album"."ArtistId" = "%4_Artist"."ArtistId")
-                                          ) AS "%5_rows"
-                                      ) AS "%5_rows"
-                                  ) AS "%3_RELATIONSHIP_Artist"
-                              ) AS "%3_RELATIONSHIP_Artist" ON ('true')
-                            WHERE
-                              ("%0_Artist"."ArtistId" = "%2_Album"."ArtistId")
-                          ) AS "%7_rows"
-                      ) AS "%7_rows"
-                  ) AS "%1_RELATIONSHIP_Albums"
-              ) AS "%1_RELATIONSHIP_Albums" ON ('true')
-          ) AS "%10_rows"
-      ) AS "%10_rows"
-  ) AS "%9_universe";
+                                              (
+                                                SELECT
+                                                  "%6_Artist".*
+                                                FROM
+                                                  "public"."Artist" AS "%6_Artist"
+                                                WHERE
+                                                  ("%4_Album"."ArtistId" = "%6_Artist"."ArtistId")
+                                              ) AS "%7_Artist"
+                                          ) AS "%8_rows"
+                                      ) AS "%8_rows"
+                                  ) AS "%5_RELATIONSHIP_Artist"
+                              ) AS "%5_RELATIONSHIP_Artist" ON ('true')
+                          ) AS "%10_rows"
+                      ) AS "%10_rows"
+                  ) AS "%2_RELATIONSHIP_Albums"
+              ) AS "%2_RELATIONSHIP_Albums" ON ('true')
+          ) AS "%13_rows"
+      ) AS "%13_rows"
+  ) AS "%12_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__no_fields.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__no_fields.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%1_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,24 +11,29 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%2_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
             FROM
-              "public"."Album" AS "%0_Album"
-            WHERE
               (
-                "%0_Album"."Title" IN (
-                  cast($1 as "pg_catalog"."varchar"),
-                  cast($2 as "pg_catalog"."varchar")
-                )
-              )
-            LIMIT
-              10
-          ) AS "%2_rows"
-      ) AS "%2_rows"
-  ) AS "%1_universe";
+                SELECT
+                  "%0_Album".*
+                FROM
+                  "public"."Album" AS "%0_Album"
+                WHERE
+                  (
+                    "%0_Album"."Title" IN (
+                      cast($1 as "pg_catalog"."varchar"),
+                      cast($2 as "pg_catalog"."varchar")
+                    )
+                  )
+                LIMIT
+                  10
+              ) AS "%1_Album"
+          ) AS "%3_rows"
+      ) AS "%3_rows"
+  ) AS "%2_universe";
 
 {
     1: String(

--- a/crates/query-engine/translation/tests/snapshots/tests__select_array_column.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_array_column.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 WITH "%1_NATIVE_QUERY_array_series" AS (
-  WITH "%6_NATIVE_QUERY_array_series" AS (
+  WITH "%7_NATIVE_QUERY_array_series" AS (
     SELECT
       array_agg(arr.series) AS series
     FROM
@@ -15,10 +15,10 @@ WITH "%1_NATIVE_QUERY_array_series" AS (
   SELECT
     *
   FROM
-    "%6_NATIVE_QUERY_array_series" AS "%7_NATIVE_QUERY_array_series"
+    "%7_NATIVE_QUERY_array_series" AS "%8_NATIVE_QUERY_array_series"
 )
 SELECT
-  coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%3_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -26,15 +26,20 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_array_series"."series" AS "series"
+              "%2_array_series"."series" AS "series"
             FROM
-              "%1_NATIVE_QUERY_array_series" AS "%0_array_series"
-          ) AS "%3_rows"
-      ) AS "%3_rows"
-  ) AS "%2_universe";
+              (
+                SELECT
+                  "%0_array_series".*
+                FROM
+                  "%1_NATIVE_QUERY_array_series" AS "%0_array_series"
+              ) AS "%2_array_series"
+          ) AS "%4_rows"
+      ) AS "%4_rows"
+  ) AS "%3_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__select_array_column_nested_types.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_array_column_nested_types.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 WITH "%1_NATIVE_QUERY_summarize_organizations" AS (
-  WITH "%6_NATIVE_QUERY_summarize_organizations" AS (
+  WITH "%7_NATIVE_QUERY_summarize_organizations" AS (
     SELECT
       'The organization ' || org.name || ' has ' || no_committees :: text || ' committees, ' || 'the largest of which has ' || max_members || ' members.' AS result
     FROM
@@ -42,10 +42,10 @@ WITH "%1_NATIVE_QUERY_summarize_organizations" AS (
   SELECT
     *
   FROM
-    "%6_NATIVE_QUERY_summarize_organizations" AS "%7_NATIVE_QUERY_summarize_organizations"
+    "%7_NATIVE_QUERY_summarize_organizations" AS "%8_NATIVE_QUERY_summarize_organizations"
 )
 SELECT
-  coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%3_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -53,16 +53,21 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_summarize_organizations"."result" AS "result"
+              "%2_summarize_organizations"."result" AS "result"
             FROM
-              "%1_NATIVE_QUERY_summarize_organizations" AS "%0_summarize_organizations"
-          ) AS "%3_rows"
-      ) AS "%3_rows"
-  ) AS "%2_universe";
+              (
+                SELECT
+                  "%0_summarize_organizations".*
+                FROM
+                  "%1_NATIVE_QUERY_summarize_organizations" AS "%0_summarize_organizations"
+              ) AS "%2_summarize_organizations"
+          ) AS "%4_rows"
+      ) AS "%4_rows"
+  ) AS "%3_universe";
 
 {
     1: Value(

--- a/crates/query-engine/translation/tests/snapshots/tests__select_array_column_reverse.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_array_column_reverse.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 WITH "%1_NATIVE_QUERY_array_reverse" AS (
-  WITH "%6_NATIVE_QUERY_array_reverse" AS (
+  WITH "%7_NATIVE_QUERY_array_reverse" AS (
     SELECT
       array_agg(x) as reversed
     FROM
@@ -22,10 +22,10 @@ WITH "%1_NATIVE_QUERY_array_reverse" AS (
                     SELECT
                       *
                     FROM
-                      "%6_NATIVE_QUERY_array_reverse" AS "%7_NATIVE_QUERY_array_reverse"
+                      "%7_NATIVE_QUERY_array_reverse" AS "%8_NATIVE_QUERY_array_reverse"
                   )
                   SELECT
-                    coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
+                    coalesce(json_agg(row_to_json("%3_universe")), '[]') AS "universe"
                   FROM
                     (
                       SELECT
@@ -33,16 +33,21 @@ WITH "%1_NATIVE_QUERY_array_reverse" AS (
                       FROM
                         (
                           SELECT
-                            coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
+                            coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
                           FROM
                             (
                               SELECT
-                                "%0_array_reverse"."reversed" AS "reversed"
+                                "%2_array_reverse"."reversed" AS "reversed"
                               FROM
-                                "%1_NATIVE_QUERY_array_reverse" AS "%0_array_reverse"
-                            ) AS "%3_rows"
-                        ) AS "%3_rows"
-                    ) AS "%2_universe";
+                                (
+                                  SELECT
+                                    "%0_array_reverse".*
+                                  FROM
+                                    "%1_NATIVE_QUERY_array_reverse" AS "%0_array_reverse"
+                                ) AS "%2_array_reverse"
+                            ) AS "%4_rows"
+                        ) AS "%4_rows"
+                    ) AS "%3_universe";
 
 {
     1: Value(

--- a/crates/query-engine/translation/tests/snapshots/tests__select_array_variable.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_array_variable.snap
@@ -3,16 +3,16 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg("%6_universe_agg"."universe"), '[]') AS "universe"
+  coalesce(json_agg("%7_universe_agg"."universe"), '[]') AS "universe"
 FROM
   (
     SELECT
-      row_to_json("%3_universe") AS "universe"
+      row_to_json("%4_universe") AS "universe"
     FROM
       jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" "int4", "%variables" "jsonb")
       CROSS JOIN LATERAL (
         WITH "%2_NATIVE_QUERY_count_elements" AS (
-          WITH "%7_NATIVE_QUERY_count_elements" AS (
+          WITH "%8_NATIVE_QUERY_count_elements" AS (
             SELECT
               array_length(
                 (
@@ -25,26 +25,31 @@ FROM
                         SELECT
                           *
                         FROM
-                          "%7_NATIVE_QUERY_count_elements" AS "%8_NATIVE_QUERY_count_elements"
+                          "%8_NATIVE_QUERY_count_elements" AS "%9_NATIVE_QUERY_count_elements"
                       )
                       SELECT
                         *
                       FROM
                         (
                           SELECT
-                            coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
+                            coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
                           FROM
                             (
                               SELECT
-                                "%1_count_elements"."result" AS "result"
+                                "%3_count_elements"."result" AS "result"
                               FROM
-                                "%2_NATIVE_QUERY_count_elements" AS "%1_count_elements"
-                            ) AS "%4_rows"
-                        ) AS "%4_rows"
-                    ) AS "%3_universe"
+                                (
+                                  SELECT
+                                    "%1_count_elements".*
+                                  FROM
+                                    "%2_NATIVE_QUERY_count_elements" AS "%1_count_elements"
+                                ) AS "%3_count_elements"
+                            ) AS "%5_rows"
+                        ) AS "%5_rows"
+                    ) AS "%4_universe"
                   ORDER BY
                     "%0_%variables_table"."%variable_order" ASC
-                ) AS "%6_universe_agg";
+                ) AS "%7_universe_agg";
 
 {
     1: Variable(

--- a/crates/query-engine/translation/tests/snapshots/tests__select_array_variable_nested_types.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_array_variable_nested_types.snap
@@ -3,16 +3,16 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg("%6_universe_agg"."universe"), '[]') AS "universe"
+  coalesce(json_agg("%7_universe_agg"."universe"), '[]') AS "universe"
 FROM
   (
     SELECT
-      row_to_json("%3_universe") AS "universe"
+      row_to_json("%4_universe") AS "universe"
     FROM
       jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" "int4", "%variables" "jsonb")
       CROSS JOIN LATERAL (
         WITH "%2_NATIVE_QUERY_summarize_organizations" AS (
-          WITH "%7_NATIVE_QUERY_summarize_organizations" AS (
+          WITH "%8_NATIVE_QUERY_summarize_organizations" AS (
             SELECT
               'The organization ' || org.name || ' has ' || no_committees :: text || ' committees, ' || 'the largest of which has ' || max_members || ' members.' AS result
             FROM
@@ -51,26 +51,31 @@ FROM
           SELECT
             *
           FROM
-            "%7_NATIVE_QUERY_summarize_organizations" AS "%8_NATIVE_QUERY_summarize_organizations"
+            "%8_NATIVE_QUERY_summarize_organizations" AS "%9_NATIVE_QUERY_summarize_organizations"
         )
         SELECT
           *
         FROM
           (
             SELECT
-              coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
+              coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
             FROM
               (
                 SELECT
-                  "%1_summarize_organizations"."result" AS "result"
+                  "%3_summarize_organizations"."result" AS "result"
                 FROM
-                  "%2_NATIVE_QUERY_summarize_organizations" AS "%1_summarize_organizations"
-              ) AS "%4_rows"
-          ) AS "%4_rows"
-      ) AS "%3_universe"
+                  (
+                    SELECT
+                      "%1_summarize_organizations".*
+                    FROM
+                      "%2_NATIVE_QUERY_summarize_organizations" AS "%1_summarize_organizations"
+                  ) AS "%3_summarize_organizations"
+              ) AS "%5_rows"
+          ) AS "%5_rows"
+      ) AS "%4_universe"
     ORDER BY
       "%0_%variables_table"."%variable_order" ASC
-  ) AS "%6_universe_agg";
+  ) AS "%7_universe_agg";
 
 {
     1: Variable(

--- a/crates/query-engine/translation/tests/snapshots/tests__select_composite_column_complex.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_composite_column_complex.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 WITH "%1_NATIVE_QUERY_make_person" AS (
-  WITH "%15_NATIVE_QUERY_make_person" AS (
+  WITH "%16_NATIVE_QUERY_make_person" AS (
     SELECT
       ROW(
         jsonb_populate_record(cast(null as "public"."person_name"), $1),
@@ -13,10 +13,10 @@ WITH "%1_NATIVE_QUERY_make_person" AS (
   SELECT
     *
   FROM
-    "%15_NATIVE_QUERY_make_person" AS "%16_NATIVE_QUERY_make_person"
+    "%16_NATIVE_QUERY_make_person" AS "%17_NATIVE_QUERY_make_person"
 )
 SELECT
-  coalesce(json_agg(row_to_json("%11_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%12_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -24,61 +24,66 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%12_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%13_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%10_nested_fields_collect"."collected" AS "result"
+              "%11_nested_fields_collect"."collected" AS "result"
             FROM
-              "%1_NATIVE_QUERY_make_person" AS "%0_make_person"
+              (
+                SELECT
+                  "%0_make_person".*
+                FROM
+                  "%1_NATIVE_QUERY_make_person" AS "%0_make_person"
+              ) AS "%2_make_person"
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  row_to_json("%2_nested_fields") AS "collected"
+                  row_to_json("%3_nested_fields") AS "collected"
                 FROM
                   (
                     SELECT
-                      "%6_nested_fields_collect"."collected" AS "address",
-                      "%9_nested_fields_collect"."collected" AS "name"
+                      "%7_nested_fields_collect"."collected" AS "address",
+                      "%10_nested_fields_collect"."collected" AS "name"
                     FROM
                       (
                         SELECT
-                          ("%0_make_person"."result").*
-                      ) AS "%3_make_person.result"
+                          ("%2_make_person"."result").*
+                      ) AS "%4_make_person.result"
                       LEFT OUTER JOIN LATERAL (
                         SELECT
-                          row_to_json("%4_nested_fields") AS "collected"
+                          row_to_json("%5_nested_fields") AS "collected"
                         FROM
                           (
                             SELECT
-                              "%5_make_person.result.address"."address_line_1" AS "address_line_1",
-                              "%5_make_person.result.address"."address_line_2" AS "address_line_2"
+                              "%6_make_person.result.address"."address_line_1" AS "address_line_1",
+                              "%6_make_person.result.address"."address_line_2" AS "address_line_2"
                             FROM
                               (
                                 SELECT
-                                  ("%3_make_person.result"."address").*
-                              ) AS "%5_make_person.result.address"
-                          ) AS "%4_nested_fields"
-                      ) AS "%6_nested_fields_collect" ON ('true')
+                                  ("%4_make_person.result"."address").*
+                              ) AS "%6_make_person.result.address"
+                          ) AS "%5_nested_fields"
+                      ) AS "%7_nested_fields_collect" ON ('true')
                       LEFT OUTER JOIN LATERAL (
                         SELECT
-                          row_to_json("%7_nested_fields") AS "collected"
+                          row_to_json("%8_nested_fields") AS "collected"
                         FROM
                           (
                             SELECT
-                              "%8_make_person.result.name"."first_name" AS "first_name",
-                              "%8_make_person.result.name"."last_name" AS "last_name"
+                              "%9_make_person.result.name"."first_name" AS "first_name",
+                              "%9_make_person.result.name"."last_name" AS "last_name"
                             FROM
                               (
                                 SELECT
-                                  ("%3_make_person.result"."name").*
-                              ) AS "%8_make_person.result.name"
-                          ) AS "%7_nested_fields"
-                      ) AS "%9_nested_fields_collect" ON ('true')
-                  ) AS "%2_nested_fields"
-              ) AS "%10_nested_fields_collect" ON ('true')
-          ) AS "%12_rows"
-      ) AS "%12_rows"
-  ) AS "%11_universe";
+                                  ("%4_make_person.result"."name").*
+                              ) AS "%9_make_person.result.name"
+                          ) AS "%8_nested_fields"
+                      ) AS "%10_nested_fields_collect" ON ('true')
+                  ) AS "%3_nested_fields"
+              ) AS "%11_nested_fields_collect" ON ('true')
+          ) AS "%13_rows"
+      ) AS "%13_rows"
+  ) AS "%12_universe";
 
 {
     1: Value(

--- a/crates/query-engine/translation/tests/snapshots/tests__select_composite_column_simple.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_composite_column_simple.snap
@@ -3,17 +3,17 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 WITH "%1_NATIVE_QUERY_address_identity_function" AS (
-  WITH "%9_NATIVE_QUERY_address_identity_function" AS (
+  WITH "%10_NATIVE_QUERY_address_identity_function" AS (
     SELECT
       jsonb_populate_record(cast(null as "public"."person_address"), $1) as result
   )
   SELECT
     *
   FROM
-    "%9_NATIVE_QUERY_address_identity_function" AS "%10_NATIVE_QUERY_address_identity_function"
+    "%10_NATIVE_QUERY_address_identity_function" AS "%11_NATIVE_QUERY_address_identity_function"
 )
 SELECT
-  coalesce(json_agg(row_to_json("%5_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%6_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -21,31 +21,36 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%6_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%7_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%4_nested_fields_collect"."collected" AS "result"
+              "%5_nested_fields_collect"."collected" AS "result"
             FROM
-              "%1_NATIVE_QUERY_address_identity_function" AS "%0_address_identity_function"
+              (
+                SELECT
+                  "%0_address_identity_function".*
+                FROM
+                  "%1_NATIVE_QUERY_address_identity_function" AS "%0_address_identity_function"
+              ) AS "%2_address_identity_function"
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  row_to_json("%2_nested_fields") AS "collected"
+                  row_to_json("%3_nested_fields") AS "collected"
                 FROM
                   (
                     SELECT
-                      "%3_address_identity_function.result"."address_line_1" AS "address_line_1",
-                      "%3_address_identity_function.result"."address_line_2" AS "address_line_2"
+                      "%4_address_identity_function.result"."address_line_1" AS "address_line_1",
+                      "%4_address_identity_function.result"."address_line_2" AS "address_line_2"
                     FROM
                       (
                         SELECT
-                          ("%0_address_identity_function"."result").*
-                      ) AS "%3_address_identity_function.result"
-                  ) AS "%2_nested_fields"
-              ) AS "%4_nested_fields_collect" ON ('true')
-          ) AS "%6_rows"
-      ) AS "%6_rows"
-  ) AS "%5_universe";
+                          ("%2_address_identity_function"."result").*
+                      ) AS "%4_address_identity_function.result"
+                  ) AS "%3_nested_fields"
+              ) AS "%5_nested_fields_collect" ON ('true')
+          ) AS "%7_rows"
+      ) AS "%7_rows"
+  ) AS "%6_universe";
 
 {
     1: Value(

--- a/crates/query-engine/translation/tests/snapshots/tests__select_composite_variable_complex.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_composite_variable_complex.snap
@@ -3,16 +3,16 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg("%15_universe_agg"."universe"), '[]') AS "universe"
+  coalesce(json_agg("%16_universe_agg"."universe"), '[]') AS "universe"
 FROM
   (
     SELECT
-      row_to_json("%12_universe") AS "universe"
+      row_to_json("%13_universe") AS "universe"
     FROM
       jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" "int4", "%variables" "jsonb")
       CROSS JOIN LATERAL (
         WITH "%2_NATIVE_QUERY_make_person" AS (
-          WITH "%16_NATIVE_QUERY_make_person" AS (
+          WITH "%17_NATIVE_QUERY_make_person" AS (
             SELECT
               ROW(
                 jsonb_populate_record(
@@ -28,71 +28,76 @@ FROM
           SELECT
             *
           FROM
-            "%16_NATIVE_QUERY_make_person" AS "%17_NATIVE_QUERY_make_person"
+            "%17_NATIVE_QUERY_make_person" AS "%18_NATIVE_QUERY_make_person"
         )
         SELECT
           *
         FROM
           (
             SELECT
-              coalesce(json_agg(row_to_json("%13_rows")), '[]') AS "rows"
+              coalesce(json_agg(row_to_json("%14_rows")), '[]') AS "rows"
             FROM
               (
                 SELECT
-                  "%11_nested_fields_collect"."collected" AS "result"
+                  "%12_nested_fields_collect"."collected" AS "result"
                 FROM
-                  "%2_NATIVE_QUERY_make_person" AS "%1_make_person"
+                  (
+                    SELECT
+                      "%1_make_person".*
+                    FROM
+                      "%2_NATIVE_QUERY_make_person" AS "%1_make_person"
+                  ) AS "%3_make_person"
                   LEFT OUTER JOIN LATERAL (
                     SELECT
-                      row_to_json("%3_nested_fields") AS "collected"
+                      row_to_json("%4_nested_fields") AS "collected"
                     FROM
                       (
                         SELECT
-                          "%7_nested_fields_collect"."collected" AS "address",
-                          "%10_nested_fields_collect"."collected" AS "name"
+                          "%8_nested_fields_collect"."collected" AS "address",
+                          "%11_nested_fields_collect"."collected" AS "name"
                         FROM
                           (
                             SELECT
-                              ("%1_make_person"."result").*
-                          ) AS "%4_make_person.result"
+                              ("%3_make_person"."result").*
+                          ) AS "%5_make_person.result"
                           LEFT OUTER JOIN LATERAL (
                             SELECT
-                              row_to_json("%5_nested_fields") AS "collected"
+                              row_to_json("%6_nested_fields") AS "collected"
                             FROM
                               (
                                 SELECT
-                                  "%6_make_person.result.address"."address_line_1" AS "address_line_1",
-                                  "%6_make_person.result.address"."address_line_2" AS "address_line_2"
+                                  "%7_make_person.result.address"."address_line_1" AS "address_line_1",
+                                  "%7_make_person.result.address"."address_line_2" AS "address_line_2"
                                 FROM
                                   (
                                     SELECT
-                                      ("%4_make_person.result"."address").*
-                                  ) AS "%6_make_person.result.address"
-                              ) AS "%5_nested_fields"
-                          ) AS "%7_nested_fields_collect" ON ('true')
+                                      ("%5_make_person.result"."address").*
+                                  ) AS "%7_make_person.result.address"
+                              ) AS "%6_nested_fields"
+                          ) AS "%8_nested_fields_collect" ON ('true')
                           LEFT OUTER JOIN LATERAL (
                             SELECT
-                              row_to_json("%8_nested_fields") AS "collected"
+                              row_to_json("%9_nested_fields") AS "collected"
                             FROM
                               (
                                 SELECT
-                                  "%9_make_person.result.name"."first_name" AS "first_name",
-                                  "%9_make_person.result.name"."last_name" AS "last_name"
+                                  "%10_make_person.result.name"."first_name" AS "first_name",
+                                  "%10_make_person.result.name"."last_name" AS "last_name"
                                 FROM
                                   (
                                     SELECT
-                                      ("%4_make_person.result"."name").*
-                                  ) AS "%9_make_person.result.name"
-                              ) AS "%8_nested_fields"
-                          ) AS "%10_nested_fields_collect" ON ('true')
-                      ) AS "%3_nested_fields"
-                  ) AS "%11_nested_fields_collect" ON ('true')
-              ) AS "%13_rows"
-          ) AS "%13_rows"
-      ) AS "%12_universe"
+                                      ("%5_make_person.result"."name").*
+                                  ) AS "%10_make_person.result.name"
+                              ) AS "%9_nested_fields"
+                          ) AS "%11_nested_fields_collect" ON ('true')
+                      ) AS "%4_nested_fields"
+                  ) AS "%12_nested_fields_collect" ON ('true')
+              ) AS "%14_rows"
+          ) AS "%14_rows"
+      ) AS "%13_universe"
     ORDER BY
       "%0_%variables_table"."%variable_order" ASC
-  ) AS "%15_universe_agg";
+  ) AS "%16_universe_agg";
 
 {
     1: Variable(

--- a/crates/query-engine/translation/tests/snapshots/tests__select_composite_variable_simple.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_composite_variable_simple.snap
@@ -3,16 +3,16 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg("%9_universe_agg"."universe"), '[]') AS "universe"
+  coalesce(json_agg("%10_universe_agg"."universe"), '[]') AS "universe"
 FROM
   (
     SELECT
-      row_to_json("%6_universe") AS "universe"
+      row_to_json("%7_universe") AS "universe"
     FROM
       jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" "int4", "%variables" "jsonb")
       CROSS JOIN LATERAL (
         WITH "%2_NATIVE_QUERY_address_identity_function" AS (
-          WITH "%10_NATIVE_QUERY_address_identity_function" AS (
+          WITH "%11_NATIVE_QUERY_address_identity_function" AS (
             SELECT
               jsonb_populate_record(
                 cast(null as "public"."person_address"),
@@ -22,41 +22,46 @@ FROM
           SELECT
             *
           FROM
-            "%10_NATIVE_QUERY_address_identity_function" AS "%11_NATIVE_QUERY_address_identity_function"
+            "%11_NATIVE_QUERY_address_identity_function" AS "%12_NATIVE_QUERY_address_identity_function"
         )
         SELECT
           *
         FROM
           (
             SELECT
-              coalesce(json_agg(row_to_json("%7_rows")), '[]') AS "rows"
+              coalesce(json_agg(row_to_json("%8_rows")), '[]') AS "rows"
             FROM
               (
                 SELECT
-                  "%5_nested_fields_collect"."collected" AS "result"
+                  "%6_nested_fields_collect"."collected" AS "result"
                 FROM
-                  "%2_NATIVE_QUERY_address_identity_function" AS "%1_address_identity_function"
+                  (
+                    SELECT
+                      "%1_address_identity_function".*
+                    FROM
+                      "%2_NATIVE_QUERY_address_identity_function" AS "%1_address_identity_function"
+                  ) AS "%3_address_identity_function"
                   LEFT OUTER JOIN LATERAL (
                     SELECT
-                      row_to_json("%3_nested_fields") AS "collected"
+                      row_to_json("%4_nested_fields") AS "collected"
                     FROM
                       (
                         SELECT
-                          "%4_address_identity_function.result"."address_line_1" AS "address_line_1",
-                          "%4_address_identity_function.result"."address_line_2" AS "address_line_2"
+                          "%5_address_identity_function.result"."address_line_1" AS "address_line_1",
+                          "%5_address_identity_function.result"."address_line_2" AS "address_line_2"
                         FROM
                           (
                             SELECT
-                              ("%1_address_identity_function"."result").*
-                          ) AS "%4_address_identity_function.result"
-                      ) AS "%3_nested_fields"
-                  ) AS "%5_nested_fields_collect" ON ('true')
-              ) AS "%7_rows"
-          ) AS "%7_rows"
-      ) AS "%6_universe"
+                              ("%3_address_identity_function"."result").*
+                          ) AS "%5_address_identity_function.result"
+                      ) AS "%4_nested_fields"
+                  ) AS "%6_nested_fields_collect" ON ('true')
+              ) AS "%8_rows"
+          ) AS "%8_rows"
+      ) AS "%7_universe"
     ORDER BY
       "%0_%variables_table"."%variable_order" ASC
-  ) AS "%9_universe_agg";
+  ) AS "%10_universe_agg";
 
 {
     1: Variable(

--- a/crates/query-engine/translation/tests/snapshots/tests__select_nested_column_complex.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_nested_column_complex.snap
@@ -3,17 +3,17 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 WITH "%1_NATIVE_QUERY_organization_identity_function" AS (
-  WITH "%18_NATIVE_QUERY_organization_identity_function" AS (
+  WITH "%19_NATIVE_QUERY_organization_identity_function" AS (
     SELECT
       jsonb_populate_record(cast(null as "public"."organization"), $1) as result_the_column
   )
   SELECT
     *
   FROM
-    "%18_NATIVE_QUERY_organization_identity_function" AS "%19_NATIVE_QUERY_organization_identity_function"
+    "%19_NATIVE_QUERY_organization_identity_function" AS "%20_NATIVE_QUERY_organization_identity_function"
 )
 SELECT
-  coalesce(json_agg(row_to_json("%14_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%15_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -21,90 +21,95 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%15_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%16_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%13_nested_fields_collect"."collected" AS "the_organization"
+              "%14_nested_fields_collect"."collected" AS "the_organization"
             FROM
-              "%1_NATIVE_QUERY_organization_identity_function" AS "%0_organization_identity_function"
+              (
+                SELECT
+                  "%0_organization_identity_function".*
+                FROM
+                  "%1_NATIVE_QUERY_organization_identity_function" AS "%0_organization_identity_function"
+              ) AS "%2_organization_identity_function"
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  row_to_json("%2_nested_fields") AS "collected"
+                  row_to_json("%3_nested_fields") AS "collected"
                 FROM
                   (
                     SELECT
-                      "%3_organization_identity_function.result_the_field"."name" AS "name_of_the_org",
-                      "%12_nested_fields_collect"."collected" AS "committees_of_the_org"
+                      "%4_organization_identity_function.result_the_field"."name" AS "name_of_the_org",
+                      "%13_nested_fields_collect"."collected" AS "committees_of_the_org"
                     FROM
                       (
                         SELECT
                           (
-                            "%0_organization_identity_function"."result_the_column"
+                            "%2_organization_identity_function"."result_the_column"
                           ).*
-                      ) AS "%3_organization_identity_function.result_the_field"
+                      ) AS "%4_organization_identity_function.result_the_field"
                       LEFT OUTER JOIN LATERAL (
                         SELECT
-                          json_agg(row_to_json("%4_nested_fields")) AS "collected"
+                          json_agg(row_to_json("%5_nested_fields")) AS "collected"
                         FROM
                           (
                             SELECT
-                              "%5_organization_identity_function.result_the_field.committees"."name" AS "name_of_the_committee",
-                              "%8_nested_fields_collect"."collected" AS "members_of_the_committee",
-                              "%11_nested_fields_collect"."collected" AS "members_of_the_committee_last_names_only"
+                              "%6_organization_identity_function.result_the_field.committees"."name" AS "name_of_the_committee",
+                              "%9_nested_fields_collect"."collected" AS "members_of_the_committee",
+                              "%12_nested_fields_collect"."collected" AS "members_of_the_committee_last_names_only"
                             FROM
                               (
                                 SELECT
                                   (
                                     unnest(
-                                      "%3_organization_identity_function.result_the_field"."committees"
+                                      "%4_organization_identity_function.result_the_field"."committees"
                                     )
                                   ).*
-                              ) AS "%5_organization_identity_function.result_the_field.committees"
+                              ) AS "%6_organization_identity_function.result_the_field.committees"
                               LEFT OUTER JOIN LATERAL (
                                 SELECT
-                                  json_agg(row_to_json("%6_nested_fields")) AS "collected"
+                                  json_agg(row_to_json("%7_nested_fields")) AS "collected"
                                 FROM
                                   (
                                     SELECT
-                                      "%7_organization_identity_function.result_the_field.committees.members"."first_name" AS "member_first_name",
-                                      "%7_organization_identity_function.result_the_field.committees.members"."last_name" AS "member_last_name"
+                                      "%8_organization_identity_function.result_the_field.committees.members"."first_name" AS "member_first_name",
+                                      "%8_organization_identity_function.result_the_field.committees.members"."last_name" AS "member_last_name"
                                     FROM
                                       (
                                         SELECT
                                           (
                                             unnest(
-                                              "%5_organization_identity_function.result_the_field.committees"."members"
+                                              "%6_organization_identity_function.result_the_field.committees"."members"
                                             )
                                           ).*
-                                      ) AS "%7_organization_identity_function.result_the_field.committees.members"
-                                  ) AS "%6_nested_fields"
-                              ) AS "%8_nested_fields_collect" ON ('true')
+                                      ) AS "%8_organization_identity_function.result_the_field.committees.members"
+                                  ) AS "%7_nested_fields"
+                              ) AS "%9_nested_fields_collect" ON ('true')
                               LEFT OUTER JOIN LATERAL (
                                 SELECT
-                                  json_agg(row_to_json("%9_nested_fields")) AS "collected"
+                                  json_agg(row_to_json("%10_nested_fields")) AS "collected"
                                 FROM
                                   (
                                     SELECT
-                                      "%10_organization_identity_function.result_the_field.committees.members"."last_name" AS "member_last_name"
+                                      "%11_organization_identity_function.result_the_field.committees.members"."last_name" AS "member_last_name"
                                     FROM
                                       (
                                         SELECT
                                           (
                                             unnest(
-                                              "%5_organization_identity_function.result_the_field.committees"."members"
+                                              "%6_organization_identity_function.result_the_field.committees"."members"
                                             )
                                           ).*
-                                      ) AS "%10_organization_identity_function.result_the_field.committees.members"
-                                  ) AS "%9_nested_fields"
-                              ) AS "%11_nested_fields_collect" ON ('true')
-                          ) AS "%4_nested_fields"
-                      ) AS "%12_nested_fields_collect" ON ('true')
-                  ) AS "%2_nested_fields"
-              ) AS "%13_nested_fields_collect" ON ('true')
-          ) AS "%15_rows"
-      ) AS "%15_rows"
-  ) AS "%14_universe";
+                                      ) AS "%11_organization_identity_function.result_the_field.committees.members"
+                                  ) AS "%10_nested_fields"
+                              ) AS "%12_nested_fields_collect" ON ('true')
+                          ) AS "%5_nested_fields"
+                      ) AS "%13_nested_fields_collect" ON ('true')
+                  ) AS "%3_nested_fields"
+              ) AS "%14_nested_fields_collect" ON ('true')
+          ) AS "%16_rows"
+      ) AS "%16_rows"
+  ) AS "%15_universe";
 
 {
     1: Value(

--- a/crates/query-engine/translation/tests/snapshots/tests__select_nested_column_simple.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_nested_column_simple.snap
@@ -3,17 +3,17 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 WITH "%1_NATIVE_QUERY_address_identity_function" AS (
-  WITH "%9_NATIVE_QUERY_address_identity_function" AS (
+  WITH "%10_NATIVE_QUERY_address_identity_function" AS (
     SELECT
       jsonb_populate_record(cast(null as "public"."person_address"), $1) as result
   )
   SELECT
     *
   FROM
-    "%9_NATIVE_QUERY_address_identity_function" AS "%10_NATIVE_QUERY_address_identity_function"
+    "%10_NATIVE_QUERY_address_identity_function" AS "%11_NATIVE_QUERY_address_identity_function"
 )
 SELECT
-  coalesce(json_agg(row_to_json("%5_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%6_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -21,30 +21,35 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%6_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%7_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%4_nested_fields_collect"."collected" AS "result"
+              "%5_nested_fields_collect"."collected" AS "result"
             FROM
-              "%1_NATIVE_QUERY_address_identity_function" AS "%0_address_identity_function"
+              (
+                SELECT
+                  "%0_address_identity_function".*
+                FROM
+                  "%1_NATIVE_QUERY_address_identity_function" AS "%0_address_identity_function"
+              ) AS "%2_address_identity_function"
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  row_to_json("%2_nested_fields") AS "collected"
+                  row_to_json("%3_nested_fields") AS "collected"
                 FROM
                   (
                     SELECT
-                      "%3_address_identity_function.result"."address_line_1" AS "the_first_line_of_the_address"
+                      "%4_address_identity_function.result"."address_line_1" AS "the_first_line_of_the_address"
                     FROM
                       (
                         SELECT
-                          ("%0_address_identity_function"."result").*
-                      ) AS "%3_address_identity_function.result"
-                  ) AS "%2_nested_fields"
-              ) AS "%4_nested_fields_collect" ON ('true')
-          ) AS "%6_rows"
-      ) AS "%6_rows"
-  ) AS "%5_universe";
+                          ("%2_address_identity_function"."result").*
+                      ) AS "%4_address_identity_function.result"
+                  ) AS "%3_nested_fields"
+              ) AS "%5_nested_fields_collect" ON ('true')
+          ) AS "%7_rows"
+      ) AS "%7_rows"
+  ) AS "%6_universe";
 
 {
     1: Value(

--- a/crates/query-engine/translation/tests/snapshots/tests__select_track_order_by_artist_id_and_album_title.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_track_order_by_artist_id_and_album_title.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%3_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%4_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,38 +11,43 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Track"."Name" AS "Name"
+              "%3_Track"."Name" AS "Name"
             FROM
-              "public"."Track" AS "%0_Track"
-              LEFT OUTER JOIN LATERAL (
+              (
                 SELECT
-                  "%1_ORDER_PART_Album"."ArtistId" AS "ArtistId",
-                  "%1_ORDER_PART_Album"."Title" AS "Title"
+                  "%0_Track".*
                 FROM
-                  (
+                  "public"."Track" AS "%0_Track"
+                  LEFT OUTER JOIN LATERAL (
                     SELECT
                       "%1_ORDER_PART_Album"."ArtistId" AS "ArtistId",
                       "%1_ORDER_PART_Album"."Title" AS "Title"
                     FROM
-                      "public"."Album" AS "%1_ORDER_PART_Album"
-                    WHERE
                       (
-                        "%0_Track"."AlbumId" = "%1_ORDER_PART_Album"."AlbumId"
-                      )
-                  ) AS "%1_ORDER_PART_Album"
-              ) AS "%2_ORDER_FOR_Track" ON ('true')
-            ORDER BY
-              "%2_ORDER_FOR_Track"."ArtistId" ASC,
-              "%0_Track"."Name" ASC,
-              "%2_ORDER_FOR_Track"."Title" ASC
-            LIMIT
-              5
-          ) AS "%4_rows"
-      ) AS "%4_rows"
-  ) AS "%3_universe";
+                        SELECT
+                          "%1_ORDER_PART_Album"."ArtistId" AS "ArtistId",
+                          "%1_ORDER_PART_Album"."Title" AS "Title"
+                        FROM
+                          "public"."Album" AS "%1_ORDER_PART_Album"
+                        WHERE
+                          (
+                            "%0_Track"."AlbumId" = "%1_ORDER_PART_Album"."AlbumId"
+                          )
+                      ) AS "%1_ORDER_PART_Album"
+                  ) AS "%2_ORDER_FOR_Track" ON ('true')
+                ORDER BY
+                  "%2_ORDER_FOR_Track"."ArtistId" ASC,
+                  "%0_Track"."Name" ASC,
+                  "%2_ORDER_FOR_Track"."Title" ASC
+                LIMIT
+                  5
+              ) AS "%3_Track"
+          ) AS "%5_rows"
+      ) AS "%5_rows"
+  ) AS "%4_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__select_where_album_id_equals_self_nested_object_relationship.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_where_album_id_equals_self_nested_object_relationship.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%14_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%17_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,18 +11,92 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%15_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%18_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Track"."Name" AS "track",
-              "%0_Track"."AlbumId" AS "AlbumId",
-              "%1_RELATIONSHIP_Album"."Album" AS "Album"
+              "%6_Track"."Name" AS "track",
+              "%6_Track"."AlbumId" AS "AlbumId",
+              "%7_RELATIONSHIP_Album"."Album" AS "Album"
             FROM
-              "public"."Track" AS "%0_Track"
+              (
+                SELECT
+                  "%0_Track".*
+                FROM
+                  "public"."Track" AS "%0_Track"
+                WHERE
+                  EXISTS (
+                    SELECT
+                      1
+                    FROM
+                      (
+                        SELECT
+                          "%1_BOOLEXP_Album".*
+                        FROM
+                          (
+                            SELECT
+                              *
+                            FROM
+                              "public"."Album" AS "%1_BOOLEXP_Album"
+                            WHERE
+                              (
+                                (
+                                  "%1_BOOLEXP_Album"."Title" = cast($1 as "pg_catalog"."varchar")
+                                )
+                                AND (
+                                  "%0_Track"."AlbumId" = "%1_BOOLEXP_Album"."AlbumId"
+                                )
+                              )
+                          ) AS "%1_BOOLEXP_Album"
+                      ) AS "%2_BOOLEXP_Album" FULL
+                      OUTER JOIN LATERAL (
+                        SELECT
+                          "%4_BOOLEXP_Artist".*
+                        FROM
+                          (
+                            SELECT
+                              *
+                            FROM
+                              "public"."Album" AS "%3_BOOLEXP_Album"
+                            WHERE
+                              (
+                                (
+                                  "%3_BOOLEXP_Album"."Title" = cast($2 as "pg_catalog"."varchar")
+                                )
+                                AND (
+                                  "%0_Track"."AlbumId" = "%3_BOOLEXP_Album"."AlbumId"
+                                )
+                              )
+                          ) AS "%3_BOOLEXP_Album"
+                          INNER JOIN LATERAL (
+                            SELECT
+                              *
+                            FROM
+                              "public"."Artist" AS "%4_BOOLEXP_Artist"
+                            WHERE
+                              (
+                                (
+                                  "%4_BOOLEXP_Artist"."Name" = cast($3 as "pg_catalog"."varchar")
+                                )
+                                AND (
+                                  "%3_BOOLEXP_Album"."ArtistId" = "%4_BOOLEXP_Artist"."ArtistId"
+                                )
+                              )
+                          ) AS "%4_BOOLEXP_Artist" ON ('true')
+                      ) AS "%5_BOOLEXP_Artist" ON ('true')
+                    WHERE
+                      (
+                        "%2_BOOLEXP_Album"."AlbumId" > "%5_BOOLEXP_Artist"."ArtistId"
+                      )
+                  )
+                ORDER BY
+                  "%0_Track"."TrackId" ASC
+                LIMIT
+                  5
+              ) AS "%6_Track"
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  row_to_json("%1_RELATIONSHIP_Album") AS "Album"
+                  row_to_json("%7_RELATIONSHIP_Album") AS "Album"
                 FROM
                   (
                     SELECT
@@ -30,17 +104,24 @@ FROM
                     FROM
                       (
                         SELECT
-                          coalesce(json_agg(row_to_json("%12_rows")), '[]') AS "rows"
+                          coalesce(json_agg(row_to_json("%15_rows")), '[]') AS "rows"
                         FROM
                           (
                             SELECT
-                              "%7_Album"."Title" AS "album",
-                              "%8_RELATIONSHIP_Artist"."Artist" AS "Artist"
+                              "%9_Album"."Title" AS "album",
+                              "%10_RELATIONSHIP_Artist"."Artist" AS "Artist"
                             FROM
-                              "public"."Album" AS "%7_Album"
+                              (
+                                SELECT
+                                  "%8_Album".*
+                                FROM
+                                  "public"."Album" AS "%8_Album"
+                                WHERE
+                                  ("%6_Track"."AlbumId" = "%8_Album"."AlbumId")
+                              ) AS "%9_Album"
                               LEFT OUTER JOIN LATERAL (
                                 SELECT
-                                  row_to_json("%8_RELATIONSHIP_Artist") AS "Artist"
+                                  row_to_json("%10_RELATIONSHIP_Artist") AS "Artist"
                                 FROM
                                   (
                                     SELECT
@@ -48,98 +129,32 @@ FROM
                                     FROM
                                       (
                                         SELECT
-                                          coalesce(json_agg(row_to_json("%10_rows")), '[]') AS "rows"
+                                          coalesce(json_agg(row_to_json("%13_rows")), '[]') AS "rows"
                                         FROM
                                           (
                                             SELECT
-                                              "%9_Artist"."Name" AS "artist",
-                                              "%9_Artist"."ArtistId" AS "ArtistId"
+                                              "%12_Artist"."Name" AS "artist",
+                                              "%12_Artist"."ArtistId" AS "ArtistId"
                                             FROM
-                                              "public"."Artist" AS "%9_Artist"
-                                            WHERE
-                                              ("%7_Album"."ArtistId" = "%9_Artist"."ArtistId")
-                                          ) AS "%10_rows"
-                                      ) AS "%10_rows"
-                                  ) AS "%8_RELATIONSHIP_Artist"
-                              ) AS "%8_RELATIONSHIP_Artist" ON ('true')
-                            WHERE
-                              ("%0_Track"."AlbumId" = "%7_Album"."AlbumId")
-                          ) AS "%12_rows"
-                      ) AS "%12_rows"
-                  ) AS "%1_RELATIONSHIP_Album"
-              ) AS "%1_RELATIONSHIP_Album" ON ('true')
-            WHERE
-              EXISTS (
-                SELECT
-                  1
-                FROM
-                  (
-                    SELECT
-                      "%2_BOOLEXP_Album".*
-                    FROM
-                      (
-                        SELECT
-                          *
-                        FROM
-                          "public"."Album" AS "%2_BOOLEXP_Album"
-                        WHERE
-                          (
-                            (
-                              "%2_BOOLEXP_Album"."Title" = cast($1 as "pg_catalog"."varchar")
-                            )
-                            AND (
-                              "%0_Track"."AlbumId" = "%2_BOOLEXP_Album"."AlbumId"
-                            )
-                          )
-                      ) AS "%2_BOOLEXP_Album"
-                  ) AS "%3_BOOLEXP_Album" FULL
-                  OUTER JOIN LATERAL (
-                    SELECT
-                      "%5_BOOLEXP_Artist".*
-                    FROM
-                      (
-                        SELECT
-                          *
-                        FROM
-                          "public"."Album" AS "%4_BOOLEXP_Album"
-                        WHERE
-                          (
-                            (
-                              "%4_BOOLEXP_Album"."Title" = cast($2 as "pg_catalog"."varchar")
-                            )
-                            AND (
-                              "%0_Track"."AlbumId" = "%4_BOOLEXP_Album"."AlbumId"
-                            )
-                          )
-                      ) AS "%4_BOOLEXP_Album"
-                      INNER JOIN LATERAL (
-                        SELECT
-                          *
-                        FROM
-                          "public"."Artist" AS "%5_BOOLEXP_Artist"
-                        WHERE
-                          (
-                            (
-                              "%5_BOOLEXP_Artist"."Name" = cast($3 as "pg_catalog"."varchar")
-                            )
-                            AND (
-                              "%4_BOOLEXP_Album"."ArtistId" = "%5_BOOLEXP_Artist"."ArtistId"
-                            )
-                          )
-                      ) AS "%5_BOOLEXP_Artist" ON ('true')
-                  ) AS "%6_BOOLEXP_Artist" ON ('true')
-                WHERE
-                  (
-                    "%3_BOOLEXP_Album"."AlbumId" > "%6_BOOLEXP_Artist"."ArtistId"
-                  )
-              )
-            ORDER BY
-              "%0_Track"."TrackId" ASC
-            LIMIT
-              5
-          ) AS "%15_rows"
-      ) AS "%15_rows"
-  ) AS "%14_universe";
+                                              (
+                                                SELECT
+                                                  "%11_Artist".*
+                                                FROM
+                                                  "public"."Artist" AS "%11_Artist"
+                                                WHERE
+                                                  ("%9_Album"."ArtistId" = "%11_Artist"."ArtistId")
+                                              ) AS "%12_Artist"
+                                          ) AS "%13_rows"
+                                      ) AS "%13_rows"
+                                  ) AS "%10_RELATIONSHIP_Artist"
+                              ) AS "%10_RELATIONSHIP_Artist" ON ('true')
+                          ) AS "%15_rows"
+                      ) AS "%15_rows"
+                  ) AS "%7_RELATIONSHIP_Album"
+              ) AS "%7_RELATIONSHIP_Album" ON ('true')
+          ) AS "%18_rows"
+      ) AS "%18_rows"
+  ) AS "%17_universe";
 
 {
     1: String(

--- a/crates/query-engine/translation/tests/snapshots/tests__select_where_array_relationship.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_where_array_relationship.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%7_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%9_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,17 +11,49 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%8_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%10_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Artist"."Name" AS "title",
-              "%1_RELATIONSHIP_albums"."albums" AS "albums"
+              "%3_Artist"."Name" AS "title",
+              "%4_RELATIONSHIP_albums"."albums" AS "albums"
             FROM
-              "public"."Artist" AS "%0_Artist"
+              (
+                SELECT
+                  "%0_Artist".*
+                FROM
+                  "public"."Artist" AS "%0_Artist"
+                WHERE
+                  EXISTS (
+                    SELECT
+                      1
+                    FROM
+                      (
+                        SELECT
+                          "%1_BOOLEXP_Album".*
+                        FROM
+                          (
+                            SELECT
+                              *
+                            FROM
+                              "public"."Album" AS "%1_BOOLEXP_Album"
+                            WHERE
+                              (
+                                "%0_Artist"."ArtistId" = "%1_BOOLEXP_Album"."ArtistId"
+                              )
+                          ) AS "%1_BOOLEXP_Album"
+                      ) AS "%2_BOOLEXP_Album"
+                    WHERE
+                      (
+                        "%2_BOOLEXP_Album"."Title" LIKE cast($1 as "pg_catalog"."varchar")
+                      )
+                  )
+                ORDER BY
+                  "%0_Artist"."ArtistId" ASC
+              ) AS "%3_Artist"
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  row_to_json("%1_RELATIONSHIP_albums") AS "albums"
+                  row_to_json("%4_RELATIONSHIP_albums") AS "albums"
                 FROM
                   (
                     SELECT
@@ -29,51 +61,29 @@ FROM
                     FROM
                       (
                         SELECT
-                          coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
+                          coalesce(json_agg(row_to_json("%7_rows")), '[]') AS "rows"
                         FROM
                           (
                             SELECT
-                              "%4_Album"."Title" AS "title"
+                              "%6_Album"."Title" AS "title"
                             FROM
-                              "public"."Album" AS "%4_Album"
-                            WHERE
-                              ("%0_Artist"."ArtistId" = "%4_Album"."ArtistId")
-                            ORDER BY
-                              "%4_Album"."AlbumId" ASC
-                          ) AS "%5_rows"
-                      ) AS "%5_rows"
-                  ) AS "%1_RELATIONSHIP_albums"
-              ) AS "%1_RELATIONSHIP_albums" ON ('true')
-            WHERE
-              EXISTS (
-                SELECT
-                  1
-                FROM
-                  (
-                    SELECT
-                      "%2_BOOLEXP_Album".*
-                    FROM
-                      (
-                        SELECT
-                          *
-                        FROM
-                          "public"."Album" AS "%2_BOOLEXP_Album"
-                        WHERE
-                          (
-                            "%0_Artist"."ArtistId" = "%2_BOOLEXP_Album"."ArtistId"
-                          )
-                      ) AS "%2_BOOLEXP_Album"
-                  ) AS "%3_BOOLEXP_Album"
-                WHERE
-                  (
-                    "%3_BOOLEXP_Album"."Title" LIKE cast($1 as "pg_catalog"."varchar")
-                  )
-              )
-            ORDER BY
-              "%0_Artist"."ArtistId" ASC
-          ) AS "%8_rows"
-      ) AS "%8_rows"
-  ) AS "%7_universe";
+                              (
+                                SELECT
+                                  "%5_Album".*
+                                FROM
+                                  "public"."Album" AS "%5_Album"
+                                WHERE
+                                  ("%3_Artist"."ArtistId" = "%5_Album"."ArtistId")
+                                ORDER BY
+                                  "%5_Album"."AlbumId" ASC
+                              ) AS "%6_Album"
+                          ) AS "%7_rows"
+                      ) AS "%7_rows"
+                  ) AS "%4_RELATIONSHIP_albums"
+              ) AS "%4_RELATIONSHIP_albums" ON ('true')
+          ) AS "%10_rows"
+      ) AS "%10_rows"
+  ) AS "%9_universe";
 
 {
     1: String(

--- a/crates/query-engine/translation/tests/snapshots/tests__sorting_by_nested_relationship_column.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__sorting_by_nested_relationship_column.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%4_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%5_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,42 +11,47 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%6_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_track"."Name" AS "Name"
+              "%4_track"."Name" AS "Name"
             FROM
-              "public"."Track" AS "%0_track"
-              LEFT OUTER JOIN LATERAL (
+              (
                 SELECT
-                  "%2_ORDER_PART_artist"."Name" AS "Name"
+                  "%0_track".*
                 FROM
-                  (
-                    SELECT
-                      "%1_ORDER_PART_album"."ArtistId" AS "ArtistId"
-                    FROM
-                      "public"."Album" AS "%1_ORDER_PART_album"
-                    WHERE
-                      (
-                        "%0_track"."AlbumId" = "%1_ORDER_PART_album"."AlbumId"
-                      )
-                  ) AS "%1_ORDER_PART_album"
+                  "public"."Track" AS "%0_track"
                   LEFT OUTER JOIN LATERAL (
                     SELECT
                       "%2_ORDER_PART_artist"."Name" AS "Name"
                     FROM
-                      "public"."Artist" AS "%2_ORDER_PART_artist"
-                    WHERE
                       (
-                        "%1_ORDER_PART_album"."ArtistId" = "%2_ORDER_PART_artist"."ArtistId"
-                      )
-                  ) AS "%2_ORDER_PART_artist" ON ('true')
-              ) AS "%3_ORDER_FOR_track" ON ('true')
-            ORDER BY
-              "%3_ORDER_FOR_track"."Name" ASC
-          ) AS "%5_rows"
-      ) AS "%5_rows"
-  ) AS "%4_universe";
+                        SELECT
+                          "%1_ORDER_PART_album"."ArtistId" AS "ArtistId"
+                        FROM
+                          "public"."Album" AS "%1_ORDER_PART_album"
+                        WHERE
+                          (
+                            "%0_track"."AlbumId" = "%1_ORDER_PART_album"."AlbumId"
+                          )
+                      ) AS "%1_ORDER_PART_album"
+                      LEFT OUTER JOIN LATERAL (
+                        SELECT
+                          "%2_ORDER_PART_artist"."Name" AS "Name"
+                        FROM
+                          "public"."Artist" AS "%2_ORDER_PART_artist"
+                        WHERE
+                          (
+                            "%1_ORDER_PART_album"."ArtistId" = "%2_ORDER_PART_artist"."ArtistId"
+                          )
+                      ) AS "%2_ORDER_PART_artist" ON ('true')
+                  ) AS "%3_ORDER_FOR_track" ON ('true')
+                ORDER BY
+                  "%3_ORDER_FOR_track"."Name" ASC
+              ) AS "%4_track"
+          ) AS "%6_rows"
+      ) AS "%6_rows"
+  ) AS "%5_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__sorting_by_nested_relationship_column_with_predicate.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__sorting_by_nested_relationship_column_with_predicate.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%4_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%5_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,50 +11,55 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%6_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_track"."Name" AS "Name"
+              "%4_track"."Name" AS "Name"
             FROM
-              "public"."Track" AS "%0_track"
-              LEFT OUTER JOIN LATERAL (
+              (
                 SELECT
-                  "%2_ORDER_PART_artist"."Name" AS "Name"
+                  "%0_track".*
                 FROM
-                  (
-                    SELECT
-                      "%1_ORDER_PART_album"."ArtistId" AS "ArtistId"
-                    FROM
-                      "public"."Album" AS "%1_ORDER_PART_album"
-                    WHERE
-                      (
-                        (
-                          "%0_track"."AlbumId" = "%1_ORDER_PART_album"."AlbumId"
-                        )
-                        AND (
-                          "%1_ORDER_PART_album"."Title" = cast($1 as "pg_catalog"."varchar")
-                        )
-                      )
-                  ) AS "%1_ORDER_PART_album"
+                  "public"."Track" AS "%0_track"
                   LEFT OUTER JOIN LATERAL (
                     SELECT
                       "%2_ORDER_PART_artist"."Name" AS "Name"
                     FROM
-                      "public"."Artist" AS "%2_ORDER_PART_artist"
-                    WHERE
                       (
-                        "%1_ORDER_PART_album"."ArtistId" = "%2_ORDER_PART_artist"."ArtistId"
-                      )
-                  ) AS "%2_ORDER_PART_artist" ON ('true')
-              ) AS "%3_ORDER_FOR_track" ON ('true')
-            ORDER BY
-              "%3_ORDER_FOR_track"."Name" ASC
-            LIMIT
-              3
-          ) AS "%5_rows"
-      ) AS "%5_rows"
-  ) AS "%4_universe";
+                        SELECT
+                          "%1_ORDER_PART_album"."ArtistId" AS "ArtistId"
+                        FROM
+                          "public"."Album" AS "%1_ORDER_PART_album"
+                        WHERE
+                          (
+                            (
+                              "%0_track"."AlbumId" = "%1_ORDER_PART_album"."AlbumId"
+                            )
+                            AND (
+                              "%1_ORDER_PART_album"."Title" = cast($1 as "pg_catalog"."varchar")
+                            )
+                          )
+                      ) AS "%1_ORDER_PART_album"
+                      LEFT OUTER JOIN LATERAL (
+                        SELECT
+                          "%2_ORDER_PART_artist"."Name" AS "Name"
+                        FROM
+                          "public"."Artist" AS "%2_ORDER_PART_artist"
+                        WHERE
+                          (
+                            "%1_ORDER_PART_album"."ArtistId" = "%2_ORDER_PART_artist"."ArtistId"
+                          )
+                      ) AS "%2_ORDER_PART_artist" ON ('true')
+                  ) AS "%3_ORDER_FOR_track" ON ('true')
+                ORDER BY
+                  "%3_ORDER_FOR_track"."Name" ASC
+                LIMIT
+                  3
+              ) AS "%4_track"
+          ) AS "%6_rows"
+      ) AS "%6_rows"
+  ) AS "%5_universe";
 
 {
     1: String(

--- a/crates/query-engine/translation/tests/snapshots/tests__sorting_by_nested_relationship_count.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__sorting_by_nested_relationship_count.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%3_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%4_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,34 +11,39 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Artist"."Name" AS "Name"
+              "%3_Artist"."Name" AS "Name"
             FROM
-              "public"."Artist" AS "%0_Artist"
-              LEFT OUTER JOIN LATERAL (
+              (
                 SELECT
-                  count("%1_ORDER_PART_Album"."AlbumId") AS "AlbumId"
+                  "%0_Artist".*
                 FROM
-                  (
+                  "public"."Artist" AS "%0_Artist"
+                  LEFT OUTER JOIN LATERAL (
                     SELECT
-                      "%1_ORDER_PART_Album"."AlbumId" AS "AlbumId"
+                      count("%1_ORDER_PART_Album"."AlbumId") AS "AlbumId"
                     FROM
-                      "public"."Album" AS "%1_ORDER_PART_Album"
-                    WHERE
                       (
-                        "%0_Artist"."ArtistId" = "%1_ORDER_PART_Album"."ArtistId"
-                      )
-                  ) AS "%1_ORDER_PART_Album"
-              ) AS "%2_ORDER_FOR_Artist" ON ('true')
-            ORDER BY
-              "%2_ORDER_FOR_Artist"."AlbumId" DESC
-            LIMIT
-              3
-          ) AS "%4_rows"
-      ) AS "%4_rows"
-  ) AS "%3_universe";
+                        SELECT
+                          "%1_ORDER_PART_Album"."AlbumId" AS "AlbumId"
+                        FROM
+                          "public"."Album" AS "%1_ORDER_PART_Album"
+                        WHERE
+                          (
+                            "%0_Artist"."ArtistId" = "%1_ORDER_PART_Album"."ArtistId"
+                          )
+                      ) AS "%1_ORDER_PART_Album"
+                  ) AS "%2_ORDER_FOR_Artist" ON ('true')
+                ORDER BY
+                  "%2_ORDER_FOR_Artist"."AlbumId" DESC
+                LIMIT
+                  3
+              ) AS "%3_Artist"
+          ) AS "%5_rows"
+      ) AS "%5_rows"
+  ) AS "%4_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__sorting_by_recursive_relationship_column.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__sorting_by_recursive_relationship_column.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%4_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%5_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,42 +11,47 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%6_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Company"."Name" AS "Name"
+              "%4_Company"."Name" AS "Name"
             FROM
-              "public"."Company" AS "%0_Company"
-              LEFT OUTER JOIN LATERAL (
+              (
                 SELECT
-                  "%2_ORDER_PART_Person"."Name" AS "Name"
+                  "%0_Company".*
                 FROM
-                  (
-                    SELECT
-                      "%1_ORDER_PART_Person"."ParentId" AS "ParentId"
-                    FROM
-                      "public"."Person" AS "%1_ORDER_PART_Person"
-                    WHERE
-                      (
-                        "%0_Company"."CEOId" = "%1_ORDER_PART_Person"."PersonId"
-                      )
-                  ) AS "%1_ORDER_PART_Person"
+                  "public"."Company" AS "%0_Company"
                   LEFT OUTER JOIN LATERAL (
                     SELECT
                       "%2_ORDER_PART_Person"."Name" AS "Name"
                     FROM
-                      "public"."Person" AS "%2_ORDER_PART_Person"
-                    WHERE
                       (
-                        "%1_ORDER_PART_Person"."ParentId" = "%2_ORDER_PART_Person"."PersonId"
-                      )
-                  ) AS "%2_ORDER_PART_Person" ON ('true')
-              ) AS "%3_ORDER_FOR_Company" ON ('true')
-            ORDER BY
-              "%3_ORDER_FOR_Company"."Name" ASC
-          ) AS "%5_rows"
-      ) AS "%5_rows"
-  ) AS "%4_universe";
+                        SELECT
+                          "%1_ORDER_PART_Person"."ParentId" AS "ParentId"
+                        FROM
+                          "public"."Person" AS "%1_ORDER_PART_Person"
+                        WHERE
+                          (
+                            "%0_Company"."CEOId" = "%1_ORDER_PART_Person"."PersonId"
+                          )
+                      ) AS "%1_ORDER_PART_Person"
+                      LEFT OUTER JOIN LATERAL (
+                        SELECT
+                          "%2_ORDER_PART_Person"."Name" AS "Name"
+                        FROM
+                          "public"."Person" AS "%2_ORDER_PART_Person"
+                        WHERE
+                          (
+                            "%1_ORDER_PART_Person"."ParentId" = "%2_ORDER_PART_Person"."PersonId"
+                          )
+                      ) AS "%2_ORDER_PART_Person" ON ('true')
+                  ) AS "%3_ORDER_FOR_Company" ON ('true')
+                ORDER BY
+                  "%3_ORDER_FOR_Company"."Name" ASC
+              ) AS "%4_Company"
+          ) AS "%6_rows"
+      ) AS "%6_rows"
+  ) AS "%5_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__sorting_by_relationship_column.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__sorting_by_relationship_column.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%3_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%4_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,34 +11,39 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Album"."Title" AS "Name"
+              "%3_Album"."Title" AS "Name"
             FROM
-              "public"."Album" AS "%0_Album"
-              LEFT OUTER JOIN LATERAL (
+              (
                 SELECT
-                  "%1_ORDER_PART_Artist"."Name" AS "Name"
+                  "%0_Album".*
                 FROM
-                  (
+                  "public"."Album" AS "%0_Album"
+                  LEFT OUTER JOIN LATERAL (
                     SELECT
                       "%1_ORDER_PART_Artist"."Name" AS "Name"
                     FROM
-                      "public"."Artist" AS "%1_ORDER_PART_Artist"
-                    WHERE
                       (
-                        "%0_Album"."ArtistId" = "%1_ORDER_PART_Artist"."ArtistId"
-                      )
-                  ) AS "%1_ORDER_PART_Artist"
-              ) AS "%2_ORDER_FOR_Album" ON ('true')
-            ORDER BY
-              "%2_ORDER_FOR_Album"."Name" ASC
-            LIMIT
-              5 OFFSET 3
-          ) AS "%4_rows"
-      ) AS "%4_rows"
-  ) AS "%3_universe";
+                        SELECT
+                          "%1_ORDER_PART_Artist"."Name" AS "Name"
+                        FROM
+                          "public"."Artist" AS "%1_ORDER_PART_Artist"
+                        WHERE
+                          (
+                            "%0_Album"."ArtistId" = "%1_ORDER_PART_Artist"."ArtistId"
+                          )
+                      ) AS "%1_ORDER_PART_Artist"
+                  ) AS "%2_ORDER_FOR_Album" ON ('true')
+                ORDER BY
+                  "%2_ORDER_FOR_Album"."Name" ASC
+                LIMIT
+                  5 OFFSET 3
+              ) AS "%3_Album"
+          ) AS "%5_rows"
+      ) AS "%5_rows"
+  ) AS "%4_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__sorting_by_relationship_column_with_true_predicate.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__sorting_by_relationship_column_with_true_predicate.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%3_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%4_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,34 +11,39 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Album"."Title" AS "Name"
+              "%3_Album"."Title" AS "Name"
             FROM
-              "public"."Album" AS "%0_Album"
-              LEFT OUTER JOIN LATERAL (
+              (
                 SELECT
-                  "%1_ORDER_PART_Artist"."Name" AS "Name"
+                  "%0_Album".*
                 FROM
-                  (
+                  "public"."Album" AS "%0_Album"
+                  LEFT OUTER JOIN LATERAL (
                     SELECT
                       "%1_ORDER_PART_Artist"."Name" AS "Name"
                     FROM
-                      "public"."Artist" AS "%1_ORDER_PART_Artist"
-                    WHERE
                       (
-                        "%0_Album"."ArtistId" = "%1_ORDER_PART_Artist"."ArtistId"
-                      )
-                  ) AS "%1_ORDER_PART_Artist"
-              ) AS "%2_ORDER_FOR_Album" ON ('true')
-            ORDER BY
-              "%2_ORDER_FOR_Album"."Name" ASC
-            LIMIT
-              5 OFFSET 3
-          ) AS "%4_rows"
-      ) AS "%4_rows"
-  ) AS "%3_universe";
+                        SELECT
+                          "%1_ORDER_PART_Artist"."Name" AS "Name"
+                        FROM
+                          "public"."Artist" AS "%1_ORDER_PART_Artist"
+                        WHERE
+                          (
+                            "%0_Album"."ArtistId" = "%1_ORDER_PART_Artist"."ArtistId"
+                          )
+                      ) AS "%1_ORDER_PART_Artist"
+                  ) AS "%2_ORDER_FOR_Album" ON ('true')
+                ORDER BY
+                  "%2_ORDER_FOR_Album"."Name" ASC
+                LIMIT
+                  5 OFFSET 3
+              ) AS "%3_Album"
+          ) AS "%5_rows"
+      ) AS "%5_rows"
+  ) AS "%4_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__sorting_by_relationship_count.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__sorting_by_relationship_count.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%3_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%4_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,34 +11,39 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Artist"."Name" AS "Name"
+              "%3_Artist"."Name" AS "Name"
             FROM
-              "public"."Artist" AS "%0_Artist"
-              LEFT OUTER JOIN LATERAL (
+              (
                 SELECT
-                  COUNT("%1_ORDER_PART_Album"."count") AS "count"
+                  "%0_Artist".*
                 FROM
-                  (
+                  "public"."Artist" AS "%0_Artist"
+                  LEFT OUTER JOIN LATERAL (
                     SELECT
-                      1 AS "count"
+                      COUNT("%1_ORDER_PART_Album"."count") AS "count"
                     FROM
-                      "public"."Album" AS "%1_ORDER_PART_Album"
-                    WHERE
                       (
-                        "%0_Artist"."ArtistId" = "%1_ORDER_PART_Album"."ArtistId"
-                      )
-                  ) AS "%1_ORDER_PART_Album"
-              ) AS "%2_ORDER_FOR_Artist" ON ('true')
-            ORDER BY
-              "%2_ORDER_FOR_Artist"."count" DESC
-            LIMIT
-              5
-          ) AS "%4_rows"
-      ) AS "%4_rows"
-  ) AS "%3_universe";
+                        SELECT
+                          1 AS "count"
+                        FROM
+                          "public"."Album" AS "%1_ORDER_PART_Album"
+                        WHERE
+                          (
+                            "%0_Artist"."ArtistId" = "%1_ORDER_PART_Album"."ArtistId"
+                          )
+                      ) AS "%1_ORDER_PART_Album"
+                  ) AS "%2_ORDER_FOR_Artist" ON ('true')
+                ORDER BY
+                  "%2_ORDER_FOR_Artist"."count" DESC
+                LIMIT
+                  5
+              ) AS "%3_Artist"
+          ) AS "%5_rows"
+      ) AS "%5_rows"
+  ) AS "%4_universe";
 
 {}

--- a/crates/query-engine/translation/tests/snapshots/tests__sorting_by_relationship_count_with_predicate.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__sorting_by_relationship_count_with_predicate.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%4_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%5_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,53 +11,58 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%6_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Artist"."Name" AS "Name"
+              "%4_Artist"."Name" AS "Name"
             FROM
-              "public"."Artist" AS "%0_Artist"
-              LEFT OUTER JOIN LATERAL (
+              (
                 SELECT
-                  COUNT("%1_ORDER_PART_Album"."count") AS "count"
+                  "%0_Artist".*
                 FROM
-                  (
+                  "public"."Artist" AS "%0_Artist"
+                  LEFT OUTER JOIN LATERAL (
                     SELECT
-                      1 AS "count"
+                      COUNT("%1_ORDER_PART_Album"."count") AS "count"
                     FROM
-                      "public"."Album" AS "%1_ORDER_PART_Album"
-                    WHERE
                       (
-                        (
-                          "%0_Artist"."ArtistId" = "%1_ORDER_PART_Album"."ArtistId"
-                        )
-                        AND EXISTS (
-                          SELECT
-                            1 AS "one"
-                          FROM
-                            "public"."Track" AS "%2_track"
-                          WHERE
+                        SELECT
+                          1 AS "count"
+                        FROM
+                          "public"."Album" AS "%1_ORDER_PART_Album"
+                        WHERE
+                          (
                             (
-                              (
-                                "%2_track"."Name" LIKE cast($1 as "pg_catalog"."varchar")
-                              )
-                              AND (
-                                "%1_ORDER_PART_Album"."AlbumId" = "%2_track"."AlbumId"
-                              )
+                              "%0_Artist"."ArtistId" = "%1_ORDER_PART_Album"."ArtistId"
                             )
-                        )
-                      )
-                  ) AS "%1_ORDER_PART_Album"
-              ) AS "%3_ORDER_FOR_Artist" ON ('true')
-            ORDER BY
-              "%3_ORDER_FOR_Artist"."count" DESC,
-              "%0_Artist"."Name" DESC
-            LIMIT
-              5
-          ) AS "%5_rows"
-      ) AS "%5_rows"
-  ) AS "%4_universe";
+                            AND EXISTS (
+                              SELECT
+                                1 AS "one"
+                              FROM
+                                "public"."Track" AS "%2_track"
+                              WHERE
+                                (
+                                  (
+                                    "%2_track"."Name" LIKE cast($1 as "pg_catalog"."varchar")
+                                  )
+                                  AND (
+                                    "%1_ORDER_PART_Album"."AlbumId" = "%2_track"."AlbumId"
+                                  )
+                                )
+                            )
+                          )
+                      ) AS "%1_ORDER_PART_Album"
+                  ) AS "%3_ORDER_FOR_Artist" ON ('true')
+                ORDER BY
+                  "%3_ORDER_FOR_Artist"."count" DESC,
+                  "%0_Artist"."Name" DESC
+                LIMIT
+                  5
+              ) AS "%4_Artist"
+          ) AS "%6_rows"
+      ) AS "%6_rows"
+  ) AS "%5_universe";
 
 {
     1: String(

--- a/crates/query-engine/translation/tests/snapshots/tests__types__select_types_on_comparisons.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__types__select_types_on_comparisons.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%1_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,40 +11,45 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%2_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_types"."date" AS "date"
+              "%1_types"."date" AS "date"
             FROM
-              "public"."types" AS "%0_types"
-            WHERE
               (
-                (
+                SELECT
+                  "%0_types".*
+                FROM
+                  "public"."types" AS "%0_types"
+                WHERE
                   (
                     (
                       (
-                        "%0_types"."date" = cast($1 as "pg_catalog"."date")
+                        (
+                          (
+                            "%0_types"."date" = cast($1 as "pg_catalog"."date")
+                          )
+                          AND (
+                            "%0_types"."time" = cast($2 as "pg_catalog"."time")
+                          )
+                        )
+                        AND (
+                          "%0_types"."timetz" = cast($3 as "pg_catalog"."timetz")
+                        )
                       )
                       AND (
-                        "%0_types"."time" = cast($2 as "pg_catalog"."time")
+                        "%0_types"."timestamp" = cast($4 as "pg_catalog"."timestamp")
                       )
                     )
                     AND (
-                      "%0_types"."timetz" = cast($3 as "pg_catalog"."timetz")
+                      "%0_types"."timestamptz" = cast($5 as "pg_catalog"."timestamptz")
                     )
                   )
-                  AND (
-                    "%0_types"."timestamp" = cast($4 as "pg_catalog"."timestamp")
-                  )
-                )
-                AND (
-                  "%0_types"."timestamptz" = cast($5 as "pg_catalog"."timestamptz")
-                )
-              )
-          ) AS "%2_rows"
-      ) AS "%2_rows"
-  ) AS "%1_universe";
+              ) AS "%1_types"
+          ) AS "%3_rows"
+      ) AS "%3_rows"
+  ) AS "%2_universe";
 
 {
     1: String(

--- a/crates/query-engine/translation/tests/snapshots/tests__types__select_types_on_native_queries.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__types__select_types_on_native_queries.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 WITH "%1_NATIVE_QUERY_types" AS (
-  WITH "%6_NATIVE_QUERY_types" AS (
+  WITH "%7_NATIVE_QUERY_types" AS (
     SELECT
       cast($1 as "pg_catalog"."date") as date,
       cast($2 as "pg_catalog"."time") as time,
@@ -14,10 +14,10 @@ WITH "%1_NATIVE_QUERY_types" AS (
   SELECT
     *
   FROM
-    "%6_NATIVE_QUERY_types" AS "%7_NATIVE_QUERY_types"
+    "%7_NATIVE_QUERY_types" AS "%8_NATIVE_QUERY_types"
 )
 SELECT
-  coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%3_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -25,20 +25,25 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_types"."date" AS "date",
-              "%0_types"."time" AS "time",
-              "%0_types"."timetz" AS "timetz",
-              "%0_types"."timestamp" AS "timestamp",
-              "%0_types"."timestamptz" AS "timestamptz"
+              "%2_types"."date" AS "date",
+              "%2_types"."time" AS "time",
+              "%2_types"."timetz" AS "timetz",
+              "%2_types"."timestamp" AS "timestamp",
+              "%2_types"."timestamptz" AS "timestamptz"
             FROM
-              "%1_NATIVE_QUERY_types" AS "%0_types"
-          ) AS "%3_rows"
-      ) AS "%3_rows"
-  ) AS "%2_universe";
+              (
+                SELECT
+                  "%0_types".*
+                FROM
+                  "%1_NATIVE_QUERY_types" AS "%0_types"
+              ) AS "%2_types"
+          ) AS "%4_rows"
+      ) AS "%4_rows"
+  ) AS "%3_universe";
 
 {
     1: String(

--- a/crates/query-engine/translation/tests/snapshots/tests__very_nested_recursive_relationship.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__very_nested_recursive_relationship.snap
@@ -3,7 +3,7 @@ source: crates/query-engine/translation/tests/tests.rs
 expression: result
 ---
 SELECT
-  coalesce(json_agg(row_to_json("%17_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%22_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -11,16 +11,21 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%18_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%23_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%1_RELATIONSHIP_Albums"."Albums" AS "Albums"
+              "%2_RELATIONSHIP_Albums"."Albums" AS "Albums"
             FROM
-              "public"."Artist" AS "%0_Artist"
+              (
+                SELECT
+                  "%0_Artist".*
+                FROM
+                  "public"."Artist" AS "%0_Artist"
+              ) AS "%1_Artist"
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  row_to_json("%1_RELATIONSHIP_Albums") AS "Albums"
+                  row_to_json("%2_RELATIONSHIP_Albums") AS "Albums"
                 FROM
                   (
                     SELECT
@@ -28,16 +33,23 @@ FROM
                     FROM
                       (
                         SELECT
-                          coalesce(json_agg(row_to_json("%15_rows")), '[]') AS "rows"
+                          coalesce(json_agg(row_to_json("%20_rows")), '[]') AS "rows"
                         FROM
                           (
                             SELECT
-                              "%3_RELATIONSHIP_Artist"."Artist" AS "Artist"
+                              "%5_RELATIONSHIP_Artist"."Artist" AS "Artist"
                             FROM
-                              "public"."Album" AS "%2_Album"
+                              (
+                                SELECT
+                                  "%3_Album".*
+                                FROM
+                                  "public"."Album" AS "%3_Album"
+                                WHERE
+                                  ("%1_Artist"."ArtistId" = "%3_Album"."ArtistId")
+                              ) AS "%4_Album"
                               LEFT OUTER JOIN LATERAL (
                                 SELECT
-                                  row_to_json("%3_RELATIONSHIP_Artist") AS "Artist"
+                                  row_to_json("%5_RELATIONSHIP_Artist") AS "Artist"
                                 FROM
                                   (
                                     SELECT
@@ -45,17 +57,24 @@ FROM
                                     FROM
                                       (
                                         SELECT
-                                          coalesce(json_agg(row_to_json("%13_rows")), '[]') AS "rows"
+                                          coalesce(json_agg(row_to_json("%18_rows")), '[]') AS "rows"
                                         FROM
                                           (
                                             SELECT
-                                              "%4_Artist"."Name" AS "name",
-                                              "%5_RELATIONSHIP_Albums"."Albums" AS "Albums"
+                                              "%7_Artist"."Name" AS "name",
+                                              "%8_RELATIONSHIP_Albums"."Albums" AS "Albums"
                                             FROM
-                                              "public"."Artist" AS "%4_Artist"
+                                              (
+                                                SELECT
+                                                  "%6_Artist".*
+                                                FROM
+                                                  "public"."Artist" AS "%6_Artist"
+                                                WHERE
+                                                  ("%4_Album"."ArtistId" = "%6_Artist"."ArtistId")
+                                              ) AS "%7_Artist"
                                               LEFT OUTER JOIN LATERAL (
                                                 SELECT
-                                                  row_to_json("%5_RELATIONSHIP_Albums") AS "Albums"
+                                                  row_to_json("%8_RELATIONSHIP_Albums") AS "Albums"
                                                 FROM
                                                   (
                                                     SELECT
@@ -63,16 +82,23 @@ FROM
                                                     FROM
                                                       (
                                                         SELECT
-                                                          coalesce(json_agg(row_to_json("%11_rows")), '[]') AS "rows"
+                                                          coalesce(json_agg(row_to_json("%16_rows")), '[]') AS "rows"
                                                         FROM
                                                           (
                                                             SELECT
-                                                              "%7_RELATIONSHIP_Artist"."Artist" AS "Artist"
+                                                              "%11_RELATIONSHIP_Artist"."Artist" AS "Artist"
                                                             FROM
-                                                              "public"."Album" AS "%6_Album"
+                                                              (
+                                                                SELECT
+                                                                  "%9_Album".*
+                                                                FROM
+                                                                  "public"."Album" AS "%9_Album"
+                                                                WHERE
+                                                                  ("%7_Artist"."ArtistId" = "%9_Album"."ArtistId")
+                                                              ) AS "%10_Album"
                                                               LEFT OUTER JOIN LATERAL (
                                                                 SELECT
-                                                                  row_to_json("%7_RELATIONSHIP_Artist") AS "Artist"
+                                                                  row_to_json("%11_RELATIONSHIP_Artist") AS "Artist"
                                                                 FROM
                                                                   (
                                                                     SELECT
@@ -80,39 +106,38 @@ FROM
                                                                     FROM
                                                                       (
                                                                         SELECT
-                                                                          coalesce(json_agg(row_to_json("%9_rows")), '[]') AS "rows"
+                                                                          coalesce(json_agg(row_to_json("%14_rows")), '[]') AS "rows"
                                                                         FROM
                                                                           (
                                                                             SELECT
-                                                                              "%8_Artist"."Name" AS "name"
+                                                                              "%13_Artist"."Name" AS "name"
                                                                             FROM
-                                                                              "public"."Artist" AS "%8_Artist"
-                                                                            WHERE
-                                                                              ("%6_Album"."ArtistId" = "%8_Artist"."ArtistId")
-                                                                          ) AS "%9_rows"
-                                                                      ) AS "%9_rows"
-                                                                  ) AS "%7_RELATIONSHIP_Artist"
-                                                              ) AS "%7_RELATIONSHIP_Artist" ON ('true')
-                                                            WHERE
-                                                              ("%4_Artist"."ArtistId" = "%6_Album"."ArtistId")
-                                                          ) AS "%11_rows"
-                                                      ) AS "%11_rows"
-                                                  ) AS "%5_RELATIONSHIP_Albums"
-                                              ) AS "%5_RELATIONSHIP_Albums" ON ('true')
-                                            WHERE
-                                              ("%2_Album"."ArtistId" = "%4_Artist"."ArtistId")
-                                          ) AS "%13_rows"
-                                      ) AS "%13_rows"
-                                  ) AS "%3_RELATIONSHIP_Artist"
-                              ) AS "%3_RELATIONSHIP_Artist" ON ('true')
-                            WHERE
-                              ("%0_Artist"."ArtistId" = "%2_Album"."ArtistId")
-                          ) AS "%15_rows"
-                      ) AS "%15_rows"
-                  ) AS "%1_RELATIONSHIP_Albums"
-              ) AS "%1_RELATIONSHIP_Albums" ON ('true')
-          ) AS "%18_rows"
-      ) AS "%18_rows"
-  ) AS "%17_universe";
+                                                                              (
+                                                                                SELECT
+                                                                                  "%12_Artist".*
+                                                                                FROM
+                                                                                  "public"."Artist" AS "%12_Artist"
+                                                                                WHERE
+                                                                                  ("%10_Album"."ArtistId" = "%12_Artist"."ArtistId")
+                                                                              ) AS "%13_Artist"
+                                                                          ) AS "%14_rows"
+                                                                      ) AS "%14_rows"
+                                                                  ) AS "%11_RELATIONSHIP_Artist"
+                                                              ) AS "%11_RELATIONSHIP_Artist" ON ('true')
+                                                          ) AS "%16_rows"
+                                                      ) AS "%16_rows"
+                                                  ) AS "%8_RELATIONSHIP_Albums"
+                                              ) AS "%8_RELATIONSHIP_Albums" ON ('true')
+                                          ) AS "%18_rows"
+                                      ) AS "%18_rows"
+                                  ) AS "%5_RELATIONSHIP_Artist"
+                              ) AS "%5_RELATIONSHIP_Artist" ON ('true')
+                          ) AS "%20_rows"
+                      ) AS "%20_rows"
+                  ) AS "%2_RELATIONSHIP_Albums"
+              ) AS "%2_RELATIONSHIP_Albums" ON ('true')
+          ) AS "%23_rows"
+      ) AS "%23_rows"
+  ) AS "%22_universe";
 
 {}

--- a/crates/tests/databases-tests/src/citus/explain_tests.rs
+++ b/crates/tests/databases-tests/src/citus/explain_tests.rs
@@ -21,13 +21,7 @@ mod explain {
     #[tokio::test]
     async fn select_where_name_nilike() {
         let result = run_query_explain(create_router().await, "select_where_name_nilike").await;
-        let keywords = &[
-            "Aggregate",
-            "Subquery Scan",
-            "Limit",
-            "Index Scan",
-            "Filter",
-        ];
+        let keywords = &["Aggregate", "Limit", "Index Scan", "Filter"];
         is_contained_in_lines(keywords, &result.details.plan);
         insta::assert_snapshot!(result.details.query);
     }

--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__explain_tests__explain__select_by_pk.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__explain_tests__explain__select_by_pk.snap
@@ -4,7 +4,7 @@ expression: result.details.query
 ---
 EXPLAIN
 SELECT
-  coalesce(json_agg(row_to_json("%1_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -12,15 +12,20 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%2_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Album"."Title" AS "Title"
+              "%1_Album"."Title" AS "Title"
             FROM
-              "public"."Album" AS "%0_Album"
-            WHERE
-              ("%0_Album"."AlbumId" = 35)
-          ) AS "%2_rows"
-      ) AS "%2_rows"
-  ) AS "%1_universe"
+              (
+                SELECT
+                  "%0_Album".*
+                FROM
+                  "public"."Album" AS "%0_Album"
+                WHERE
+                  ("%0_Album"."AlbumId" = 35)
+              ) AS "%1_Album"
+          ) AS "%3_rows"
+      ) AS "%3_rows"
+  ) AS "%2_universe"

--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__explain_tests__explain__select_where_name_nilike.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__explain_tests__explain__select_where_name_nilike.snap
@@ -4,7 +4,7 @@ expression: result.details.query
 ---
 EXPLAIN
 SELECT
-  coalesce(json_agg(row_to_json("%1_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -12,21 +12,26 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%2_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Album"."Title" AS "Title"
+              "%1_Album"."Title" AS "Title"
             FROM
-              "public"."Album" AS "%0_Album"
-            WHERE
               (
-                "%0_Album"."Title" !~~* cast($1 as "pg_catalog"."varchar")
-              )
-            ORDER BY
-              "%0_Album"."AlbumId" ASC
-            LIMIT
-              5
-          ) AS "%2_rows"
-      ) AS "%2_rows"
-  ) AS "%1_universe"
+                SELECT
+                  "%0_Album".*
+                FROM
+                  "public"."Album" AS "%0_Album"
+                WHERE
+                  (
+                    "%0_Album"."Title" !~~* cast($1 as "pg_catalog"."varchar")
+                  )
+                ORDER BY
+                  "%0_Album"."AlbumId" ASC
+                LIMIT
+                  5
+              ) AS "%1_Album"
+          ) AS "%3_rows"
+      ) AS "%3_rows"
+  ) AS "%2_universe"

--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__explain_tests__explain__select_where_variable.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__explain_tests__explain__select_where_variable.snap
@@ -4,11 +4,11 @@ expression: result.details.query
 ---
 EXPLAIN
 SELECT
-  coalesce(json_agg("%5_universe_agg"."universe"), '[]') AS "universe"
+  coalesce(json_agg("%6_universe_agg"."universe"), '[]') AS "universe"
 FROM
   (
     SELECT
-      row_to_json("%2_universe") AS "universe"
+      row_to_json("%3_universe") AS "universe"
     FROM
       jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" "int4", "%variables" "jsonb")
       CROSS JOIN LATERAL (
@@ -17,15 +17,19 @@ FROM
         FROM
           (
             SELECT
-              coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
+              coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
             FROM
               (
                 SELECT
-                  "%1_Album"."Title" AS "Title"
+                  "%2_Album"."Title" AS "Title"
                 FROM
-                  "public"."Album" AS "%1_Album"
-                WHERE
                   (
-                    "%1_Album"."Title" ~~ cast(
+                    SELECT
+                      "%1_Album".*
+                    FROM
+                      "public"."Album" AS "%1_Album"
+                    WHERE
                       (
-                        ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "pg_catalog"."varchar")) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%3_rows") AS "%3_rows") AS "%2_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%5_universe_agg"
+                        "%1_Album"."Title" ~~ cast(
+                          (
+                            ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "pg_catalog"."varchar")) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%2_Album") AS "%4_rows") AS "%4_rows") AS "%3_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%6_universe_agg"

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__explain_tests__explain__select_by_pk.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__explain_tests__explain__select_by_pk.snap
@@ -4,7 +4,7 @@ expression: result.details.query
 ---
 EXPLAIN
 SELECT
-  coalesce(json_agg(row_to_json("%1_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -12,15 +12,20 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%2_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Album"."Title" AS "Title"
+              "%1_Album"."Title" AS "Title"
             FROM
-              "public"."Album" AS "%0_Album"
-            WHERE
-              ("%0_Album"."AlbumId" = 35)
-          ) AS "%2_rows"
-      ) AS "%2_rows"
-  ) AS "%1_universe"
+              (
+                SELECT
+                  "%0_Album".*
+                FROM
+                  "public"."Album" AS "%0_Album"
+                WHERE
+                  ("%0_Album"."AlbumId" = 35)
+              ) AS "%1_Album"
+          ) AS "%3_rows"
+      ) AS "%3_rows"
+  ) AS "%2_universe"

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__explain_tests__explain__select_where_name_nilike.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__explain_tests__explain__select_where_name_nilike.snap
@@ -4,7 +4,7 @@ expression: result.details.query
 ---
 EXPLAIN
 SELECT
-  coalesce(json_agg(row_to_json("%1_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -12,21 +12,26 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%2_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Album"."Title" AS "Title"
+              "%1_Album"."Title" AS "Title"
             FROM
-              "public"."Album" AS "%0_Album"
-            WHERE
               (
-                "%0_Album"."Title" NOT ILIKE cast($1 as "pg_catalog"."varchar")
-              )
-            ORDER BY
-              "%0_Album"."AlbumId" ASC
-            LIMIT
-              5
-          ) AS "%2_rows"
-      ) AS "%2_rows"
-  ) AS "%1_universe"
+                SELECT
+                  "%0_Album".*
+                FROM
+                  "public"."Album" AS "%0_Album"
+                WHERE
+                  (
+                    "%0_Album"."Title" NOT ILIKE cast($1 as "pg_catalog"."varchar")
+                  )
+                ORDER BY
+                  "%0_Album"."AlbumId" ASC
+                LIMIT
+                  5
+              ) AS "%1_Album"
+          ) AS "%3_rows"
+      ) AS "%3_rows"
+  ) AS "%2_universe"

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__explain_tests__explain__select_where_variable.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__explain_tests__explain__select_where_variable.snap
@@ -4,11 +4,11 @@ expression: result.details.query
 ---
 EXPLAIN
 SELECT
-  coalesce(json_agg("%5_universe_agg"."universe"), '[]') AS "universe"
+  coalesce(json_agg("%6_universe_agg"."universe"), '[]') AS "universe"
 FROM
   (
     SELECT
-      row_to_json("%2_universe") AS "universe"
+      row_to_json("%3_universe") AS "universe"
     FROM
       jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" "int4", "%variables" "jsonb")
       CROSS JOIN LATERAL (
@@ -17,15 +17,19 @@ FROM
         FROM
           (
             SELECT
-              coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
+              coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
             FROM
               (
                 SELECT
-                  "%1_Album"."Title" AS "Title"
+                  "%2_Album"."Title" AS "Title"
                 FROM
-                  "public"."Album" AS "%1_Album"
-                WHERE
                   (
-                    "%1_Album"."Title" LIKE cast(
+                    SELECT
+                      "%1_Album".*
+                    FROM
+                      "public"."Album" AS "%1_Album"
+                    WHERE
                       (
-                        ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "pg_catalog"."varchar")) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%3_rows") AS "%3_rows") AS "%2_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%5_universe_agg"
+                        "%1_Album"."Title" LIKE cast(
+                          (
+                            ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "pg_catalog"."varchar")) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%2_Album") AS "%4_rows") AS "%4_rows") AS "%3_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%6_universe_agg"

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__query_tests__native_queries__select_artist_with_album_by_title_relationship_arguments.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__query_tests__native_queries__select_artist_with_album_by_title_relationship_arguments.snap
@@ -16,6 +16,26 @@ expression: result
         }
       },
       {
+        "Name": "The Who",
+        "albums": {
+          "rows": [
+            {
+              "title": "My Generation - The Very Best Of The Who"
+            }
+          ]
+        }
+      },
+      {
+        "Name": "Battlestar Galactica",
+        "albums": {
+          "rows": [
+            {
+              "title": "Battlestar Galactica: The Story So Far"
+            }
+          ]
+        }
+      },
+      {
         "Name": "The Rolling Stones",
         "albums": {
           "rows": []
@@ -28,16 +48,6 @@ expression: result
         }
       },
       {
-        "Name": "The Who",
-        "albums": {
-          "rows": [
-            {
-              "title": "My Generation - The Very Best Of The Who"
-            }
-          ]
-        }
-      },
-      {
         "Name": "Tim Maia",
         "albums": {
           "rows": []
@@ -47,16 +57,6 @@ expression: result
         "Name": "Titãs",
         "albums": {
           "rows": []
-        }
-      },
-      {
-        "Name": "Battlestar Galactica",
-        "albums": {
-          "rows": [
-            {
-              "title": "Battlestar Galactica: The Story So Far"
-            }
-          ]
         }
       }
     ]

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__query_tests__native_queries__select_order_by_artist_album_count.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__query_tests__native_queries__select_order_by_artist_album_count.snap
@@ -6,6 +6,38 @@ expression: result
   {
     "rows": [
       {
+        "Name": "Black Label Society",
+        "albums": {
+          "aggregates": {
+            "how_many_albums": 2
+          },
+          "rows": [
+            {
+              "Title": "Alcohol Fueled Brewtality Live! [Disc 1]"
+            },
+            {
+              "Title": "Alcohol Fueled Brewtality Live! [Disc 2]"
+            }
+          ]
+        }
+      },
+      {
+        "Name": "Faith No More",
+        "albums": {
+          "aggregates": {
+            "how_many_albums": 2
+          },
+          "rows": [
+            {
+              "Title": "Album Of The Year"
+            },
+            {
+              "Title": "Angel Dust"
+            }
+          ]
+        }
+      },
+      {
         "Name": "Iron Maiden",
         "albums": {
           "aggregates": {
@@ -39,38 +71,6 @@ expression: result
             },
             {
               "Title": "Arquivo Os Paralamas Do Sucesso"
-            }
-          ]
-        }
-      },
-      {
-        "Name": "Black Label Society",
-        "albums": {
-          "aggregates": {
-            "how_many_albums": 2
-          },
-          "rows": [
-            {
-              "Title": "Alcohol Fueled Brewtality Live! [Disc 1]"
-            },
-            {
-              "Title": "Alcohol Fueled Brewtality Live! [Disc 2]"
-            }
-          ]
-        }
-      },
-      {
-        "Name": "Faith No More",
-        "albums": {
-          "aggregates": {
-            "how_many_albums": 2
-          },
-          "rows": [
-            {
-              "Title": "Album Of The Year"
-            },
-            {
-              "Title": "Angel Dust"
             }
           ]
         }

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__query_tests__sorting__select_order_by_artist_name_with_name.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__query_tests__sorting__select_order_by_artist_name_with_name.snap
@@ -29,16 +29,6 @@ expression: result
         "Artist": {
           "rows": [
             {
-              "Name": "Aaron Copland & London Symphony Orchestra"
-            }
-          ]
-        },
-        "Name": "A Copland Celebration, Vol. I"
-      },
-      {
-        "Artist": {
-          "rows": [
-            {
               "Name": "Aaron Goldberg"
             }
           ]
@@ -54,6 +44,16 @@ expression: result
           ]
         },
         "Name": "The World of Classical Favourites"
+      },
+      {
+        "Artist": {
+          "rows": [
+            {
+              "Name": "Aaron Copland & London Symphony Orchestra"
+            }
+          ]
+        },
+        "Name": "A Copland Celebration, Vol. I"
       }
     ]
   }

--- a/crates/tests/databases-tests/src/postgres/explain_tests.rs
+++ b/crates/tests/databases-tests/src/postgres/explain_tests.rs
@@ -21,13 +21,7 @@ mod query {
     #[tokio::test]
     async fn select_where_name_nilike() {
         let result = run_query_explain(create_router().await, "select_where_name_nilike").await;
-        let keywords = &[
-            "Aggregate",
-            "Subquery Scan",
-            "Limit",
-            "Index Scan",
-            "Filter",
-        ];
+        let keywords = &["Aggregate", "Limit", "Index Scan", "Filter"];
         is_contained_in_lines(keywords, &result.details.plan);
         insta::assert_snapshot!(result.details.query);
     }
@@ -35,13 +29,7 @@ mod query {
     #[tokio::test]
     async fn duplicate_filter_results() {
         let result = run_query_explain(create_router().await, "duplicate_filter_results").await;
-        let keywords = &[
-            "Aggregate",
-            "Subquery Scan",
-            "Limit",
-            "Index Scan",
-            "Filter",
-        ];
+        let keywords = &["Aggregate", "Limit", "Index Scan", "Filter"];
         is_contained_in_lines(keywords, &result.details.plan);
         insta::assert_snapshot!(result.details.query);
     }
@@ -50,13 +38,7 @@ mod query {
     async fn duplicate_filter_results_nested() {
         let result =
             run_query_explain(create_router().await, "duplicate_filter_results_nested").await;
-        let keywords = &[
-            "Aggregate",
-            "Subquery Scan",
-            "Limit",
-            "Index Scan",
-            "Filter",
-        ];
+        let keywords = &["Aggregate", "Limit", "Index Scan", "Filter"];
         is_contained_in_lines(keywords, &result.details.plan);
         insta::assert_snapshot!(result.details.query);
     }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__delete_invoice_line.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__delete_invoice_line.snap
@@ -36,7 +36,7 @@ EXPLAIN WITH "%0_generated_mutation" AS (
 SELECT
   (
     SELECT
-      json_build_object('result', row_to_json("%7_universe"), 'type', $1) AS "universe"
+      json_build_object('result', row_to_json("%8_universe"), 'type', $1) AS "universe"
     FROM
       (
         SELECT
@@ -44,37 +44,42 @@ SELECT
         FROM
           (
             SELECT
-              coalesce(json_agg(row_to_json("%8_returning")), '[]') AS "returning"
+              coalesce(json_agg(row_to_json("%9_returning")), '[]') AS "returning"
             FROM
               (
                 SELECT
-                  "%4_InvoiceLine"."InvoiceLineId" AS "invoice_line_id",
-                  "%4_InvoiceLine"."Quantity" AS "quantity"
+                  "%5_InvoiceLine"."InvoiceLineId" AS "invoice_line_id",
+                  "%5_InvoiceLine"."Quantity" AS "quantity"
                 FROM
-                  "%0_generated_mutation" AS "%4_InvoiceLine"
-              ) AS "%8_returning"
-          ) AS "%8_returning"
+                  (
+                    SELECT
+                      "%4_InvoiceLine".*
+                    FROM
+                      "%0_generated_mutation" AS "%4_InvoiceLine"
+                  ) AS "%5_InvoiceLine"
+              ) AS "%9_returning"
+          ) AS "%9_returning"
           CROSS JOIN (
             SELECT
               COUNT(*) AS "affected_rows"
             FROM
               (
                 SELECT
-                  "%5_InvoiceLine".*
+                  "%6_InvoiceLine".*
                 FROM
-                  "%0_generated_mutation" AS "%5_InvoiceLine"
-              ) AS "%6_InvoiceLine"
-          ) AS "%9_aggregates"
-      ) AS "%7_universe"
+                  "%0_generated_mutation" AS "%6_InvoiceLine"
+              ) AS "%7_InvoiceLine"
+          ) AS "%10_aggregates"
+      ) AS "%8_universe"
   ) AS "%results",
   (
     SELECT
       coalesce(
         bool_and(
-          "%10_delete_InvoiceLine_by_InvoiceLineId"."%check__constraint"
+          "%11_delete_InvoiceLine_by_InvoiceLineId"."%check__constraint"
         ),
         true
       ) AS "%check__constraint"
     FROM
-      "%0_generated_mutation" AS "%10_delete_InvoiceLine_by_InvoiceLineId"
+      "%0_generated_mutation" AS "%11_delete_InvoiceLine_by_InvoiceLineId"
   ) AS "%check__constraint"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__delete_playlist_track.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__delete_playlist_track.snap
@@ -9,7 +9,7 @@ EXPLAIN WITH "%0_NATIVE_QUERY_delete_playlist_track" AS (
     "TrackId" = 90 RETURNING *
 )
 SELECT
-  json_build_object('result', row_to_json("%4_universe"), 'type', $1) AS "universe"
+  json_build_object('result', row_to_json("%5_universe"), 'type', $1) AS "universe"
 FROM
   (
     SELECT
@@ -17,24 +17,29 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%5_returninG")), '[]') AS "returninG"
+          coalesce(json_agg(row_to_json("%6_returninG")), '[]') AS "returninG"
         FROM
           (
             SELECT
-              "%1_delete_playlist_track"."PlaylistId" AS "playlist_id"
+              "%2_delete_playlist_track"."PlaylistId" AS "playlist_id"
             FROM
-              "%0_NATIVE_QUERY_delete_playlist_track" AS "%1_delete_playlist_track"
-          ) AS "%5_returninG"
-      ) AS "%5_returninG"
+              (
+                SELECT
+                  "%1_delete_playlist_track".*
+                FROM
+                  "%0_NATIVE_QUERY_delete_playlist_track" AS "%1_delete_playlist_track"
+              ) AS "%2_delete_playlist_track"
+          ) AS "%6_returninG"
+      ) AS "%6_returninG"
       CROSS JOIN (
         SELECT
           COUNT(*) AS "affectedRows"
         FROM
           (
             SELECT
-              "%2_delete_playlist_track".*
+              "%3_delete_playlist_track".*
             FROM
-              "%0_NATIVE_QUERY_delete_playlist_track" AS "%2_delete_playlist_track"
-          ) AS "%3_delete_playlist_track"
-      ) AS "%6_aggregates"
-  ) AS "%4_universe"
+              "%0_NATIVE_QUERY_delete_playlist_track" AS "%3_delete_playlist_track"
+          ) AS "%4_delete_playlist_track"
+      ) AS "%7_aggregates"
+  ) AS "%5_universe"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__insert_artist_album.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__insert_artist_album.snap
@@ -9,7 +9,7 @@ EXPLAIN WITH "%0_NATIVE_QUERY_insert_artist" AS (
     (276, cast($1 as "pg_catalog"."varchar")) RETURNING *
 )
 SELECT
-  json_build_object('result', row_to_json("%4_universe"), 'type', $2) AS "universe"
+  json_build_object('result', row_to_json("%5_universe"), 'type', $2) AS "universe"
 FROM
   (
     SELECT
@@ -17,28 +17,33 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%5_returning")), '[]') AS "returning"
+          coalesce(json_agg(row_to_json("%6_returning")), '[]') AS "returning"
         FROM
           (
             SELECT
-              "%1_insert_artist"."ArtistId" AS "artist_id",
-              "%1_insert_artist"."Name" AS "name"
+              "%2_insert_artist"."ArtistId" AS "artist_id",
+              "%2_insert_artist"."Name" AS "name"
             FROM
-              "%0_NATIVE_QUERY_insert_artist" AS "%1_insert_artist"
-          ) AS "%5_returning"
-      ) AS "%5_returning"
+              (
+                SELECT
+                  "%1_insert_artist".*
+                FROM
+                  "%0_NATIVE_QUERY_insert_artist" AS "%1_insert_artist"
+              ) AS "%2_insert_artist"
+          ) AS "%6_returning"
+      ) AS "%6_returning"
       CROSS JOIN (
         SELECT
           COUNT(*) AS "affected_rows"
         FROM
           (
             SELECT
-              "%2_insert_artist".*
+              "%3_insert_artist".*
             FROM
-              "%0_NATIVE_QUERY_insert_artist" AS "%2_insert_artist"
-          ) AS "%3_insert_artist"
-      ) AS "%6_aggregates"
-  ) AS "%4_universe"
+              "%0_NATIVE_QUERY_insert_artist" AS "%3_insert_artist"
+          ) AS "%4_insert_artist"
+      ) AS "%7_aggregates"
+  ) AS "%5_universe"
 
 
 EXPLAIN WITH "%0_NATIVE_QUERY_insert_album" AS (
@@ -48,7 +53,12 @@ EXPLAIN WITH "%0_NATIVE_QUERY_insert_album" AS (
 (348, cast($1 as "pg_catalog"."varchar"), 276) RETURNING *
 )
 SELECT
-  json_build_object('result', row_to_json("%8_universe"), 'type', $2) AS "universe"
+  json_build_object(
+    'result',
+    row_to_json("%10_universe"),
+    'type',
+    $2
+  ) AS "universe"
 FROM
   (
     SELECT
@@ -56,18 +66,23 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%9_returning")), '[]') AS "returning"
+          coalesce(json_agg(row_to_json("%11_returning")), '[]') AS "returning"
         FROM
           (
             SELECT
-              "%1_insert_album"."AlbumId" AS "album_id",
-              "%1_insert_album"."Title" AS "title",
-              "%2_RELATIONSHIP_artist"."artist" AS "artist"
+              "%2_insert_album"."AlbumId" AS "album_id",
+              "%2_insert_album"."Title" AS "title",
+              "%3_RELATIONSHIP_artist"."artist" AS "artist"
             FROM
-              "%0_NATIVE_QUERY_insert_album" AS "%1_insert_album"
+              (
+                SELECT
+                  "%1_insert_album".*
+                FROM
+                  "%0_NATIVE_QUERY_insert_album" AS "%1_insert_album"
+              ) AS "%2_insert_album"
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  row_to_json("%2_RELATIONSHIP_artist") AS "artist"
+                  row_to_json("%3_RELATIONSHIP_artist") AS "artist"
                 FROM
                   (
                     SELECT
@@ -75,32 +90,37 @@ FROM
                     FROM
                       (
                         SELECT
-                          coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
+                          coalesce(json_agg(row_to_json("%6_rows")), '[]') AS "rows"
                         FROM
                           (
                             SELECT
-                              "%3_Artist"."Name" AS "name"
+                              "%5_Artist"."Name" AS "name"
                             FROM
-                              "public"."Artist" AS "%3_Artist"
-                            WHERE
                               (
-                                "%1_insert_album"."ArtistId" = "%3_Artist"."ArtistId"
-                              )
-                          ) AS "%4_rows"
-                      ) AS "%4_rows"
-                  ) AS "%2_RELATIONSHIP_artist"
-              ) AS "%2_RELATIONSHIP_artist" ON ('true')
-          ) AS "%9_returning"
-      ) AS "%9_returning"
+                                SELECT
+                                  "%4_Artist".*
+                                FROM
+                                  "public"."Artist" AS "%4_Artist"
+                                WHERE
+                                  (
+                                    "%2_insert_album"."ArtistId" = "%4_Artist"."ArtistId"
+                                  )
+                              ) AS "%5_Artist"
+                          ) AS "%6_rows"
+                      ) AS "%6_rows"
+                  ) AS "%3_RELATIONSHIP_artist"
+              ) AS "%3_RELATIONSHIP_artist" ON ('true')
+          ) AS "%11_returning"
+      ) AS "%11_returning"
       CROSS JOIN (
         SELECT
           COUNT(*) AS "affected_rows"
         FROM
           (
             SELECT
-              "%6_insert_album".*
+              "%8_insert_album".*
             FROM
-              "%0_NATIVE_QUERY_insert_album" AS "%6_insert_album"
-          ) AS "%7_insert_album"
-      ) AS "%10_aggregates"
-  ) AS "%8_universe"
+              "%0_NATIVE_QUERY_insert_album" AS "%8_insert_album"
+          ) AS "%9_insert_album"
+      ) AS "%12_aggregates"
+  ) AS "%10_universe"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__v2_insert_custom_dog.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__v2_insert_custom_dog.snap
@@ -25,7 +25,7 @@ EXPLAIN WITH "%0_generated_mutation" AS (
 SELECT
   (
     SELECT
-      json_build_object('result', row_to_json("%4_universe"), 'type', $7) AS "universe"
+      json_build_object('result', row_to_json("%5_universe"), 'type', $7) AS "universe"
     FROM
       (
         SELECT
@@ -33,39 +33,44 @@ SELECT
         FROM
           (
             SELECT
-              coalesce(json_agg(row_to_json("%5_returning")), '[]') AS "returning"
+              coalesce(json_agg(row_to_json("%6_returning")), '[]') AS "returning"
             FROM
               (
                 SELECT
-                  cast("%1_custom_dog"."id" as "text") AS "id",
-                  "%1_custom_dog"."name" AS "name",
-                  "%1_custom_dog"."birthday" AS "birthday",
-                  cast("%1_custom_dog"."height_cm" as "text") AS "height_cm",
-                  cast("%1_custom_dog"."height_in" as "text") AS "height_inch",
-                  "%1_custom_dog"."adopter_name" AS "adopter_name"
+                  cast("%2_custom_dog"."id" as "text") AS "id",
+                  "%2_custom_dog"."name" AS "name",
+                  "%2_custom_dog"."birthday" AS "birthday",
+                  cast("%2_custom_dog"."height_cm" as "text") AS "height_cm",
+                  cast("%2_custom_dog"."height_in" as "text") AS "height_inch",
+                  "%2_custom_dog"."adopter_name" AS "adopter_name"
                 FROM
-                  "%0_generated_mutation" AS "%1_custom_dog"
-              ) AS "%5_returning"
-          ) AS "%5_returning"
+                  (
+                    SELECT
+                      "%1_custom_dog".*
+                    FROM
+                      "%0_generated_mutation" AS "%1_custom_dog"
+                  ) AS "%2_custom_dog"
+              ) AS "%6_returning"
+          ) AS "%6_returning"
           CROSS JOIN (
             SELECT
               COUNT(*) AS "affected_rows"
             FROM
               (
                 SELECT
-                  "%2_custom_dog".*
+                  "%3_custom_dog".*
                 FROM
-                  "%0_generated_mutation" AS "%2_custom_dog"
-              ) AS "%3_custom_dog"
-          ) AS "%6_aggregates"
-      ) AS "%4_universe"
+                  "%0_generated_mutation" AS "%3_custom_dog"
+              ) AS "%4_custom_dog"
+          ) AS "%7_aggregates"
+      ) AS "%5_universe"
   ) AS "%results",
   (
     SELECT
       coalesce(
-        bool_and("%7_insert_custom_dog"."%check__constraint"),
+        bool_and("%8_insert_custom_dog"."%check__constraint"),
         true
       ) AS "%check__constraint"
     FROM
-      "%0_generated_mutation" AS "%7_insert_custom_dog"
+      "%0_generated_mutation" AS "%8_insert_custom_dog"
   ) AS "%check__constraint"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__v2_insert_update_custom_dog.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__mutation__v2_insert_update_custom_dog.snap
@@ -22,7 +22,7 @@ EXPLAIN WITH "%0_generated_mutation" AS (
 SELECT
   (
     SELECT
-      json_build_object('result', row_to_json("%4_universe"), 'type', $4) AS "universe"
+      json_build_object('result', row_to_json("%5_universe"), 'type', $4) AS "universe"
     FROM
       (
         SELECT
@@ -30,41 +30,46 @@ SELECT
         FROM
           (
             SELECT
-              coalesce(json_agg(row_to_json("%5_returning")), '[]') AS "returning"
+              coalesce(json_agg(row_to_json("%6_returning")), '[]') AS "returning"
             FROM
               (
                 SELECT
-                  cast("%1_custom_dog"."id" as "text") AS "id",
-                  "%1_custom_dog"."name" AS "name",
-                  "%1_custom_dog"."birthday" AS "birthday",
-                  cast("%1_custom_dog"."height_cm" as "text") AS "height_cm",
-                  cast("%1_custom_dog"."height_in" as "text") AS "height_inch",
-                  "%1_custom_dog"."adopter_name" AS "adopter_name"
+                  cast("%2_custom_dog"."id" as "text") AS "id",
+                  "%2_custom_dog"."name" AS "name",
+                  "%2_custom_dog"."birthday" AS "birthday",
+                  cast("%2_custom_dog"."height_cm" as "text") AS "height_cm",
+                  cast("%2_custom_dog"."height_in" as "text") AS "height_inch",
+                  "%2_custom_dog"."adopter_name" AS "adopter_name"
                 FROM
-                  "%0_generated_mutation" AS "%1_custom_dog"
-              ) AS "%5_returning"
-          ) AS "%5_returning"
+                  (
+                    SELECT
+                      "%1_custom_dog".*
+                    FROM
+                      "%0_generated_mutation" AS "%1_custom_dog"
+                  ) AS "%2_custom_dog"
+              ) AS "%6_returning"
+          ) AS "%6_returning"
           CROSS JOIN (
             SELECT
               COUNT(*) AS "affected_rows"
             FROM
               (
                 SELECT
-                  "%2_custom_dog".*
+                  "%3_custom_dog".*
                 FROM
-                  "%0_generated_mutation" AS "%2_custom_dog"
-              ) AS "%3_custom_dog"
-          ) AS "%6_aggregates"
-      ) AS "%4_universe"
+                  "%0_generated_mutation" AS "%3_custom_dog"
+              ) AS "%4_custom_dog"
+          ) AS "%7_aggregates"
+      ) AS "%5_universe"
   ) AS "%results",
   (
     SELECT
       coalesce(
         bool_and(
-          "%7_update_custom_dog_by_id"."%check__constraint"
+          "%8_update_custom_dog_by_id"."%check__constraint"
         ),
         true
       ) AS "%check__constraint"
     FROM
-      "%0_generated_mutation" AS "%7_update_custom_dog_by_id"
+      "%0_generated_mutation" AS "%8_update_custom_dog_by_id"
   ) AS "%check__constraint"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__duplicate_filter_results.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__duplicate_filter_results.snap
@@ -4,7 +4,7 @@ expression: result.details.query
 ---
 EXPLAIN
 SELECT
-  coalesce(json_agg(row_to_json("%3_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%4_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -12,42 +12,47 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Artist"."Name" AS "Name"
+              "%3_Artist"."Name" AS "Name"
             FROM
-              "public"."Artist" AS "%0_Artist"
-            WHERE
-              EXISTS (
+              (
                 SELECT
-                  1
+                  "%0_Artist".*
                 FROM
-                  (
+                  "public"."Artist" AS "%0_Artist"
+                WHERE
+                  EXISTS (
                     SELECT
-                      "%1_BOOLEXP_Album".*
+                      1
                     FROM
                       (
                         SELECT
-                          *
+                          "%1_BOOLEXP_Album".*
                         FROM
-                          "public"."Album" AS "%1_BOOLEXP_Album"
-                        WHERE
                           (
-                            "%0_Artist"."ArtistId" = "%1_BOOLEXP_Album"."ArtistId"
-                          )
-                      ) AS "%1_BOOLEXP_Album"
-                  ) AS "%2_BOOLEXP_Album"
-                WHERE
-                  (
-                    "%2_BOOLEXP_Album"."Title" ~~ cast($1 as "pg_catalog"."varchar")
+                            SELECT
+                              *
+                            FROM
+                              "public"."Album" AS "%1_BOOLEXP_Album"
+                            WHERE
+                              (
+                                "%0_Artist"."ArtistId" = "%1_BOOLEXP_Album"."ArtistId"
+                              )
+                          ) AS "%1_BOOLEXP_Album"
+                      ) AS "%2_BOOLEXP_Album"
+                    WHERE
+                      (
+                        "%2_BOOLEXP_Album"."Title" ~~ cast($1 as "pg_catalog"."varchar")
+                      )
                   )
-              )
-            ORDER BY
-              "%0_Artist"."ArtistId" ASC
-            LIMIT
-              5
-          ) AS "%4_rows"
-      ) AS "%4_rows"
-  ) AS "%3_universe"
+                ORDER BY
+                  "%0_Artist"."ArtistId" ASC
+                LIMIT
+                  5
+              ) AS "%3_Artist"
+          ) AS "%5_rows"
+      ) AS "%5_rows"
+  ) AS "%4_universe"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__duplicate_filter_results_nested.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__duplicate_filter_results_nested.snap
@@ -4,7 +4,7 @@ expression: result.details.query
 ---
 EXPLAIN
 SELECT
-  coalesce(json_agg(row_to_json("%6_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%7_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -12,72 +12,77 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%7_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%8_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Artist"."Name" AS "Name"
+              "%6_Artist"."Name" AS "Name"
             FROM
-              "public"."Artist" AS "%0_Artist"
-            WHERE
-              EXISTS (
+              (
                 SELECT
-                  1
+                  "%0_Artist".*
                 FROM
-                  (
-                    SELECT
-                      "%2_BOOLEXP_Track".*
-                    FROM
-                      (
-                        SELECT
-                          *
-                        FROM
-                          "public"."Album" AS "%1_BOOLEXP_Album"
-                        WHERE
-                          (
-                            "%0_Artist"."ArtistId" = "%1_BOOLEXP_Album"."ArtistId"
-                          )
-                      ) AS "%1_BOOLEXP_Album"
-                      INNER JOIN LATERAL (
-                        SELECT
-                          *
-                        FROM
-                          "public"."Track" AS "%2_BOOLEXP_Track"
-                        WHERE
-                          (
-                            "%1_BOOLEXP_Album"."AlbumId" = "%2_BOOLEXP_Track"."AlbumId"
-                          )
-                      ) AS "%2_BOOLEXP_Track" ON ('true')
-                  ) AS "%3_BOOLEXP_Track" FULL
-                  OUTER JOIN LATERAL (
-                    SELECT
-                      "%4_BOOLEXP_Album".*
-                    FROM
-                      (
-                        SELECT
-                          *
-                        FROM
-                          "public"."Album" AS "%4_BOOLEXP_Album"
-                        WHERE
-                          (
-                            "%0_Artist"."ArtistId" = "%4_BOOLEXP_Album"."ArtistId"
-                          )
-                      ) AS "%4_BOOLEXP_Album"
-                  ) AS "%5_BOOLEXP_Album" ON ('true')
+                  "public"."Artist" AS "%0_Artist"
                 WHERE
-                  (
-                    (
-                      "%3_BOOLEXP_Track"."Name" ~~ cast($1 as "pg_catalog"."varchar")
-                    )
-                    OR (
-                      "%5_BOOLEXP_Album"."Title" ~~ cast($2 as "pg_catalog"."varchar")
-                    )
+                  EXISTS (
+                    SELECT
+                      1
+                    FROM
+                      (
+                        SELECT
+                          "%2_BOOLEXP_Track".*
+                        FROM
+                          (
+                            SELECT
+                              *
+                            FROM
+                              "public"."Album" AS "%1_BOOLEXP_Album"
+                            WHERE
+                              (
+                                "%0_Artist"."ArtistId" = "%1_BOOLEXP_Album"."ArtistId"
+                              )
+                          ) AS "%1_BOOLEXP_Album"
+                          INNER JOIN LATERAL (
+                            SELECT
+                              *
+                            FROM
+                              "public"."Track" AS "%2_BOOLEXP_Track"
+                            WHERE
+                              (
+                                "%1_BOOLEXP_Album"."AlbumId" = "%2_BOOLEXP_Track"."AlbumId"
+                              )
+                          ) AS "%2_BOOLEXP_Track" ON ('true')
+                      ) AS "%3_BOOLEXP_Track" FULL
+                      OUTER JOIN LATERAL (
+                        SELECT
+                          "%4_BOOLEXP_Album".*
+                        FROM
+                          (
+                            SELECT
+                              *
+                            FROM
+                              "public"."Album" AS "%4_BOOLEXP_Album"
+                            WHERE
+                              (
+                                "%0_Artist"."ArtistId" = "%4_BOOLEXP_Album"."ArtistId"
+                              )
+                          ) AS "%4_BOOLEXP_Album"
+                      ) AS "%5_BOOLEXP_Album" ON ('true')
+                    WHERE
+                      (
+                        (
+                          "%3_BOOLEXP_Track"."Name" ~~ cast($1 as "pg_catalog"."varchar")
+                        )
+                        OR (
+                          "%5_BOOLEXP_Album"."Title" ~~ cast($2 as "pg_catalog"."varchar")
+                        )
+                      )
                   )
-              )
-            ORDER BY
-              "%0_Artist"."ArtistId" ASC
-            LIMIT
-              5
-          ) AS "%7_rows"
-      ) AS "%7_rows"
-  ) AS "%6_universe"
+                ORDER BY
+                  "%0_Artist"."ArtistId" ASC
+                LIMIT
+                  5
+              ) AS "%6_Artist"
+          ) AS "%8_rows"
+      ) AS "%8_rows"
+  ) AS "%7_universe"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__filter_institution_by_nested_field_collection.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__filter_institution_by_nested_field_collection.snap
@@ -4,7 +4,7 @@ expression: result.details.query
 ---
 EXPLAIN
 SELECT
-  coalesce(json_agg(row_to_json("%5_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%6_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -12,42 +12,47 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%6_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%7_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_institution_institution"."id" AS "id",
-              "%0_institution_institution"."name" AS "name",
-              "%3_nested_fields_collect"."collected" AS "staff"
+              "%2_institution_institution"."id" AS "id",
+              "%2_institution_institution"."name" AS "name",
+              "%5_nested_fields_collect"."collected" AS "staff"
             FROM
-              "institution"."institution" AS "%0_institution_institution"
+              (
+                SELECT
+                  "%0_institution_institution".*
+                FROM
+                  "institution"."institution" AS "%0_institution_institution"
+                WHERE
+                  EXISTS (
+                    SELECT
+                      1
+                    FROM
+                      UNNEST("%0_institution_institution"."staff") AS "%1_institution_institution.staff"
+                    WHERE
+                      (
+                        "%1_institution_institution.staff"."last_name" = cast($1 as "pg_catalog"."text")
+                      )
+                  )
+              ) AS "%2_institution_institution"
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  json_agg(row_to_json("%1_nested_fields")) AS "collected"
+                  json_agg(row_to_json("%3_nested_fields")) AS "collected"
                 FROM
                   (
                     SELECT
-                      "%2_institution_institution.staff"."first_name" AS "first_name",
-                      "%2_institution_institution.staff"."last_name" AS "last_name",
-                      "%2_institution_institution.staff"."specialities" AS "specialities"
+                      "%4_institution_institution.staff"."first_name" AS "first_name",
+                      "%4_institution_institution.staff"."last_name" AS "last_name",
+                      "%4_institution_institution.staff"."specialities" AS "specialities"
                     FROM
                       (
                         SELECT
-                          (unnest("%0_institution_institution"."staff")).*
-                      ) AS "%2_institution_institution.staff"
-                  ) AS "%1_nested_fields"
-              ) AS "%3_nested_fields_collect" ON ('true')
-            WHERE
-              EXISTS (
-                SELECT
-                  1
-                FROM
-                  UNNEST("%0_institution_institution"."staff") AS "%4_institution_institution.staff"
-                WHERE
-                  (
-                    "%4_institution_institution.staff"."last_name" = cast($1 as "pg_catalog"."text")
-                  )
-              )
-          ) AS "%6_rows"
-      ) AS "%6_rows"
-  ) AS "%5_universe"
+                          (unnest("%2_institution_institution"."staff")).*
+                      ) AS "%4_institution_institution.staff"
+                  ) AS "%3_nested_fields"
+              ) AS "%5_nested_fields_collect" ON ('true')
+          ) AS "%7_rows"
+      ) AS "%7_rows"
+  ) AS "%6_universe"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__native_queries__embedded_variable.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__native_queries__embedded_variable.snap
@@ -4,16 +4,16 @@ expression: result.details.query
 ---
 EXPLAIN
 SELECT
-  coalesce(json_agg("%6_universe_agg"."universe"), '[]') AS "universe"
+  coalesce(json_agg("%7_universe_agg"."universe"), '[]') AS "universe"
 FROM
   (
     SELECT
-      row_to_json("%3_universe") AS "universe"
+      row_to_json("%4_universe") AS "universe"
     FROM
       jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" "int4", "%variables" "jsonb")
       CROSS JOIN LATERAL (
         WITH "%2_NATIVE_QUERY_album_by_title" AS (
-          WITH "%7_NATIVE_QUERY_album_by_title" AS (
+          WITH "%8_NATIVE_QUERY_album_by_title" AS (
             SELECT
               *
             FROM
@@ -26,25 +26,30 @@ FROM
                 SELECT
                   *
                 FROM
-                  "%7_NATIVE_QUERY_album_by_title" AS "%8_NATIVE_QUERY_album_by_title"
+                  "%8_NATIVE_QUERY_album_by_title" AS "%9_NATIVE_QUERY_album_by_title"
               )
             SELECT
               *
             FROM
               (
                 SELECT
-                  coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
+                  coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
                 FROM
                   (
                     SELECT
-                      "%1_album_by_title"."Title" AS "Title"
+                      "%3_album_by_title"."Title" AS "Title"
                     FROM
-                      "%2_NATIVE_QUERY_album_by_title" AS "%1_album_by_title"
-                    ORDER BY
-                      "%1_album_by_title"."AlbumId" ASC
-                  ) AS "%4_rows"
-              ) AS "%4_rows"
-          ) AS "%3_universe"
+                      (
+                        SELECT
+                          "%1_album_by_title".*
+                        FROM
+                          "%2_NATIVE_QUERY_album_by_title" AS "%1_album_by_title"
+                        ORDER BY
+                          "%1_album_by_title"."AlbumId" ASC
+                      ) AS "%3_album_by_title"
+                  ) AS "%5_rows"
+              ) AS "%5_rows"
+          ) AS "%4_universe"
           ORDER BY
             "%0_%variables_table"."%variable_order" ASC
-        ) AS "%6_universe_agg"
+        ) AS "%7_universe_agg"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__nested_field_relationship.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__nested_field_relationship.snap
@@ -4,7 +4,7 @@ expression: result.details.query
 ---
 EXPLAIN
 SELECT
-  coalesce(json_agg(row_to_json("%8_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%10_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -12,29 +12,34 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%9_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%11_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_institution_institution"."name" AS "name",
-              "%7_nested_fields_collect"."collected" AS "staff"
+              "%1_institution_institution"."name" AS "name",
+              "%9_nested_fields_collect"."collected" AS "staff"
             FROM
-              "institution"."institution" AS "%0_institution_institution"
+              (
+                SELECT
+                  "%0_institution_institution".*
+                FROM
+                  "institution"."institution" AS "%0_institution_institution"
+              ) AS "%1_institution_institution"
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  json_agg(row_to_json("%1_nested_fields")) AS "collected"
+                  json_agg(row_to_json("%2_nested_fields")) AS "collected"
                 FROM
                   (
                     SELECT
-                      "%3_RELATIONSHIP_favourite_artist"."favourite_artist" AS "favourite_artist"
+                      "%4_RELATIONSHIP_favourite_artist"."favourite_artist" AS "favourite_artist"
                     FROM
                       (
                         SELECT
-                          (unnest("%0_institution_institution"."staff")).*
-                      ) AS "%2_institution_institution.staff"
+                          (unnest("%1_institution_institution"."staff")).*
+                      ) AS "%3_institution_institution.staff"
                       LEFT OUTER JOIN LATERAL (
                         SELECT
-                          row_to_json("%3_RELATIONSHIP_favourite_artist") AS "favourite_artist"
+                          row_to_json("%4_RELATIONSHIP_favourite_artist") AS "favourite_artist"
                         FROM
                           (
                             SELECT
@@ -42,24 +47,29 @@ FROM
                             FROM
                               (
                                 SELECT
-                                  coalesce(json_agg(row_to_json("%5_rows")), '[]') AS "rows"
+                                  coalesce(json_agg(row_to_json("%7_rows")), '[]') AS "rows"
                                 FROM
                                   (
                                     SELECT
-                                      "%4_Artist"."ArtistId" AS "artist_id",
-                                      "%4_Artist"."Name" AS "name"
+                                      "%6_Artist"."ArtistId" AS "artist_id",
+                                      "%6_Artist"."Name" AS "name"
                                     FROM
-                                      "public"."Artist" AS "%4_Artist"
-                                    WHERE
                                       (
-                                        "%2_institution_institution.staff"."favourite_artist_id" = "%4_Artist"."ArtistId"
-                                      )
-                                  ) AS "%5_rows"
-                              ) AS "%5_rows"
-                          ) AS "%3_RELATIONSHIP_favourite_artist"
-                      ) AS "%3_RELATIONSHIP_favourite_artist" ON ('true')
-                  ) AS "%1_nested_fields"
-              ) AS "%7_nested_fields_collect" ON ('true')
-          ) AS "%9_rows"
-      ) AS "%9_rows"
-  ) AS "%8_universe"
+                                        SELECT
+                                          "%5_Artist".*
+                                        FROM
+                                          "public"."Artist" AS "%5_Artist"
+                                        WHERE
+                                          (
+                                            "%3_institution_institution.staff"."favourite_artist_id" = "%5_Artist"."ArtistId"
+                                          )
+                                      ) AS "%6_Artist"
+                                  ) AS "%7_rows"
+                              ) AS "%7_rows"
+                          ) AS "%4_RELATIONSHIP_favourite_artist"
+                      ) AS "%4_RELATIONSHIP_favourite_artist" ON ('true')
+                  ) AS "%2_nested_fields"
+              ) AS "%9_nested_fields_collect" ON ('true')
+          ) AS "%11_rows"
+      ) AS "%11_rows"
+  ) AS "%10_universe"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__order_by_nested_field.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__order_by_nested_field.snap
@@ -4,7 +4,7 @@ expression: result.details.query
 ---
 EXPLAIN
 SELECT
-  coalesce(json_agg(row_to_json("%10_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%11_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -12,63 +12,68 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%11_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%12_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%3_nested_fields_collect"."collected" AS "name",
-              "%9_nested_fields_collect"."collected" AS "characters"
+              "%4_nested_fields_collect"."collected" AS "name",
+              "%10_nested_fields_collect"."collected" AS "characters"
             FROM
-              "public"."group_leader" AS "%0_group_leader"
+              (
+                SELECT
+                  "%0_group_leader".*
+                FROM
+                  "public"."group_leader" AS "%0_group_leader"
+                ORDER BY
+                  ("%0_group_leader"."characters")."name" DESC
+              ) AS "%1_group_leader"
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  row_to_json("%1_nested_fields") AS "collected"
+                  row_to_json("%2_nested_fields") AS "collected"
                 FROM
                   (
                     SELECT
-                      "%2_group_leader.name"."name" AS "name",
-                      cast("%2_group_leader.name"."popularity" as "text") AS "popularity"
+                      "%3_group_leader.name"."name" AS "name",
+                      cast("%3_group_leader.name"."popularity" as "text") AS "popularity"
                     FROM
                       (
                         SELECT
-                          ("%0_group_leader"."name").*
-                      ) AS "%2_group_leader.name"
-                  ) AS "%1_nested_fields"
-              ) AS "%3_nested_fields_collect" ON ('true')
+                          ("%1_group_leader"."name").*
+                      ) AS "%3_group_leader.name"
+                  ) AS "%2_nested_fields"
+              ) AS "%4_nested_fields_collect" ON ('true')
               LEFT OUTER JOIN LATERAL (
                 SELECT
-                  row_to_json("%4_nested_fields") AS "collected"
+                  row_to_json("%5_nested_fields") AS "collected"
                 FROM
                   (
                     SELECT
-                      "%8_nested_fields_collect"."collected" AS "members",
-                      "%5_group_leader.characters"."name" AS "name"
+                      "%9_nested_fields_collect"."collected" AS "members",
+                      "%6_group_leader.characters"."name" AS "name"
                     FROM
                       (
                         SELECT
-                          ("%0_group_leader"."characters").*
-                      ) AS "%5_group_leader.characters"
+                          ("%1_group_leader"."characters").*
+                      ) AS "%6_group_leader.characters"
                       LEFT OUTER JOIN LATERAL (
                         SELECT
-                          json_agg(row_to_json("%6_nested_fields")) AS "collected"
+                          json_agg(row_to_json("%7_nested_fields")) AS "collected"
                         FROM
                           (
                             SELECT
-                              "%7_group_leader.characters.members"."name" AS "name",
+                              "%8_group_leader.characters.members"."name" AS "name",
                               cast(
-                                "%7_group_leader.characters.members"."popularity" as "text"
+                                "%8_group_leader.characters.members"."popularity" as "text"
                               ) AS "popularity"
                             FROM
                               (
                                 SELECT
-                                  (unnest("%5_group_leader.characters"."members")).*
-                              ) AS "%7_group_leader.characters.members"
-                          ) AS "%6_nested_fields"
-                      ) AS "%8_nested_fields_collect" ON ('true')
-                  ) AS "%4_nested_fields"
-              ) AS "%9_nested_fields_collect" ON ('true')
-            ORDER BY
-              ("%0_group_leader"."characters")."name" DESC
-          ) AS "%11_rows"
-      ) AS "%11_rows"
-  ) AS "%10_universe"
+                                  (unnest("%6_group_leader.characters"."members")).*
+                              ) AS "%8_group_leader.characters.members"
+                          ) AS "%7_nested_fields"
+                      ) AS "%9_nested_fields_collect" ON ('true')
+                  ) AS "%5_nested_fields"
+              ) AS "%10_nested_fields_collect" ON ('true')
+          ) AS "%12_rows"
+      ) AS "%12_rows"
+  ) AS "%11_universe"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__select_by_pk.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__select_by_pk.snap
@@ -4,7 +4,7 @@ expression: result.details.query
 ---
 EXPLAIN
 SELECT
-  coalesce(json_agg(row_to_json("%1_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -12,15 +12,20 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%2_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Album"."Title" AS "Title"
+              "%1_Album"."Title" AS "Title"
             FROM
-              "public"."Album" AS "%0_Album"
-            WHERE
-              ("%0_Album"."AlbumId" = 35)
-          ) AS "%2_rows"
-      ) AS "%2_rows"
-  ) AS "%1_universe"
+              (
+                SELECT
+                  "%0_Album".*
+                FROM
+                  "public"."Album" AS "%0_Album"
+                WHERE
+                  ("%0_Album"."AlbumId" = 35)
+              ) AS "%1_Album"
+          ) AS "%3_rows"
+      ) AS "%3_rows"
+  ) AS "%2_universe"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__select_where_name_nilike.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__select_where_name_nilike.snap
@@ -4,7 +4,7 @@ expression: result.details.query
 ---
 EXPLAIN
 SELECT
-  coalesce(json_agg(row_to_json("%1_universe")), '[]') AS "universe"
+  coalesce(json_agg(row_to_json("%2_universe")), '[]') AS "universe"
 FROM
   (
     SELECT
@@ -12,21 +12,26 @@ FROM
     FROM
       (
         SELECT
-          coalesce(json_agg(row_to_json("%2_rows")), '[]') AS "rows"
+          coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
         FROM
           (
             SELECT
-              "%0_Album"."Title" AS "Title"
+              "%1_Album"."Title" AS "Title"
             FROM
-              "public"."Album" AS "%0_Album"
-            WHERE
               (
-                "%0_Album"."Title" !~~* cast($1 as "pg_catalog"."varchar")
-              )
-            ORDER BY
-              "%0_Album"."AlbumId" ASC
-            LIMIT
-              5
-          ) AS "%2_rows"
-      ) AS "%2_rows"
-  ) AS "%1_universe"
+                SELECT
+                  "%0_Album".*
+                FROM
+                  "public"."Album" AS "%0_Album"
+                WHERE
+                  (
+                    "%0_Album"."Title" !~~* cast($1 as "pg_catalog"."varchar")
+                  )
+                ORDER BY
+                  "%0_Album"."AlbumId" ASC
+                LIMIT
+                  5
+              ) AS "%1_Album"
+          ) AS "%3_rows"
+      ) AS "%3_rows"
+  ) AS "%2_universe"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__select_where_no_variable.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__select_where_no_variable.snap
@@ -4,11 +4,11 @@ expression: result.details.query
 ---
 EXPLAIN
 SELECT
-  coalesce(json_agg("%5_universe_agg"."universe"), '[]') AS "universe"
+  coalesce(json_agg("%6_universe_agg"."universe"), '[]') AS "universe"
 FROM
   (
     SELECT
-      row_to_json("%2_universe") AS "universe"
+      row_to_json("%3_universe") AS "universe"
     FROM
       jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" "int4", "%variables" "jsonb")
       CROSS JOIN LATERAL (
@@ -17,15 +17,19 @@ FROM
         FROM
           (
             SELECT
-              coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
+              coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
             FROM
               (
                 SELECT
-                  "%1_Album"."Title" AS "Title"
+                  "%2_Album"."Title" AS "Title"
                 FROM
-                  "public"."Album" AS "%1_Album"
-                WHERE
                   (
-                    "%1_Album"."Title" ~~ cast(
+                    SELECT
+                      "%1_Album".*
+                    FROM
+                      "public"."Album" AS "%1_Album"
+                    WHERE
                       (
-                        ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "pg_catalog"."varchar")) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%3_rows") AS "%3_rows") AS "%2_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%5_universe_agg"
+                        "%1_Album"."Title" ~~ cast(
+                          (
+                            ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "pg_catalog"."varchar")) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%2_Album") AS "%4_rows") AS "%4_rows") AS "%3_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%6_universe_agg"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__select_where_variable.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__select_where_variable.snap
@@ -4,11 +4,11 @@ expression: result.details.query
 ---
 EXPLAIN
 SELECT
-  coalesce(json_agg("%5_universe_agg"."universe"), '[]') AS "universe"
+  coalesce(json_agg("%6_universe_agg"."universe"), '[]') AS "universe"
 FROM
   (
     SELECT
-      row_to_json("%2_universe") AS "universe"
+      row_to_json("%3_universe") AS "universe"
     FROM
       jsonb_to_recordset($1) AS "%0_%variables_table"("%variable_order" "int4", "%variables" "jsonb")
       CROSS JOIN LATERAL (
@@ -17,15 +17,19 @@ FROM
         FROM
           (
             SELECT
-              coalesce(json_agg(row_to_json("%3_rows")), '[]') AS "rows"
+              coalesce(json_agg(row_to_json("%4_rows")), '[]') AS "rows"
             FROM
               (
                 SELECT
-                  "%1_Album"."Title" AS "Title"
+                  "%2_Album"."Title" AS "Title"
                 FROM
-                  "public"."Album" AS "%1_Album"
-                WHERE
                   (
-                    "%1_Album"."Title" ~~ cast(
+                    SELECT
+                      "%1_Album".*
+                    FROM
+                      "public"."Album" AS "%1_Album"
+                    WHERE
                       (
-                        ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "pg_catalog"."varchar")) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%3_rows") AS "%3_rows") AS "%2_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%5_universe_agg"
+                        "%1_Album"."Title" ~~ cast(
+                          (
+                            ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "pg_catalog"."varchar")) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%2_Album") AS "%4_rows") AS "%4_rows") AS "%3_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%6_universe_agg"


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

<!-- What is this PR trying to accomplish (and why, if it's not obvious)? -->
This PR copies some patterns used in v2, which it turns out yield better performance on cockroachdb.

<!-- Consider: do we need to add a changelog entry? -->

### How

<!-- How is it trying to accomplish it (what are the implementation steps)? -->

We add an additional subquery wherever we directly reference a source table, to make sure the where clause for that table is applied before any lateral joins.

### Ordering

Ordering and limit are also moved into the subquery.

V2 instead does the following:
- if ordering across a relationship, put the join and order by clause outside the subquery, at the same level as other relationships. also put any limit clause there
- if ordering on a local field, put the order by and limit inside the subquery. additionally, also put a copy of the order by clause outside the subquery, at the same level as relationships

We do not replicate this behavior, and the last bit worries me.
Will ordering be preserved without the second order by clause?

Commiting as is for now but will probably add the clause.