### PR TITLE
Improve ordering with subquery

### DIFF
--- a/crates/query-engine/translation/src/translation/query/root.rs
+++ b/crates/query-engine/translation/src/translation/query/root.rs
@@ -107,6 +107,62 @@ pub enum ReturnsFields {
 }
 
 /// Translate rows part of query to sql ast.
+///
+/// To improve performance, we want to reduce the rows in scope as much as possible before performing any joins for relationships
+/// To do this, we add a subquery with the where clause, any required joins, and possibly an order by and limit clause
+/// If ordering by columns in another table, we instead add the order by, required joins, and limit to the parent query
+/// If ordering in the subquery, we must also apply the order by in the parent, as ordering is not guaranteed after joins
+///
+/// Example: Order by a column on the target table
+/// ```sql
+/// SELECT
+/// "%1_Album"."Title" AS "Title"
+/// FROM
+///   (
+///     SELECT
+///       "%0_Album".*
+///     FROM
+///       "public"."Album" AS "%0_Album"
+///     ORDER BY
+///       "%0_Album"."AlbumId" ASC
+///     LIMIT
+///       5
+///   ) AS "%1_Album"
+/// ORDER BY
+///   "%1_Album"."AlbumId" ASC
+/// ```
+///
+/// Example: Order by a related column
+/// ```sql
+/// SELECT
+///   "%1_Album"."Title" AS "Name"
+/// FROM
+///   (
+///     SELECT
+///       "%0_Album".*
+///     FROM
+///       "public"."Album" AS "%0_Album"
+///   ) AS "%1_Album"
+///   LEFT OUTER JOIN LATERAL (
+///     SELECT
+///       "%2_ORDER_PART_Artist"."Name" AS "Name"
+///     FROM
+///       (
+///         SELECT
+///           "%2_ORDER_PART_Artist"."Name" AS "Name"
+///         FROM
+///           "public"."Artist" AS "%2_ORDER_PART_Artist"
+///         WHERE
+///           (
+///             "%1_Album"."ArtistId" = "%2_ORDER_PART_Artist"."ArtistId"
+///           )
+///       ) AS "%2_ORDER_PART_Artist"
+///   ) AS "%3_ORDER_FOR_Album" ON ('true')
+/// ORDER BY
+///   "%3_ORDER_FOR_Album"."Name" ASC
+/// LIMIT
+///   5 OFFSET 3
+/// ```
 fn translate_rows(
     env: &Env,
     state: &mut State,
@@ -116,19 +172,71 @@ fn translate_rows(
 ) -> Result<(ReturnsFields, sql::ast::Select), Error> {
     let (current_table, from_clause) = make_reference_and_from_clause(env, state, make_from)?;
 
+    // the root table and the current table are the same at this point
+    let subquery_root_and_current_table = RootAndCurrentTables {
+        root_table: current_table.clone(),
+        current_table: current_table.clone(),
+    };
+
+    let mut subquery_select =
+        sql::helpers::star_from_select(current_table.reference.clone(), from_clause);
+
+    // we want to put the where clause, including any required joins, in a subquery that is applied before any joins used to navigate relationships
+
+    // translate where
+    let filter = match &query.predicate {
+        None => Ok(sql::helpers::true_expr()),
+        Some(predicate) => {
+            filtering::translate(env, state, &subquery_root_and_current_table, predicate)
+        }
+    }?;
+
+    // Apply a join predicate if we want one.
+    subquery_select.where_ = match join_predicate {
+        // Only apply the existing filter.
+        None => sql::ast::Where(filter),
+        Some(join_predicate) => {
+            // Apply the join predicate.
+            sql::ast::Where(relationships::translate_column_mapping(
+                env,
+                join_predicate.join_with,
+                &current_table.reference,
+                filter, // AND with the existing filter.
+                join_predicate.relationship,
+            )?)
+        }
+    };
+
+    // unless there is an order by clause that traverses relationships, we can put the order by clause and limit in the subquery
+    let has_order_by_across_relationship = query.order_by.as_ref().is_some_and(|order_by| {
+        order_by
+            .elements
+            .iter()
+            .any(|element| match &element.target {
+                ndc_models::OrderByTarget::Column { path, .. }
+                | ndc_models::OrderByTarget::SingleColumnAggregate { path, .. }
+                | ndc_models::OrderByTarget::StarCountAggregate { path } => !path.is_empty(),
+            })
+    });
+
+    if !has_order_by_across_relationship {
+        // translate order_by
+        // we expect order_by_joins to be empty, because we're not traversing any relationship
+        let (order_by, _order_by_joins) = sorting::translate(
+            env,
+            state,
+            &subquery_root_and_current_table,
+            query.order_by.as_ref(),
+        )?;
+        subquery_select.order_by = order_by;
+        // Add the limit.
+        subquery_select.limit = sql::ast::Limit {
+            limit: query.limit,
+            offset: query.offset,
+        };
+    };
     // We want to filter and limit on this table in a separate subquery before adding lateral joins for any relationships
     // this improves query planning on cockroachdb
-    let mut select = sql::helpers::star_from_select(current_table.reference.clone(), from_clause);
-
-    // Translate the common part of the query - where, order by, limit, etc.
-    translate_query_part(
-        env,
-        state,
-        &current_table,
-        join_predicate,
-        query,
-        &mut select,
-    )?;
 
     let alias = state.make_table_alias(current_table.source.name_for_alias());
 
@@ -137,8 +245,13 @@ fn translate_rows(
         reference: sql::ast::TableReference::AliasedTable(alias.clone()),
     };
 
+    let root_and_current_table = RootAndCurrentTables {
+        root_table: current_table.clone(),
+        current_table: current_table.clone(),
+    };
+
     let from_clause = sql::ast::From::Select {
-        select: Box::new(select),
+        select: Box::new(subquery_select),
         alias,
     };
 
@@ -172,6 +285,26 @@ fn translate_rows(
         relationships::translate(env, state, &current_table, join_relationship_fields)?;
 
     fields_select.joins.extend(relationship_joins);
+
+    if has_order_by_across_relationship {
+        let (order_by, order_by_joins) =
+            sorting::translate(env, state, &root_and_current_table, query.order_by.as_ref())?;
+
+        fields_select.order_by = order_by;
+        fields_select.joins.extend(order_by_joins);
+
+        // Add the limit.
+        fields_select.limit = sql::ast::Limit {
+            limit: query.limit,
+            offset: query.offset,
+        };
+    } else {
+        // if we aren't ordering across a relationship, we expect joins to be empty
+        // however, we must repeat the order by clause, else ordering may not be guaranteed after joins
+        let (order_by, _order_by_joins) =
+            sorting::translate(env, state, &root_and_current_table, query.order_by.as_ref())?;
+        fields_select.order_by = order_by;
+    }
 
     Ok((returns_fields, fields_select))
 }

--- a/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_with_album_by_title.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_with_album_by_title.snap
@@ -84,6 +84,8 @@ FROM
                       ) AS "%7_rows"
                   ) AS "%3_RELATIONSHIP_Albums"
               ) AS "%3_RELATIONSHIP_Albums" ON ('true')
+            ORDER BY
+              "%2_artist"."ArtistId" ASC
           ) AS "%10_rows"
       ) AS "%10_rows"
   ) AS "%9_universe";

--- a/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_with_album_by_title_relationship_arguments.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__native_queries__select_artist_with_album_by_title_relationship_arguments.snap
@@ -83,10 +83,14 @@ FROM
                                 ORDER BY
                                   "%4_album_by_title"."AlbumId" ASC
                               ) AS "%6_album_by_title"
+                            ORDER BY
+                              "%6_album_by_title"."AlbumId" ASC
                           ) AS "%7_rows"
                       ) AS "%7_rows"
                   ) AS "%3_RELATIONSHIP_Albums"
               ) AS "%3_RELATIONSHIP_Albums" ON ('true')
+            ORDER BY
+              "%2_artist"."ArtistId" ASC
           ) AS "%10_rows"
       ) AS "%10_rows"
   ) AS "%9_universe";

--- a/crates/query-engine/translation/tests/snapshots/tests__select_track_order_by_artist_id_and_album_title.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_track_order_by_artist_id_and_album_title.snap
@@ -15,37 +15,37 @@ FROM
         FROM
           (
             SELECT
-              "%3_Track"."Name" AS "Name"
+              "%1_Track"."Name" AS "Name"
             FROM
               (
                 SELECT
                   "%0_Track".*
                 FROM
                   "public"."Track" AS "%0_Track"
-                  LEFT OUTER JOIN LATERAL (
+              ) AS "%1_Track"
+              LEFT OUTER JOIN LATERAL (
+                SELECT
+                  "%2_ORDER_PART_Album"."ArtistId" AS "ArtistId",
+                  "%2_ORDER_PART_Album"."Title" AS "Title"
+                FROM
+                  (
                     SELECT
-                      "%1_ORDER_PART_Album"."ArtistId" AS "ArtistId",
-                      "%1_ORDER_PART_Album"."Title" AS "Title"
+                      "%2_ORDER_PART_Album"."ArtistId" AS "ArtistId",
+                      "%2_ORDER_PART_Album"."Title" AS "Title"
                     FROM
+                      "public"."Album" AS "%2_ORDER_PART_Album"
+                    WHERE
                       (
-                        SELECT
-                          "%1_ORDER_PART_Album"."ArtistId" AS "ArtistId",
-                          "%1_ORDER_PART_Album"."Title" AS "Title"
-                        FROM
-                          "public"."Album" AS "%1_ORDER_PART_Album"
-                        WHERE
-                          (
-                            "%0_Track"."AlbumId" = "%1_ORDER_PART_Album"."AlbumId"
-                          )
-                      ) AS "%1_ORDER_PART_Album"
-                  ) AS "%2_ORDER_FOR_Track" ON ('true')
-                ORDER BY
-                  "%2_ORDER_FOR_Track"."ArtistId" ASC,
-                  "%0_Track"."Name" ASC,
-                  "%2_ORDER_FOR_Track"."Title" ASC
-                LIMIT
-                  5
-              ) AS "%3_Track"
+                        "%1_Track"."AlbumId" = "%2_ORDER_PART_Album"."AlbumId"
+                      )
+                  ) AS "%2_ORDER_PART_Album"
+              ) AS "%3_ORDER_FOR_Track" ON ('true')
+            ORDER BY
+              "%3_ORDER_FOR_Track"."ArtistId" ASC,
+              "%1_Track"."Name" ASC,
+              "%3_ORDER_FOR_Track"."Title" ASC
+            LIMIT
+              5
           ) AS "%5_rows"
       ) AS "%5_rows"
   ) AS "%4_universe";

--- a/crates/query-engine/translation/tests/snapshots/tests__select_where_album_id_equals_self_nested_object_relationship.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_where_album_id_equals_self_nested_object_relationship.snap
@@ -152,6 +152,8 @@ FROM
                       ) AS "%15_rows"
                   ) AS "%7_RELATIONSHIP_Album"
               ) AS "%7_RELATIONSHIP_Album" ON ('true')
+            ORDER BY
+              "%6_Track"."TrackId" ASC
           ) AS "%18_rows"
       ) AS "%18_rows"
   ) AS "%17_universe";

--- a/crates/query-engine/translation/tests/snapshots/tests__select_where_array_relationship.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__select_where_array_relationship.snap
@@ -77,10 +77,14 @@ FROM
                                 ORDER BY
                                   "%5_Album"."AlbumId" ASC
                               ) AS "%6_Album"
+                            ORDER BY
+                              "%6_Album"."AlbumId" ASC
                           ) AS "%7_rows"
                       ) AS "%7_rows"
                   ) AS "%4_RELATIONSHIP_albums"
               ) AS "%4_RELATIONSHIP_albums" ON ('true')
+            ORDER BY
+              "%3_Artist"."ArtistId" ASC
           ) AS "%10_rows"
       ) AS "%10_rows"
   ) AS "%9_universe";

--- a/crates/query-engine/translation/tests/snapshots/tests__sorting_by_nested_relationship_column.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__sorting_by_nested_relationship_column.snap
@@ -15,41 +15,41 @@ FROM
         FROM
           (
             SELECT
-              "%4_track"."Name" AS "Name"
+              "%1_track"."Name" AS "Name"
             FROM
               (
                 SELECT
                   "%0_track".*
                 FROM
                   "public"."Track" AS "%0_track"
+              ) AS "%1_track"
+              LEFT OUTER JOIN LATERAL (
+                SELECT
+                  "%3_ORDER_PART_artist"."Name" AS "Name"
+                FROM
+                  (
+                    SELECT
+                      "%2_ORDER_PART_album"."ArtistId" AS "ArtistId"
+                    FROM
+                      "public"."Album" AS "%2_ORDER_PART_album"
+                    WHERE
+                      (
+                        "%1_track"."AlbumId" = "%2_ORDER_PART_album"."AlbumId"
+                      )
+                  ) AS "%2_ORDER_PART_album"
                   LEFT OUTER JOIN LATERAL (
                     SELECT
-                      "%2_ORDER_PART_artist"."Name" AS "Name"
+                      "%3_ORDER_PART_artist"."Name" AS "Name"
                     FROM
+                      "public"."Artist" AS "%3_ORDER_PART_artist"
+                    WHERE
                       (
-                        SELECT
-                          "%1_ORDER_PART_album"."ArtistId" AS "ArtistId"
-                        FROM
-                          "public"."Album" AS "%1_ORDER_PART_album"
-                        WHERE
-                          (
-                            "%0_track"."AlbumId" = "%1_ORDER_PART_album"."AlbumId"
-                          )
-                      ) AS "%1_ORDER_PART_album"
-                      LEFT OUTER JOIN LATERAL (
-                        SELECT
-                          "%2_ORDER_PART_artist"."Name" AS "Name"
-                        FROM
-                          "public"."Artist" AS "%2_ORDER_PART_artist"
-                        WHERE
-                          (
-                            "%1_ORDER_PART_album"."ArtistId" = "%2_ORDER_PART_artist"."ArtistId"
-                          )
-                      ) AS "%2_ORDER_PART_artist" ON ('true')
-                  ) AS "%3_ORDER_FOR_track" ON ('true')
-                ORDER BY
-                  "%3_ORDER_FOR_track"."Name" ASC
-              ) AS "%4_track"
+                        "%2_ORDER_PART_album"."ArtistId" = "%3_ORDER_PART_artist"."ArtistId"
+                      )
+                  ) AS "%3_ORDER_PART_artist" ON ('true')
+              ) AS "%4_ORDER_FOR_track" ON ('true')
+            ORDER BY
+              "%4_ORDER_FOR_track"."Name" ASC
           ) AS "%6_rows"
       ) AS "%6_rows"
   ) AS "%5_universe";

--- a/crates/query-engine/translation/tests/snapshots/tests__sorting_by_nested_relationship_column_with_predicate.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__sorting_by_nested_relationship_column_with_predicate.snap
@@ -15,48 +15,48 @@ FROM
         FROM
           (
             SELECT
-              "%4_track"."Name" AS "Name"
+              "%1_track"."Name" AS "Name"
             FROM
               (
                 SELECT
                   "%0_track".*
                 FROM
                   "public"."Track" AS "%0_track"
+              ) AS "%1_track"
+              LEFT OUTER JOIN LATERAL (
+                SELECT
+                  "%3_ORDER_PART_artist"."Name" AS "Name"
+                FROM
+                  (
+                    SELECT
+                      "%2_ORDER_PART_album"."ArtistId" AS "ArtistId"
+                    FROM
+                      "public"."Album" AS "%2_ORDER_PART_album"
+                    WHERE
+                      (
+                        (
+                          "%1_track"."AlbumId" = "%2_ORDER_PART_album"."AlbumId"
+                        )
+                        AND (
+                          "%2_ORDER_PART_album"."Title" = cast($1 as "pg_catalog"."varchar")
+                        )
+                      )
+                  ) AS "%2_ORDER_PART_album"
                   LEFT OUTER JOIN LATERAL (
                     SELECT
-                      "%2_ORDER_PART_artist"."Name" AS "Name"
+                      "%3_ORDER_PART_artist"."Name" AS "Name"
                     FROM
+                      "public"."Artist" AS "%3_ORDER_PART_artist"
+                    WHERE
                       (
-                        SELECT
-                          "%1_ORDER_PART_album"."ArtistId" AS "ArtistId"
-                        FROM
-                          "public"."Album" AS "%1_ORDER_PART_album"
-                        WHERE
-                          (
-                            (
-                              "%0_track"."AlbumId" = "%1_ORDER_PART_album"."AlbumId"
-                            )
-                            AND (
-                              "%1_ORDER_PART_album"."Title" = cast($1 as "pg_catalog"."varchar")
-                            )
-                          )
-                      ) AS "%1_ORDER_PART_album"
-                      LEFT OUTER JOIN LATERAL (
-                        SELECT
-                          "%2_ORDER_PART_artist"."Name" AS "Name"
-                        FROM
-                          "public"."Artist" AS "%2_ORDER_PART_artist"
-                        WHERE
-                          (
-                            "%1_ORDER_PART_album"."ArtistId" = "%2_ORDER_PART_artist"."ArtistId"
-                          )
-                      ) AS "%2_ORDER_PART_artist" ON ('true')
-                  ) AS "%3_ORDER_FOR_track" ON ('true')
-                ORDER BY
-                  "%3_ORDER_FOR_track"."Name" ASC
-                LIMIT
-                  3
-              ) AS "%4_track"
+                        "%2_ORDER_PART_album"."ArtistId" = "%3_ORDER_PART_artist"."ArtistId"
+                      )
+                  ) AS "%3_ORDER_PART_artist" ON ('true')
+              ) AS "%4_ORDER_FOR_track" ON ('true')
+            ORDER BY
+              "%4_ORDER_FOR_track"."Name" ASC
+            LIMIT
+              3
           ) AS "%6_rows"
       ) AS "%6_rows"
   ) AS "%5_universe";

--- a/crates/query-engine/translation/tests/snapshots/tests__sorting_by_nested_relationship_count.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__sorting_by_nested_relationship_count.snap
@@ -15,33 +15,33 @@ FROM
         FROM
           (
             SELECT
-              "%3_Artist"."Name" AS "Name"
+              "%1_Artist"."Name" AS "Name"
             FROM
               (
                 SELECT
                   "%0_Artist".*
                 FROM
                   "public"."Artist" AS "%0_Artist"
-                  LEFT OUTER JOIN LATERAL (
+              ) AS "%1_Artist"
+              LEFT OUTER JOIN LATERAL (
+                SELECT
+                  count("%2_ORDER_PART_Album"."AlbumId") AS "AlbumId"
+                FROM
+                  (
                     SELECT
-                      count("%1_ORDER_PART_Album"."AlbumId") AS "AlbumId"
+                      "%2_ORDER_PART_Album"."AlbumId" AS "AlbumId"
                     FROM
+                      "public"."Album" AS "%2_ORDER_PART_Album"
+                    WHERE
                       (
-                        SELECT
-                          "%1_ORDER_PART_Album"."AlbumId" AS "AlbumId"
-                        FROM
-                          "public"."Album" AS "%1_ORDER_PART_Album"
-                        WHERE
-                          (
-                            "%0_Artist"."ArtistId" = "%1_ORDER_PART_Album"."ArtistId"
-                          )
-                      ) AS "%1_ORDER_PART_Album"
-                  ) AS "%2_ORDER_FOR_Artist" ON ('true')
-                ORDER BY
-                  "%2_ORDER_FOR_Artist"."AlbumId" DESC
-                LIMIT
-                  3
-              ) AS "%3_Artist"
+                        "%1_Artist"."ArtistId" = "%2_ORDER_PART_Album"."ArtistId"
+                      )
+                  ) AS "%2_ORDER_PART_Album"
+              ) AS "%3_ORDER_FOR_Artist" ON ('true')
+            ORDER BY
+              "%3_ORDER_FOR_Artist"."AlbumId" DESC
+            LIMIT
+              3
           ) AS "%5_rows"
       ) AS "%5_rows"
   ) AS "%4_universe";

--- a/crates/query-engine/translation/tests/snapshots/tests__sorting_by_recursive_relationship_column.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__sorting_by_recursive_relationship_column.snap
@@ -15,41 +15,41 @@ FROM
         FROM
           (
             SELECT
-              "%4_Company"."Name" AS "Name"
+              "%1_Company"."Name" AS "Name"
             FROM
               (
                 SELECT
                   "%0_Company".*
                 FROM
                   "public"."Company" AS "%0_Company"
+              ) AS "%1_Company"
+              LEFT OUTER JOIN LATERAL (
+                SELECT
+                  "%3_ORDER_PART_Person"."Name" AS "Name"
+                FROM
+                  (
+                    SELECT
+                      "%2_ORDER_PART_Person"."ParentId" AS "ParentId"
+                    FROM
+                      "public"."Person" AS "%2_ORDER_PART_Person"
+                    WHERE
+                      (
+                        "%1_Company"."CEOId" = "%2_ORDER_PART_Person"."PersonId"
+                      )
+                  ) AS "%2_ORDER_PART_Person"
                   LEFT OUTER JOIN LATERAL (
                     SELECT
-                      "%2_ORDER_PART_Person"."Name" AS "Name"
+                      "%3_ORDER_PART_Person"."Name" AS "Name"
                     FROM
+                      "public"."Person" AS "%3_ORDER_PART_Person"
+                    WHERE
                       (
-                        SELECT
-                          "%1_ORDER_PART_Person"."ParentId" AS "ParentId"
-                        FROM
-                          "public"."Person" AS "%1_ORDER_PART_Person"
-                        WHERE
-                          (
-                            "%0_Company"."CEOId" = "%1_ORDER_PART_Person"."PersonId"
-                          )
-                      ) AS "%1_ORDER_PART_Person"
-                      LEFT OUTER JOIN LATERAL (
-                        SELECT
-                          "%2_ORDER_PART_Person"."Name" AS "Name"
-                        FROM
-                          "public"."Person" AS "%2_ORDER_PART_Person"
-                        WHERE
-                          (
-                            "%1_ORDER_PART_Person"."ParentId" = "%2_ORDER_PART_Person"."PersonId"
-                          )
-                      ) AS "%2_ORDER_PART_Person" ON ('true')
-                  ) AS "%3_ORDER_FOR_Company" ON ('true')
-                ORDER BY
-                  "%3_ORDER_FOR_Company"."Name" ASC
-              ) AS "%4_Company"
+                        "%2_ORDER_PART_Person"."ParentId" = "%3_ORDER_PART_Person"."PersonId"
+                      )
+                  ) AS "%3_ORDER_PART_Person" ON ('true')
+              ) AS "%4_ORDER_FOR_Company" ON ('true')
+            ORDER BY
+              "%4_ORDER_FOR_Company"."Name" ASC
           ) AS "%6_rows"
       ) AS "%6_rows"
   ) AS "%5_universe";

--- a/crates/query-engine/translation/tests/snapshots/tests__sorting_by_relationship_column.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__sorting_by_relationship_column.snap
@@ -15,33 +15,33 @@ FROM
         FROM
           (
             SELECT
-              "%3_Album"."Title" AS "Name"
+              "%1_Album"."Title" AS "Name"
             FROM
               (
                 SELECT
                   "%0_Album".*
                 FROM
                   "public"."Album" AS "%0_Album"
-                  LEFT OUTER JOIN LATERAL (
+              ) AS "%1_Album"
+              LEFT OUTER JOIN LATERAL (
+                SELECT
+                  "%2_ORDER_PART_Artist"."Name" AS "Name"
+                FROM
+                  (
                     SELECT
-                      "%1_ORDER_PART_Artist"."Name" AS "Name"
+                      "%2_ORDER_PART_Artist"."Name" AS "Name"
                     FROM
+                      "public"."Artist" AS "%2_ORDER_PART_Artist"
+                    WHERE
                       (
-                        SELECT
-                          "%1_ORDER_PART_Artist"."Name" AS "Name"
-                        FROM
-                          "public"."Artist" AS "%1_ORDER_PART_Artist"
-                        WHERE
-                          (
-                            "%0_Album"."ArtistId" = "%1_ORDER_PART_Artist"."ArtistId"
-                          )
-                      ) AS "%1_ORDER_PART_Artist"
-                  ) AS "%2_ORDER_FOR_Album" ON ('true')
-                ORDER BY
-                  "%2_ORDER_FOR_Album"."Name" ASC
-                LIMIT
-                  5 OFFSET 3
-              ) AS "%3_Album"
+                        "%1_Album"."ArtistId" = "%2_ORDER_PART_Artist"."ArtistId"
+                      )
+                  ) AS "%2_ORDER_PART_Artist"
+              ) AS "%3_ORDER_FOR_Album" ON ('true')
+            ORDER BY
+              "%3_ORDER_FOR_Album"."Name" ASC
+            LIMIT
+              5 OFFSET 3
           ) AS "%5_rows"
       ) AS "%5_rows"
   ) AS "%4_universe";

--- a/crates/query-engine/translation/tests/snapshots/tests__sorting_by_relationship_column_with_true_predicate.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__sorting_by_relationship_column_with_true_predicate.snap
@@ -15,33 +15,33 @@ FROM
         FROM
           (
             SELECT
-              "%3_Album"."Title" AS "Name"
+              "%1_Album"."Title" AS "Name"
             FROM
               (
                 SELECT
                   "%0_Album".*
                 FROM
                   "public"."Album" AS "%0_Album"
-                  LEFT OUTER JOIN LATERAL (
+              ) AS "%1_Album"
+              LEFT OUTER JOIN LATERAL (
+                SELECT
+                  "%2_ORDER_PART_Artist"."Name" AS "Name"
+                FROM
+                  (
                     SELECT
-                      "%1_ORDER_PART_Artist"."Name" AS "Name"
+                      "%2_ORDER_PART_Artist"."Name" AS "Name"
                     FROM
+                      "public"."Artist" AS "%2_ORDER_PART_Artist"
+                    WHERE
                       (
-                        SELECT
-                          "%1_ORDER_PART_Artist"."Name" AS "Name"
-                        FROM
-                          "public"."Artist" AS "%1_ORDER_PART_Artist"
-                        WHERE
-                          (
-                            "%0_Album"."ArtistId" = "%1_ORDER_PART_Artist"."ArtistId"
-                          )
-                      ) AS "%1_ORDER_PART_Artist"
-                  ) AS "%2_ORDER_FOR_Album" ON ('true')
-                ORDER BY
-                  "%2_ORDER_FOR_Album"."Name" ASC
-                LIMIT
-                  5 OFFSET 3
-              ) AS "%3_Album"
+                        "%1_Album"."ArtistId" = "%2_ORDER_PART_Artist"."ArtistId"
+                      )
+                  ) AS "%2_ORDER_PART_Artist"
+              ) AS "%3_ORDER_FOR_Album" ON ('true')
+            ORDER BY
+              "%3_ORDER_FOR_Album"."Name" ASC
+            LIMIT
+              5 OFFSET 3
           ) AS "%5_rows"
       ) AS "%5_rows"
   ) AS "%4_universe";

--- a/crates/query-engine/translation/tests/snapshots/tests__sorting_by_relationship_count.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__sorting_by_relationship_count.snap
@@ -15,33 +15,33 @@ FROM
         FROM
           (
             SELECT
-              "%3_Artist"."Name" AS "Name"
+              "%1_Artist"."Name" AS "Name"
             FROM
               (
                 SELECT
                   "%0_Artist".*
                 FROM
                   "public"."Artist" AS "%0_Artist"
-                  LEFT OUTER JOIN LATERAL (
+              ) AS "%1_Artist"
+              LEFT OUTER JOIN LATERAL (
+                SELECT
+                  COUNT("%2_ORDER_PART_Album"."count") AS "count"
+                FROM
+                  (
                     SELECT
-                      COUNT("%1_ORDER_PART_Album"."count") AS "count"
+                      1 AS "count"
                     FROM
+                      "public"."Album" AS "%2_ORDER_PART_Album"
+                    WHERE
                       (
-                        SELECT
-                          1 AS "count"
-                        FROM
-                          "public"."Album" AS "%1_ORDER_PART_Album"
-                        WHERE
-                          (
-                            "%0_Artist"."ArtistId" = "%1_ORDER_PART_Album"."ArtistId"
-                          )
-                      ) AS "%1_ORDER_PART_Album"
-                  ) AS "%2_ORDER_FOR_Artist" ON ('true')
-                ORDER BY
-                  "%2_ORDER_FOR_Artist"."count" DESC
-                LIMIT
-                  5
-              ) AS "%3_Artist"
+                        "%1_Artist"."ArtistId" = "%2_ORDER_PART_Album"."ArtistId"
+                      )
+                  ) AS "%2_ORDER_PART_Album"
+              ) AS "%3_ORDER_FOR_Artist" ON ('true')
+            ORDER BY
+              "%3_ORDER_FOR_Artist"."count" DESC
+            LIMIT
+              5
           ) AS "%5_rows"
       ) AS "%5_rows"
   ) AS "%4_universe";

--- a/crates/query-engine/translation/tests/snapshots/tests__sorting_by_relationship_count_with_predicate.snap
+++ b/crates/query-engine/translation/tests/snapshots/tests__sorting_by_relationship_count_with_predicate.snap
@@ -15,51 +15,51 @@ FROM
         FROM
           (
             SELECT
-              "%4_Artist"."Name" AS "Name"
+              "%1_Artist"."Name" AS "Name"
             FROM
               (
                 SELECT
                   "%0_Artist".*
                 FROM
                   "public"."Artist" AS "%0_Artist"
-                  LEFT OUTER JOIN LATERAL (
+              ) AS "%1_Artist"
+              LEFT OUTER JOIN LATERAL (
+                SELECT
+                  COUNT("%2_ORDER_PART_Album"."count") AS "count"
+                FROM
+                  (
                     SELECT
-                      COUNT("%1_ORDER_PART_Album"."count") AS "count"
+                      1 AS "count"
                     FROM
+                      "public"."Album" AS "%2_ORDER_PART_Album"
+                    WHERE
                       (
-                        SELECT
-                          1 AS "count"
-                        FROM
-                          "public"."Album" AS "%1_ORDER_PART_Album"
-                        WHERE
-                          (
+                        (
+                          "%1_Artist"."ArtistId" = "%2_ORDER_PART_Album"."ArtistId"
+                        )
+                        AND EXISTS (
+                          SELECT
+                            1 AS "one"
+                          FROM
+                            "public"."Track" AS "%3_track"
+                          WHERE
                             (
-                              "%0_Artist"."ArtistId" = "%1_ORDER_PART_Album"."ArtistId"
+                              (
+                                "%3_track"."Name" LIKE cast($1 as "pg_catalog"."varchar")
+                              )
+                              AND (
+                                "%2_ORDER_PART_Album"."AlbumId" = "%3_track"."AlbumId"
+                              )
                             )
-                            AND EXISTS (
-                              SELECT
-                                1 AS "one"
-                              FROM
-                                "public"."Track" AS "%2_track"
-                              WHERE
-                                (
-                                  (
-                                    "%2_track"."Name" LIKE cast($1 as "pg_catalog"."varchar")
-                                  )
-                                  AND (
-                                    "%1_ORDER_PART_Album"."AlbumId" = "%2_track"."AlbumId"
-                                  )
-                                )
-                            )
-                          )
-                      ) AS "%1_ORDER_PART_Album"
-                  ) AS "%3_ORDER_FOR_Artist" ON ('true')
-                ORDER BY
-                  "%3_ORDER_FOR_Artist"."count" DESC,
-                  "%0_Artist"."Name" DESC
-                LIMIT
-                  5
-              ) AS "%4_Artist"
+                        )
+                      )
+                  ) AS "%2_ORDER_PART_Album"
+              ) AS "%4_ORDER_FOR_Artist" ON ('true')
+            ORDER BY
+              "%4_ORDER_FOR_Artist"."count" DESC,
+              "%1_Artist"."Name" DESC
+            LIMIT
+              5
           ) AS "%6_rows"
       ) AS "%6_rows"
   ) AS "%5_universe";

--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__explain_tests__explain__select_where_name_nilike.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__explain_tests__explain__select_where_name_nilike.snap
@@ -32,6 +32,8 @@ FROM
                 LIMIT
                   5
               ) AS "%1_Album"
+            ORDER BY
+              "%1_Album"."AlbumId" ASC
           ) AS "%3_rows"
       ) AS "%3_rows"
   ) AS "%2_universe"

--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__explain_tests__explain__select_where_variable.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__explain_tests__explain__select_where_variable.snap
@@ -32,4 +32,4 @@ FROM
                       (
                         "%1_Album"."Title" ~~ cast(
                           (
-                            ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "pg_catalog"."varchar")) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%2_Album") AS "%4_rows") AS "%4_rows") AS "%3_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%6_universe_agg"
+                            ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "pg_catalog"."varchar")) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%2_Album" ORDER BY "%2_Album"."AlbumId" ASC ) AS "%4_rows") AS "%4_rows") AS "%3_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%6_universe_agg"

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__explain_tests__explain__select_where_name_nilike.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__explain_tests__explain__select_where_name_nilike.snap
@@ -32,6 +32,8 @@ FROM
                 LIMIT
                   5
               ) AS "%1_Album"
+            ORDER BY
+              "%1_Album"."AlbumId" ASC
           ) AS "%3_rows"
       ) AS "%3_rows"
   ) AS "%2_universe"

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__explain_tests__explain__select_where_variable.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__explain_tests__explain__select_where_variable.snap
@@ -32,4 +32,4 @@ FROM
                       (
                         "%1_Album"."Title" LIKE cast(
                           (
-                            ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "pg_catalog"."varchar")) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%2_Album") AS "%4_rows") AS "%4_rows") AS "%3_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%6_universe_agg"
+                            ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "pg_catalog"."varchar")) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%2_Album" ORDER BY "%2_Album"."AlbumId" ASC ) AS "%4_rows") AS "%4_rows") AS "%3_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%6_universe_agg"

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__query_tests__native_queries__select_artist_with_album_by_title_relationship_arguments.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__query_tests__native_queries__select_artist_with_album_by_title_relationship_arguments.snap
@@ -16,26 +16,6 @@ expression: result
         }
       },
       {
-        "Name": "The Who",
-        "albums": {
-          "rows": [
-            {
-              "title": "My Generation - The Very Best Of The Who"
-            }
-          ]
-        }
-      },
-      {
-        "Name": "Battlestar Galactica",
-        "albums": {
-          "rows": [
-            {
-              "title": "Battlestar Galactica: The Story So Far"
-            }
-          ]
-        }
-      },
-      {
         "Name": "The Rolling Stones",
         "albums": {
           "rows": []
@@ -48,6 +28,16 @@ expression: result
         }
       },
       {
+        "Name": "The Who",
+        "albums": {
+          "rows": [
+            {
+              "title": "My Generation - The Very Best Of The Who"
+            }
+          ]
+        }
+      },
+      {
         "Name": "Tim Maia",
         "albums": {
           "rows": []
@@ -57,6 +47,16 @@ expression: result
         "Name": "Titãs",
         "albums": {
           "rows": []
+        }
+      },
+      {
+        "Name": "Battlestar Galactica",
+        "albums": {
+          "rows": [
+            {
+              "title": "Battlestar Galactica: The Story So Far"
+            }
+          ]
         }
       }
     ]

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__query_tests__native_queries__select_order_by_artist_album_count.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__query_tests__native_queries__select_order_by_artist_album_count.snap
@@ -6,38 +6,6 @@ expression: result
   {
     "rows": [
       {
-        "Name": "Black Label Society",
-        "albums": {
-          "aggregates": {
-            "how_many_albums": 2
-          },
-          "rows": [
-            {
-              "Title": "Alcohol Fueled Brewtality Live! [Disc 1]"
-            },
-            {
-              "Title": "Alcohol Fueled Brewtality Live! [Disc 2]"
-            }
-          ]
-        }
-      },
-      {
-        "Name": "Faith No More",
-        "albums": {
-          "aggregates": {
-            "how_many_albums": 2
-          },
-          "rows": [
-            {
-              "Title": "Album Of The Year"
-            },
-            {
-              "Title": "Angel Dust"
-            }
-          ]
-        }
-      },
-      {
         "Name": "Iron Maiden",
         "albums": {
           "aggregates": {
@@ -71,6 +39,38 @@ expression: result
             },
             {
               "Title": "Arquivo Os Paralamas Do Sucesso"
+            }
+          ]
+        }
+      },
+      {
+        "Name": "Black Label Society",
+        "albums": {
+          "aggregates": {
+            "how_many_albums": 2
+          },
+          "rows": [
+            {
+              "Title": "Alcohol Fueled Brewtality Live! [Disc 1]"
+            },
+            {
+              "Title": "Alcohol Fueled Brewtality Live! [Disc 2]"
+            }
+          ]
+        }
+      },
+      {
+        "Name": "Faith No More",
+        "albums": {
+          "aggregates": {
+            "how_many_albums": 2
+          },
+          "rows": [
+            {
+              "Title": "Album Of The Year"
+            },
+            {
+              "Title": "Angel Dust"
             }
           ]
         }

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__query_tests__sorting__select_order_by_artist_name_with_name.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__query_tests__sorting__select_order_by_artist_name_with_name.snap
@@ -29,6 +29,16 @@ expression: result
         "Artist": {
           "rows": [
             {
+              "Name": "Aaron Copland & London Symphony Orchestra"
+            }
+          ]
+        },
+        "Name": "A Copland Celebration, Vol. I"
+      },
+      {
+        "Artist": {
+          "rows": [
+            {
               "Name": "Aaron Goldberg"
             }
           ]
@@ -44,16 +54,6 @@ expression: result
           ]
         },
         "Name": "The World of Classical Favourites"
-      },
-      {
-        "Artist": {
-          "rows": [
-            {
-              "Name": "Aaron Copland & London Symphony Orchestra"
-            }
-          ]
-        },
-        "Name": "A Copland Celebration, Vol. I"
       }
     ]
   }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__duplicate_filter_results.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__duplicate_filter_results.snap
@@ -53,6 +53,8 @@ FROM
                 LIMIT
                   5
               ) AS "%3_Artist"
+            ORDER BY
+              "%3_Artist"."ArtistId" ASC
           ) AS "%5_rows"
       ) AS "%5_rows"
   ) AS "%4_universe"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__duplicate_filter_results_nested.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__duplicate_filter_results_nested.snap
@@ -83,6 +83,8 @@ FROM
                 LIMIT
                   5
               ) AS "%6_Artist"
+            ORDER BY
+              "%6_Artist"."ArtistId" ASC
           ) AS "%8_rows"
       ) AS "%8_rows"
   ) AS "%7_universe"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__native_queries__embedded_variable.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__native_queries__embedded_variable.snap
@@ -47,6 +47,8 @@ FROM
                         ORDER BY
                           "%1_album_by_title"."AlbumId" ASC
                       ) AS "%3_album_by_title"
+                    ORDER BY
+                      "%3_album_by_title"."AlbumId" ASC
                   ) AS "%5_rows"
               ) AS "%5_rows"
           ) AS "%4_universe"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__order_by_nested_field.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__order_by_nested_field.snap
@@ -74,6 +74,8 @@ FROM
                       ) AS "%9_nested_fields_collect" ON ('true')
                   ) AS "%5_nested_fields"
               ) AS "%10_nested_fields_collect" ON ('true')
+            ORDER BY
+              ("%1_group_leader"."characters")."name" DESC
           ) AS "%12_rows"
       ) AS "%12_rows"
   ) AS "%11_universe"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__select_where_name_nilike.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__select_where_name_nilike.snap
@@ -32,6 +32,8 @@ FROM
                 LIMIT
                   5
               ) AS "%1_Album"
+            ORDER BY
+              "%1_Album"."AlbumId" ASC
           ) AS "%3_rows"
       ) AS "%3_rows"
   ) AS "%2_universe"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__select_where_no_variable.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__select_where_no_variable.snap
@@ -32,4 +32,4 @@ FROM
                       (
                         "%1_Album"."Title" ~~ cast(
                           (
-                            ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "pg_catalog"."varchar")) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%2_Album") AS "%4_rows") AS "%4_rows") AS "%3_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%6_universe_agg"
+                            ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "pg_catalog"."varchar")) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%2_Album" ORDER BY "%2_Album"."AlbumId" ASC ) AS "%4_rows") AS "%4_rows") AS "%3_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%6_universe_agg"

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__select_where_variable.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__explain_tests__query__select_where_variable.snap
@@ -32,4 +32,4 @@ FROM
                       (
                         "%1_Album"."Title" ~~ cast(
                           (
-                            ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "pg_catalog"."varchar")) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%2_Album") AS "%4_rows") AS "%4_rows") AS "%3_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%6_universe_agg"
+                            ("%0_%variables_table"."%variables" -> $2) #>> cast(ARRAY [] as "text"[])) as "pg_catalog"."varchar")) ORDER BY "%1_Album"."AlbumId" ASC ) AS "%2_Album" ORDER BY "%2_Album"."AlbumId" ASC ) AS "%4_rows") AS "%4_rows") AS "%3_universe" ORDER BY "%0_%variables_table"."%variable_order" ASC ) AS "%6_universe_agg"


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

Improve ordering

When ordering using columns in other tables, 
When ordering through a relationship, put the order by clause and limit in the parent query.
When ordering from local column, put the order by clause and limit in the subquery.
Additionally, add a copy of the order by clause in the parent, to ensure correctness.

<!-- What is this PR trying to accomplish (and why, if it's not obvious)? -->

<!-- Consider: do we need to add a changelog entry? -->

### How

<!-- How is it trying to accomplish it (what are the implementation steps)? -->
:)