### PR TITLE
Make logs of incoming requests debug level

### DIFF
--- a/crates/connectors/ndc-postgres/src/mutation.rs
+++ b/crates/connectors/ndc-postgres/src/mutation.rs
@@ -34,7 +34,7 @@ pub async fn mutation(
 
     // See https://docs.rs/tracing/0.1.29/tracing/span/struct.Span.html#in-asynchronous-code
     let result = async move {
-        tracing::info!(
+        tracing::debug!(
             request_json = serde_json::to_string(&request).unwrap(),
             request = ?request
         );

--- a/crates/connectors/ndc-postgres/src/mutation/explain.rs
+++ b/crates/connectors/ndc-postgres/src/mutation/explain.rs
@@ -27,7 +27,7 @@ pub async fn explain(
     mutation_request: models::MutationRequest,
 ) -> Result<models::ExplainResponse, connector::ErrorResponse> {
     async move {
-        tracing::info!(
+        tracing::debug!(
             mutation_request_json = serde_json::to_string(&mutation_request).unwrap(),
             mutation_request = ?mutation_request
         );

--- a/crates/connectors/ndc-postgres/src/query.rs
+++ b/crates/connectors/ndc-postgres/src/query.rs
@@ -33,7 +33,7 @@ pub async fn query(
 
     // See https://docs.rs/tracing/0.1.29/tracing/span/struct.Span.html#in-asynchronous-code
     let result = async move {
-        tracing::info!(
+        tracing::debug!(
             query_request_json = serde_json::to_string(&query_request).unwrap(),
             query_request = ?query_request
         );

--- a/crates/connectors/ndc-postgres/src/query/explain.rs
+++ b/crates/connectors/ndc-postgres/src/query/explain.rs
@@ -25,7 +25,7 @@ pub async fn explain(
     query_request: models::QueryRequest,
 ) -> Result<models::ExplainResponse, connector::ErrorResponse> {
     async move {
-        tracing::info!(
+        tracing::debug!(
             query_request_json = serde_json::to_string(&query_request).unwrap(),
             query_request = ?query_request
         );


### PR DESCRIPTION
This PR changes trace events that include the incoming requests to debug level (from info) to avoid potentially leaking request content we do not want leaked.