### PR TITLE
Support complex & array types in native query creation cli utility

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Support composite and array arguments and columns when creating native queries via the cli. We used to assume scalars
+
 ## [v2.1.1] - 2025-03-12
 
 ### Changed

--- a/crates/configuration/src/version4/native_operations.rs
+++ b/crates/configuration/src/version4/native_operations.rs
@@ -6,6 +6,8 @@ use std::path::Path;
 use query_engine_sql::sql;
 
 use ndc_models as models;
+use sqlx::postgres::types::Oid;
+use sqlx::postgres::PgTypeKind;
 use sqlx::Connection;
 use sqlx::Executor;
 use sqlx::{Column, PgConnection};
@@ -18,6 +20,37 @@ use tracing::{info_span, Instrument};
 pub enum Kind {
     Query,
     Mutation,
+}
+
+/// Recursively figure out the underlying type oid for a given type
+/// Figure out the underlying type oid for an argument or column
+/// Usually we just want the oid, but for arrays we need the oid for the underlying (non-array) type
+fn underlying_oid(kind: &PgTypeKind, oid: Option<Oid>) -> Option<Oid> {
+    match kind {
+        PgTypeKind::Simple
+        | PgTypeKind::Pseudo
+        | PgTypeKind::Domain(_)
+        | PgTypeKind::Enum(_)
+        | PgTypeKind::Range(_)
+        | PgTypeKind::Composite(_) => oid,
+        PgTypeKind::Array(pg_type_info) => underlying_oid(pg_type_info.kind(), pg_type_info.oid()),
+    }
+}
+
+/// Convert a kind and a resolved underlying type name to a metadata type
+fn to_metadata_type(kind: &PgTypeKind, underlying_type_name: &str) -> metadata::Type {
+    match kind {
+        PgTypeKind::Simple
+        | PgTypeKind::Pseudo
+        | PgTypeKind::Domain(_)
+        | PgTypeKind::Enum(_)
+        | PgTypeKind::Range(_) => metadata::Type::ScalarType(underlying_type_name.into()),
+        PgTypeKind::Composite(_) => metadata::Type::CompositeType(underlying_type_name.into()),
+        PgTypeKind::Array(pg_type_info) => metadata::Type::ArrayType(Box::new(to_metadata_type(
+            pg_type_info.kind(),
+            underlying_type_name,
+        ))),
+    }
 }
 
 /// Take a SQL file containing a Native Operation, check against the database that it is valid,
@@ -60,21 +93,23 @@ pub async fn create(
             anyhow::bail!("Internal error: Native operation parameter was not a variable.")
         };
 
-        let the_oid = result_param
-            .oid()
+        // get the oid for the underlying type. If the parameter is an array, get the array item's oid
+        let the_oid = underlying_oid(result_param.kind(), result_param.oid())
             .ok_or(anyhow::anyhow!(
                 "Internal error: All sqlx TypeInfos should have an oid."
             ))?
             .0;
 
-        arguments_to_oids.insert(param_name, i64::from(the_oid));
+        arguments_to_oids.insert(
+            param_name,
+            (i64::from(the_oid), result_param.kind().to_owned()),
+        );
     }
 
     // Fill the columns list.
     for (index, column) in result.columns.iter().enumerate() {
-        let the_oid = column
-            .type_info()
-            .oid()
+        // get the oid for the underlying type. If the parameter is an array, get the array item's oid
+        let the_oid = underlying_oid(column.type_info().kind(), column.type_info().oid())
             .ok_or(anyhow::anyhow!(
                 "Internal error: All sqlx TypeInfos should have an oid."
             ))?
@@ -84,26 +119,42 @@ pub async fn create(
             true,
         );
 
-        columns_to_oids.insert(column.name().to_string(), (i64::from(the_oid), is_nullable));
+        columns_to_oids.insert(
+            column.name().to_string(),
+            (
+                i64::from(the_oid),
+                column.type_info().kind().to_owned(),
+                is_nullable,
+            ),
+        );
     }
 
-    let mut oids: BTreeSet<i64> = arguments_to_oids.values().copied().collect();
-    oids.extend::<BTreeSet<i64>>(columns_to_oids.values().copied().map(|x| x.0).collect());
+    let mut oids: BTreeSet<i64> = arguments_to_oids
+        .values()
+        .map(|(oid, _)| oid)
+        .copied()
+        .collect();
+    oids.extend::<BTreeSet<i64>>(
+        columns_to_oids
+            .values()
+            .map(|(oid, _, _)| oid)
+            .copied()
+            .collect(),
+    );
     let oids_vec: Vec<_> = oids.into_iter().collect();
     let oids_map = oids_to_typenames(configuration, connection_string, &oids_vec).await?;
 
     let mut arguments = BTreeMap::new();
-    for (name, oid) in arguments_to_oids {
+    for (name, (oid, kind)) in arguments_to_oids {
+        let underlying_type_name = oids_map
+            .get(&oid)
+            .ok_or_else(|| anyhow::anyhow!("Internal error: oid not found in map."))?;
+
         arguments.insert(
             name.clone().into(),
             metadata::ReadOnlyColumnInfo {
                 name: name.clone(),
-                r#type: metadata::Type::ScalarType(
-                    oids_map
-                        .get(&oid)
-                        .ok_or_else(|| anyhow::anyhow!("Internal error: oid not found in map."))?
-                        .clone(),
-                ),
+                r#type: to_metadata_type(&kind, &underlying_type_name.to_string()),
                 description: None,
                 // we don't have this information, so we assume not nullable.
                 nullable: metadata::Nullable::NonNullable,
@@ -111,17 +162,16 @@ pub async fn create(
         );
     }
     let mut columns = BTreeMap::new();
-    for (name, (oid, is_nullable)) in columns_to_oids {
+    for (name, (oid, kind, is_nullable)) in columns_to_oids {
+        let underlying_type_name = oids_map
+            .get(&oid)
+            .ok_or_else(|| anyhow::anyhow!("Internal error: oid not found in map."))?;
+
         columns.insert(
             name.clone().into(),
             metadata::ReadOnlyColumnInfo {
                 name: name.clone(),
-                r#type: metadata::Type::ScalarType(
-                    oids_map
-                        .get(&oid)
-                        .ok_or_else(|| anyhow::anyhow!("Internal error: oid not found in map."))?
-                        .clone(),
-                ),
+                r#type: to_metadata_type(&kind, &underlying_type_name.to_string()),
                 description: None,
                 nullable: if is_nullable {
                     metadata::Nullable::Nullable

--- a/crates/configuration/src/version5/native_operations.rs
+++ b/crates/configuration/src/version5/native_operations.rs
@@ -1,6 +1,8 @@
 //! Infer information about a Native Operation from a Native Operation SQL string.
 
 use ndc_models as models;
+use sqlx::postgres::types::Oid;
+use sqlx::postgres::PgTypeKind;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
@@ -20,6 +22,37 @@ use tracing::{info_span, Instrument};
 pub enum Kind {
     Query,
     Mutation,
+}
+
+/// Recursively figure out the underlying type oid for a given type
+/// Figure out the underlying type oid for an argument or column
+/// Usually we just want the oid, but for arrays we need the oid for the underlying (non-array) type
+fn underlying_oid(kind: &PgTypeKind, oid: Option<Oid>) -> Option<Oid> {
+    match kind {
+        PgTypeKind::Simple
+        | PgTypeKind::Pseudo
+        | PgTypeKind::Domain(_)
+        | PgTypeKind::Enum(_)
+        | PgTypeKind::Range(_)
+        | PgTypeKind::Composite(_) => oid,
+        PgTypeKind::Array(pg_type_info) => underlying_oid(pg_type_info.kind(), pg_type_info.oid()),
+    }
+}
+
+/// Convert a kind and a resolved underlying type name to a metadata type
+fn to_metadata_type(kind: &PgTypeKind, underlying_type_name: &str) -> metadata::Type {
+    match kind {
+        PgTypeKind::Simple
+        | PgTypeKind::Pseudo
+        | PgTypeKind::Domain(_)
+        | PgTypeKind::Enum(_)
+        | PgTypeKind::Range(_) => metadata::Type::ScalarType(underlying_type_name.into()),
+        PgTypeKind::Composite(_) => metadata::Type::CompositeType(underlying_type_name.into()),
+        PgTypeKind::Array(pg_type_info) => metadata::Type::ArrayType(Box::new(to_metadata_type(
+            pg_type_info.kind(),
+            underlying_type_name,
+        ))),
+    }
 }
 
 /// Take a SQL file containing a Native Operation, check against the database that it is valid,
@@ -64,21 +97,23 @@ pub async fn create(
             anyhow::bail!("Internal error: Native operation parameter was not a variable.")
         };
 
-        let the_oid = result_param
-            .oid()
+        // get the oid for the underlying type. If the parameter is an array, get the array item's oid
+        let the_oid = underlying_oid(result_param.kind(), result_param.oid())
             .ok_or(anyhow::anyhow!(
                 "Internal error: All sqlx TypeInfos should have an oid."
             ))?
             .0;
 
-        arguments_to_oids.insert(param_name, i64::from(the_oid));
+        arguments_to_oids.insert(
+            param_name,
+            (i64::from(the_oid), result_param.kind().to_owned()),
+        );
     }
 
     // Fill the columns list.
     for (index, column) in result.columns.iter().enumerate() {
-        let the_oid = column
-            .type_info()
-            .oid()
+        // get the oid for the underlying type. If the parameter is an array, get the array item's oid
+        let the_oid = underlying_oid(column.type_info().kind(), column.type_info().oid())
             .ok_or(anyhow::anyhow!(
                 "Internal error: All sqlx TypeInfos should have an oid."
             ))?
@@ -88,27 +123,43 @@ pub async fn create(
             true,
         );
 
-        columns_to_oids.insert(column.name().to_string(), (i64::from(the_oid), is_nullable));
+        columns_to_oids.insert(
+            column.name().to_string(),
+            (
+                i64::from(the_oid),
+                column.type_info().kind().to_owned(),
+                is_nullable,
+            ),
+        );
     }
 
-    let mut oids: BTreeSet<i64> = arguments_to_oids.values().copied().collect();
-    oids.extend::<BTreeSet<i64>>(columns_to_oids.values().copied().map(|x| x.0).collect());
+    let mut oids: BTreeSet<i64> = arguments_to_oids
+        .values()
+        .map(|(oid, _)| oid)
+        .copied()
+        .collect();
+    oids.extend::<BTreeSet<i64>>(
+        columns_to_oids
+            .values()
+            .map(|(oid, _, _)| oid)
+            .copied()
+            .collect(),
+    );
     let oids_vec: Vec<_> = oids.into_iter().collect();
     let oids_map =
         oids_to_typenames(configuration, connection_string, environment, &oids_vec).await?;
 
     let mut arguments = BTreeMap::new();
-    for (name, oid) in arguments_to_oids {
+    for (name, (oid, kind)) in arguments_to_oids {
+        let underlying_type_name = oids_map
+            .get(&oid)
+            .ok_or_else(|| anyhow::anyhow!("Internal error: oid not found in map."))?;
+
         arguments.insert(
             name.clone().into(),
             metadata::ReadOnlyColumnInfo {
                 name: name.clone(),
-                r#type: metadata::Type::ScalarType(
-                    oids_map
-                        .get(&oid)
-                        .ok_or_else(|| anyhow::anyhow!("Internal error: oid not found in map."))?
-                        .clone(),
-                ),
+                r#type: to_metadata_type(&kind, &underlying_type_name.to_string()),
                 description: None,
                 // we don't have this information, so we assume not nullable.
                 nullable: metadata::Nullable::NonNullable,
@@ -116,17 +167,16 @@ pub async fn create(
         );
     }
     let mut columns = BTreeMap::new();
-    for (name, (oid, is_nullable)) in columns_to_oids {
+    for (name, (oid, kind, is_nullable)) in columns_to_oids {
+        let underlying_type_name = oids_map
+            .get(&oid)
+            .ok_or_else(|| anyhow::anyhow!("Internal error: oid not found in map."))?;
+
         columns.insert(
             name.clone().into(),
             metadata::ReadOnlyColumnInfo {
                 name: name.clone(),
-                r#type: metadata::Type::ScalarType(
-                    oids_map
-                        .get(&oid)
-                        .ok_or_else(|| anyhow::anyhow!("Internal error: oid not found in map."))?
-                        .clone(),
-                ),
+                r#type: to_metadata_type(&kind, &underlying_type_name.to_string()),
                 description: None,
                 nullable: if is_nullable {
                     metadata::Nullable::Nullable
@@ -157,7 +207,7 @@ pub async fn oids_to_typenames(
     connection_string: &str,
     environment: &impl Environment,
     oids: &Vec<i64>,
-) -> anyhow::Result<BTreeMap<i64, models::ScalarTypeName>> {
+) -> anyhow::Result<BTreeMap<i64, models::TypeName>> {
     let connect_options =
         crate::get_connect_options(&crate::ConnectionUri::from(connection_string), environment)?;
     // Connect to the db.
@@ -171,7 +221,7 @@ pub async fn oids_to_typenames(
         .instrument(info_span!("Run oid lookup query"))
         .await?;
 
-    let mut oids_map: BTreeMap<i64, models::ScalarTypeName> = BTreeMap::new();
+    let mut oids_map: BTreeMap<i64, models::TypeName> = BTreeMap::new();
 
     // Reverse lookup the schema.typename and find the ndc type name,
     // if we find all we can just add the nq and call it a day.
@@ -183,7 +233,14 @@ pub async fn oids_to_typenames(
         let mut found = false;
         for (scalar_type_name, info) in &configuration.metadata.types.scalar.0 {
             if info.schema_name == schema_name && info.type_name == type_name {
-                oids_map.insert(oid, scalar_type_name.clone());
+                oids_map.insert(oid, scalar_type_name.inner().clone());
+                found = true;
+                continue;
+            }
+        }
+        for (composite_type_name, info) in &configuration.metadata.types.composite.0 {
+            if info.schema_name == schema_name && info.type_name == type_name {
+                oids_map.insert(oid, composite_type_name.clone());
                 found = true;
                 continue;
             }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__create_native_operation.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__configuration_tests__create_native_operation.snap
@@ -26,7 +26,7 @@ expression: result
     "characters": {
       "name": "characters",
       "type": {
-        "scalarType": "characters"
+        "compositeType": "characters"
       },
       "nullable": "nullable",
       "description": null
@@ -42,7 +42,7 @@ expression: result
     "name": {
       "name": "name",
       "type": {
-        "scalarType": "chara"
+        "compositeType": "chara"
       },
       "nullable": "nullable",
       "description": null


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

<!-- What is this PR trying to accomplish (and why, if it's not obvious)? -->

The cli native query creation utility tries to figure out  the argument & column types for the native query.

It currently assumes all columns & arguments are scalars, while the configuration supports array types & composite types.

This PR changes the utility to support composite types & array types.

<!-- Consider: do we need to add a changelog entry? -->

### How

<!-- How is it trying to accomplish it (what are the implementation steps)? -->

We build on the existing system that uses sqlx utilities to describe a query. We get type info, then use the oid from that info to get a type name from the database.

We add an extra step, to check for arrays in the types, and if so get the underlying type before fetching an OID for that type.

We also add mapping to consider the type kind whether composite, scalar, or array, as we write the configuration.

We assume types are scalar if they're not composite nor array types. This matches previous behavior.

We also update a snapshot, which it turns out was wrong until this fix.
