### PR TITLE
Add `audit.toml` file to ignore cargo audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,9 +1,20 @@
+# Example audit config file
+#
+# It may be located in the user home (`~/.cargo/audit.toml`) or in the project
+# root (`.cargo/audit.toml`).
+#
+# All of the options which can be passed via CLI arguments can also be
+# permanently specified in this file.
+
 [advisories]
-ignore = [
-  # `cargo audit` thinks we depend on `sqlx-mysql` and therefore `rsa`.
-  # We do not, as we do not enable the "mysql" feature for `sqlx`.
-  "RUSTSEC-2023-0071",
-  # `sqlx` may interpret a value larger than 4 GB as commands..
-  # We mitigate this by limiting the size of the request.
-  "RUSTSEC-2024-0363",
-]
+ignore = ["RUSTSEC-2024-0437","RUSTSEC-2023-0071"] # advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]
+
+# RUSTSEC-2024-0437
+#
+# https://github.com/tikv/rust-prometheus/issues/538#issuecomment-2708222613
+# we ignore this there is no current fix, and because the prometheus crate 
+# that uses protobuf does not parse any protobufs, only writes them.
+#
+# RUSTSEC-2023-0071
+#
+# This is imported via `sqlx-mysql` which we do not use


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

Getting some `cargo audit` failures that aren't relevant, this file allows us to ignore them.
