### PR TITLE
Bump Nix Flake, fix darwin problems

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1743908961,
-        "narHash": "sha256-e1idZdpnnHWuosI3KsBgAgrhMR05T2oqskXCmNzGPq0=",
+        "lastModified": 1750266157,
+        "narHash": "sha256-tL42YoNg9y30u7zAqtoGDNdTyXTi8EALDeCB13FtbQA=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "80ceeec0dc94ef967c371dcdc56adb280328f591",
+        "rev": "e37c943371b73ed87faf33f7583860f81f1d5a48",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744042683,
-        "narHash": "sha256-OcbNmAMhC1i9W9qlG9dA+NMz3oKo4T4s2TRCeqoncPs=",
+        "lastModified": 1750793589,
+        "narHash": "sha256-sMAgCvS6sKpwtJ7F5CW4B14rD7oI/fO9/O1Zkj0nmeI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d0fb58c032aa16827be81bcb4592213797edf6e5",
+        "rev": "8a152de8ba2619c41d8aa42a15158d523c0b6630",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743993291,
-        "narHash": "sha256-u8GHvduU1gCtoFXvTS/wGjH1ouv5S/GRGq6MAT+sG/k=",
+        "lastModified": 1750732748,
+        "narHash": "sha256-HR2b3RHsPeJm+Fb+1ui8nXibgniVj7hBNvUbXEyz0DU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "0cb3c8979c65dc6a5812dfe67499a8c7b8b4325b",
+        "rev": "4b4494b2ba7e8a8041b2e28320b2ee02c115c75f",
         "type": "github"
       },
       "original": {

--- a/nix/app.nix
+++ b/nix/app.nix
@@ -39,9 +39,6 @@ let
     ] ++ lib.optionals hostPlatform.isDarwin [
       # macOS-specific dependencies
       libiconv
-      darwin.apple_sdk.frameworks.CoreFoundation
-      darwin.apple_sdk.frameworks.Security
-      darwin.apple_sdk.frameworks.SystemConfiguration
     ];
   };
 


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

A recent [nixpkgs change](https://github.com/NixOS/nixpkgs/issues/401364) means we cannot build or use the development shells on `darwin`, this fixes that.
