### PR TITLE
Revert "Bump version to 2.1.0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "databases-tests"
-version = "2.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-postgres"
-version = "2.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-postgres-cli"
-version = "2.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "build-data",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-postgres-configuration"
-version = "2.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1903,7 +1903,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openapi-generator"
-version = "2.1.0"
+version = "2.0.0"
 dependencies = [
  "ndc-postgres-configuration",
  "serde_json",
@@ -2251,7 +2251,7 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "query-engine-execution"
-version = "2.1.0"
+version = "2.0.0"
 dependencies = [
  "bytes",
  "ndc-models",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "query-engine-metadata"
-version = "2.1.0"
+version = "2.0.0"
 dependencies = [
  "ndc-models",
  "smol_str",
@@ -2274,7 +2274,7 @@ dependencies = [
 
 [[package]]
 name = "query-engine-sql"
-version = "2.1.0"
+version = "2.0.0"
 dependencies = [
  "ndc-models",
  "schemars",
@@ -2284,7 +2284,7 @@ dependencies = [
 
 [[package]]
 name = "query-engine-translation"
-version = "2.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "indexmap 2.7.1",
@@ -3319,7 +3319,7 @@ dependencies = [
 
 [[package]]
 name = "tests-common"
-version = "2.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 
-package.version = "2.1.0"
+package.version = "2.0.0"
 package.edition = "2021"
 package.license = "Apache-2.0"
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,14 +6,6 @@
 
 ### Changed
 
-### Fixed
-
-## [v2.1.0] - 2025-03-05
-
-### Added
-
-### Changed
-
 - improved SQL generation to faciliate efficient use of indices in cockroachdb
 
 ### Fixed
@@ -390,8 +382,7 @@ Initial release.
 
 <!-- end -->
 
-[Unreleased]: https://github.com/hasura/ndc-postgres/compare/v2.1.0...HEAD
-[v2.1.0]: https://github.com/hasura/ndc-postgres/releases/tag/v2.1.0
+[Unreleased]: https://github.com/hasura/ndc-postgres/compare/v2.0.0...HEAD
 [v2.0.0]: https://github.com/hasura/ndc-postgres/releases/tag/v2.0.0
 [v1.2.0]: https://github.com/hasura/ndc-postgres/releases/tag/v1.2.0
 [v1.1.2]: https://github.com/hasura/ndc-postgres/releases/tag/v1.1.2


### PR DESCRIPTION
Reverts hasura/ndc-postgres#714

Haven't released this yet, need to include one more commit.