### PR TITLE
refactor state to prepare for dynamic conection pools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,6 +1780,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndc-models"
+version = "0.2.4"
+source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.2.4#df67fa6469431f9304aac9c237e9d2327d20da20"
+dependencies = [
+ "indexmap 2.9.0",
+ "ref-cast",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smol_str",
+]
+
+[[package]]
 name = "ndc-postgres"
 version = "2.1.1"
 dependencies = [
@@ -1826,7 +1840,7 @@ dependencies = [
  "anyhow",
  "clap",
  "jsonschema",
- "ndc-models",
+ "ndc-models 0.2.4",
  "prometheus",
  "query-engine-metadata",
  "query-engine-sql",
@@ -1842,17 +1856,17 @@ dependencies = [
 
 [[package]]
 name = "ndc-sdk"
-version = "0.6.0"
-source = "git+https://github.com/hasura/ndc-sdk-rs.git?rev=e2a1aeb#e2a1aebe54aa75b19e4633f5275b6c965afe34fb"
+version = "0.7.0"
+source = "git+https://github.com/hasura/ndc-sdk-rs.git?rev=v0.7.0#42150b36f831117346f4cdd1bf377289b33d201e"
 dependencies = [
  "async-trait",
  "axum",
  "axum-extra",
  "clap",
  "http 0.2.12",
- "ndc-models",
+ "ndc-models 0.2.4",
  "ndc-sdk-core",
- "ndc-test",
+ "ndc-test 0.2.4",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-otlp",
@@ -1874,16 +1888,16 @@ dependencies = [
 
 [[package]]
 name = "ndc-sdk-core"
-version = "0.6.0"
-source = "git+https://github.com/hasura/ndc-sdk-rs.git?rev=e2a1aeb#e2a1aebe54aa75b19e4633f5275b6c965afe34fb"
+version = "0.7.0"
+source = "git+https://github.com/hasura/ndc-sdk-rs.git?rev=v0.7.0#42150b36f831117346f4cdd1bf377289b33d201e"
 dependencies = [
  "async-trait",
  "axum",
  "bytes",
  "http 0.2.12",
  "mime",
- "ndc-models",
- "ndc-test",
+ "ndc-models 0.2.4",
+ "ndc-test 0.2.4",
  "prometheus",
  "serde",
  "serde_json",
@@ -1901,7 +1915,28 @@ dependencies = [
  "clap",
  "colorful",
  "indexmap 2.9.0",
- "ndc-models",
+ "ndc-models 0.2.2",
+ "pretty_assertions",
+ "rand 0.8.5",
+ "reqwest 0.12.12",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "ndc-test"
+version = "0.2.4"
+source = "git+https://github.com/hasura/ndc-spec.git?tag=v0.2.4#df67fa6469431f9304aac9c237e9d2327d20da20"
+dependencies = [
+ "async-trait",
+ "clap",
+ "colorful",
+ "indexmap 2.9.0",
+ "ndc-models 0.2.4",
  "pretty_assertions",
  "rand 0.8.5",
  "reqwest 0.12.12",
@@ -2420,7 +2455,7 @@ name = "query-engine-execution"
 version = "2.1.1"
 dependencies = [
  "bytes",
- "ndc-models",
+ "ndc-models 0.2.4",
  "prometheus",
  "query-engine-sql",
  "serde_json",
@@ -2434,7 +2469,7 @@ dependencies = [
 name = "query-engine-metadata"
 version = "2.1.1"
 dependencies = [
- "ndc-models",
+ "ndc-models 0.2.4",
  "smol_str",
 ]
 
@@ -2442,7 +2477,7 @@ dependencies = [
 name = "query-engine-sql"
 version = "2.1.1"
 dependencies = [
- "ndc-models",
+ "ndc-models 0.2.4",
  "schemars",
  "serde",
  "serde_json",
@@ -2456,7 +2491,7 @@ dependencies = [
  "indexmap 2.9.0",
  "insta",
  "multimap",
- "ndc-models",
+ "ndc-models 0.2.4",
  "ndc-postgres-configuration",
  "nonempty",
  "query-engine-metadata",
@@ -3579,7 +3614,7 @@ dependencies = [
  "ndc-postgres",
  "ndc-postgres-configuration",
  "ndc-sdk",
- "ndc-test",
+ "ndc-test 0.2.2",
  "reqwest 0.12.12",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ similar_names = "allow"
 too_many_lines = "allow"
 
 [workspace.dependencies]
-ndc-models = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.2.3" }
-ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs.git", rev = "e2a1aeb" }
+ndc-models = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.2.4" }
+ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs.git", rev = "v0.7.0" }
 ndc-test = { git = "https://github.com/hasura/ndc-spec.git", tag = "v0.2.3" }
 
 anyhow = "1"

--- a/crates/configuration/src/configuration.rs
+++ b/crates/configuration/src/configuration.rs
@@ -1,20 +1,19 @@
 //! Configuration for the connector.
 
-use std::path::Path;
-
-use query_engine_metadata::metadata;
-
+use crate::connect::SslInfo;
 use crate::environment::Environment;
 use crate::error::{
     MakeRuntimeConfigurationError, MultiError, ParseConfigurationError,
     WriteParsedConfigurationError,
 };
-use crate::values::{IsolationLevel, PoolSettings};
+use crate::values::{IsolationLevel, PoolSettings, Redacted};
 use crate::version3;
 use crate::version4;
 use crate::version5;
 use crate::VersionTag;
+use query_engine_metadata::metadata;
 use schemars::{gen::SchemaSettings, schema::RootSchema};
+use std::path::Path;
 
 pub fn generate_latest_schema() -> RootSchema {
     SchemaSettings::openapi3()
@@ -72,11 +71,22 @@ pub struct Configuration {
     pub metadata: metadata::Metadata,
     pub configuration_version_tag: VersionTag,
     pub pool_settings: PoolSettings,
-    pub connection_uri: String,
+    pub connection_settings: ConnectionSettings,
     pub isolation_level: IsolationLevel,
     pub mutations_version: Option<metadata::mutations::MutationsVersion>,
     pub mutations_prefix: Option<String>,
 }
+
+type ConnectionString = String;
+
+#[derive(Debug)]
+pub enum ConnectionSettings {
+    Static {
+        connection_uri: Redacted<ConnectionString>,
+        ssl: Redacted<SslInfo>,
+    },
+}
+
 pub async fn introspect(
     input: ParsedConfiguration,
     environment: impl Environment,

--- a/crates/configuration/src/lib.rs
+++ b/crates/configuration/src/lib.rs
@@ -12,14 +12,14 @@ pub mod version5;
 
 pub use configuration::{
     generate_latest_schema, introspect, make_runtime_configuration, parse_configuration,
-    upgrade_to_latest_version, write_parsed_configuration, Configuration, ParsedConfiguration,
-    DEFAULT_CONNECTION_URI_VARIABLE,
+    upgrade_to_latest_version, write_parsed_configuration, Configuration, ConnectionSettings,
+    ParsedConfiguration, DEFAULT_CONNECTION_URI_VARIABLE,
 };
-pub use values::{ConnectionUri, IsolationLevel, PoolSettings, Secret};
+pub use values::{ConnectionUri, IsolationLevel, PoolSettings, Redacted, Secret};
 
 pub use metrics::Metrics;
 
-pub use connect::get_connect_options;
+pub use connect::{get_connect_options, SslInfo};
 
 #[derive(Debug, Copy, Clone)]
 pub enum VersionTag {

--- a/crates/configuration/src/values/mod.rs
+++ b/crates/configuration/src/values/mod.rs
@@ -1,9 +1,11 @@
 mod isolation_level;
 mod pool_settings;
+mod redacted;
 mod secret;
 mod uri;
 
 pub use isolation_level::IsolationLevel;
 pub use pool_settings::PoolSettings;
+pub use redacted::Redacted;
 pub use secret::Secret;
 pub use uri::ConnectionUri;

--- a/crates/configuration/src/values/redacted.rs
+++ b/crates/configuration/src/values/redacted.rs
@@ -1,0 +1,28 @@
+use serde::Deserialize;
+
+/// A struct use to store sensitive information in configuration
+/// If printed out for any reason, will redact the inner value
+/// While we should not intentionally print out this information anyways, this is more of a safety measure that cannot hurt
+/// This also helps us mark the sensitive nature of the value.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+pub struct Redacted<T>(T);
+
+impl<T> Redacted<T> {
+    pub fn new(value: T) -> Self {
+        Self(value)
+    }
+
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+
+    pub fn inner(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> std::fmt::Debug for Redacted<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("[REDACTED]")
+    }
+}

--- a/crates/configuration/src/version4/to_runtime_configuration.rs
+++ b/crates/configuration/src/version4/to_runtime_configuration.rs
@@ -5,8 +5,11 @@ use std::collections::BTreeMap;
 
 use super::metadata;
 use super::ParsedConfiguration;
+use crate::configuration::ConnectionSettings;
+use crate::connect::read_ssl_info;
 use crate::environment::Environment;
 use crate::error::MakeRuntimeConfigurationError;
+use crate::values::Redacted;
 use crate::values::{ConnectionUri, Secret};
 use crate::VersionTag;
 
@@ -27,10 +30,18 @@ pub fn make_runtime_configuration(
             })
         }
     }?;
+    let connection_uri = Redacted::new(connection_uri);
+    let ssl = Redacted::new(read_ssl_info(&environment));
+
+    let connection_settings = ConnectionSettings::Static {
+        connection_uri,
+        ssl,
+    };
+
     Ok(crate::Configuration {
         metadata: convert_metadata(parsed_config.metadata),
         pool_settings: parsed_config.connection_settings.pool_settings,
-        connection_uri,
+        connection_settings,
         isolation_level: parsed_config.connection_settings.isolation_level,
         mutations_version: convert_mutations_version(parsed_config.mutations_version),
         configuration_version_tag: VersionTag::Version4,

--- a/crates/configuration/src/version5/mod.rs
+++ b/crates/configuration/src/version5/mod.rs
@@ -9,6 +9,7 @@ mod to_runtime_configuration;
 mod upgrade_from_v4;
 
 use ndc_models::{CollectionName, TypeName};
+use std::borrow::Cow;
 use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
 pub use to_runtime_configuration::make_runtime_configuration;
@@ -23,8 +24,10 @@ use tracing::{info_span, Instrument};
 
 use metadata::database;
 
+use crate::connect::read_ssl_info;
 use crate::environment::Environment;
 use crate::error::{ParseConfigurationError, WriteParsedConfigurationError};
+use crate::{ConnectionUri, Secret};
 
 const CONFIGURATION_FILENAME: &str = "configuration.json";
 const CONFIGURATION_JSONSCHEMA_FILENAME: &str = "schema.json";
@@ -135,8 +138,13 @@ pub async fn introspect(
     args: ParsedConfiguration,
     environment: impl Environment,
 ) -> anyhow::Result<ParsedConfiguration> {
-    let connect_options =
-        crate::get_connect_options(&args.connection_settings.connection_uri, environment)?;
+    let connection_uri = match &args.connection_settings.connection_uri {
+        ConnectionUri(Secret::Plain(value)) => Cow::Borrowed(value),
+        ConnectionUri(Secret::FromEnvironment { variable }) => {
+            Cow::Owned(environment.read(variable)?)
+        }
+    };
+    let connect_options = crate::get_connect_options(&connection_uri, &read_ssl_info(environment))?;
 
     let mut connection = PgConnection::connect_with(&connect_options)
         .instrument(info_span!("Connect to database"))

--- a/crates/configuration/src/version5/native_operations.rs
+++ b/crates/configuration/src/version5/native_operations.rs
@@ -10,6 +10,7 @@ use sqlx::Column;
 use sqlx::Connection;
 use sqlx::Executor;
 
+use crate::connect::read_ssl_info;
 use crate::environment::Environment;
 
 use super::metadata;
@@ -32,7 +33,7 @@ pub async fn create(
     operation_file_contents: &str,
 ) -> anyhow::Result<metadata::NativeQueryInfo> {
     let connect_options =
-        crate::get_connect_options(&crate::ConnectionUri::from(connection_string), environment)?;
+        crate::get_connect_options(connection_string, &read_ssl_info(environment))?;
     // Connect to the db.
     let mut connection = sqlx::PgConnection::connect_with(&connect_options).await?;
 
@@ -159,7 +160,7 @@ pub async fn oids_to_typenames(
     oids: &Vec<i64>,
 ) -> anyhow::Result<BTreeMap<i64, models::ScalarTypeName>> {
     let connect_options =
-        crate::get_connect_options(&crate::ConnectionUri::from(connection_string), environment)?;
+        crate::get_connect_options(connection_string, &read_ssl_info(environment))?;
     // Connect to the db.
     let mut connection = sqlx::PgConnection::connect_with(&connect_options)
         .instrument(info_span!("Connect to database"))

--- a/crates/connectors/ndc-postgres/src/mutation/explain.rs
+++ b/crates/connectors/ndc-postgres/src/mutation/explain.rs
@@ -40,12 +40,13 @@ pub async fn explain(
                 record::translation_error(&err, &state.query_metrics);
                 convert::translation_error_to_response(&err)
             })?;
+        let pool = state.pool_manager.acquire();
 
         // Execute an explain query.
         let results = async {
             query_engine_execution::mutation::explain(
-                &state.pool,
-                &state.database_info,
+                &pool.pool,
+                &pool.database_info,
                 &state.query_metrics,
                 plan,
             )

--- a/crates/connectors/ndc-postgres/src/query.rs
+++ b/crates/connectors/ndc-postgres/src/query.rs
@@ -6,6 +6,9 @@
 mod explain;
 pub use explain::explain;
 
+use query_engine_execution::database_info::DatabaseInfo;
+use query_engine_execution::metrics::Metrics;
+use sqlx::PgPool;
 use tracing::{info_span, Instrument};
 
 use ndc_sdk::connector;
@@ -47,11 +50,15 @@ pub async fn query(
         .instrument(info_span!("Plan query"))
         .await?;
 
+        let pool = state.pool_manager.acquire();
+
         let result = async {
-            execute_query(state, plan).await.map_err(|err| {
-                record::execution_error(&err, &state.query_metrics);
-                convert::execution_error_to_response(err)
-            })
+            execute_query(&pool.pool, &pool.database_info, &state.query_metrics, plan)
+                .await
+                .map_err(|err| {
+                    record::execution_error(&err, &state.query_metrics);
+                    convert::execution_error_to_response(err)
+                })
         }
         .instrument(info_span!("Execute query"))
         .await?;
@@ -77,15 +84,12 @@ fn plan_query(
 }
 
 async fn execute_query(
-    state: &state::State,
+    pool: &PgPool,
+    database_info: &DatabaseInfo,
+    query_metrics: &Metrics,
     plan: sql::execution_plan::ExecutionPlan<sql::execution_plan::Query>,
 ) -> Result<JsonResponse<models::QueryResponse>, query_engine_execution::error::Error> {
-    query_engine_execution::query::execute(
-        &state.pool,
-        &state.database_info,
-        &state.query_metrics,
-        plan,
-    )
-    .await
-    .map(JsonResponse::Serialized)
+    query_engine_execution::query::execute(pool, database_info, query_metrics, plan)
+        .await
+        .map(JsonResponse::Serialized)
 }

--- a/crates/connectors/ndc-postgres/src/query/explain.rs
+++ b/crates/connectors/ndc-postgres/src/query/explain.rs
@@ -39,12 +39,13 @@ pub async fn explain(
         }
         .instrument(info_span!("Plan query"))
         .await?;
+        let pool = state.pool_manager.acquire();
 
         // Execute an explain query.
         let (query, plan) = async {
             query_engine_execution::query::explain(
-                &state.pool,
-                &state.database_info,
+                &pool.pool,
+                &pool.database_info,
                 &state.query_metrics,
                 plan,
             )

--- a/crates/connectors/ndc-postgres/src/schema/mod.rs
+++ b/crates/connectors/ndc-postgres/src/schema/mod.rs
@@ -8,6 +8,7 @@ mod mutation;
 
 use std::collections::BTreeMap;
 
+use ndc_postgres_configuration::ConnectionSettings;
 use ndc_sdk::connector;
 use ndc_sdk::models;
 
@@ -418,12 +419,17 @@ pub fn get_schema(
             extraction_functions: BTreeMap::new(),
         });
 
+    let request_arguments = match config.connection_settings {
+        ConnectionSettings::Static { .. } => None,
+    };
+
     Ok(models::SchemaResponse {
         collections,
         procedures,
         functions: vec![],
         object_types,
         scalar_types,
+        request_arguments,
         capabilities: Some(models::CapabilitySchemaInfo {
             query: Some(models::QueryCapabilitiesSchemaInfo {
                 aggregates: Some(models::AggregateCapabilitiesSchemaInfo {

--- a/crates/connectors/ndc-postgres/src/state.rs
+++ b/crates/connectors/ndc-postgres/src/state.rs
@@ -2,75 +2,187 @@
 //!
 //! This is initialized on startup.
 
-use ndc_postgres_configuration::get_connect_options;
+use ndc_postgres_configuration::PoolSettings;
+use ndc_postgres_configuration::{get_connect_options, ConnectionSettings, Redacted, SslInfo};
 use percent_encoding::percent_decode_str;
+use query_engine_execution::database_info::{self, DatabaseInfo, DatabaseVersion};
+use query_engine_execution::metrics;
 use sqlx::postgres::{PgPool, PgPoolOptions, PgRow};
 use sqlx::{Connection, Row};
+use std::sync::Arc;
 use thiserror::Error;
 use tracing::{info_span, Instrument};
 use url::Url;
 
-use ndc_postgres_configuration::environment::Environment;
-use ndc_postgres_configuration::ConnectionUri;
-use ndc_postgres_configuration::PoolSettings;
-use query_engine_execution::database_info::{self, DatabaseInfo, DatabaseVersion};
-use query_engine_execution::metrics;
-
 /// State for our connector.
 #[derive(Debug)]
 pub struct State {
-    pub pool: PgPool,
-    pub database_info: DatabaseInfo,
+    pub pool_manager: PoolManager,
     pub query_metrics: metrics::Metrics,
     pub configuration_metrics: ndc_postgres_configuration::Metrics,
 }
 
+/// A connection pool bundled with database info and a unique index
+#[derive(Debug)]
+pub struct PoolContext {
+    pub pool: PgPool,
+    pub database_info: DatabaseInfo,
+    pub index: usize,
+}
+
+impl PoolContext {
+    /// Create a connection pool with default settings.
+    /// - <https://docs.rs/sqlx/latest/sqlx/pool/struct.PoolOptions.html>
+    async fn new(
+        connection_uri: &Redacted<String>,
+        ssl: &Redacted<SslInfo>,
+        pool_settings: &PoolSettings,
+        index: usize,
+    ) -> Result<Self, InitializationError> {
+        let connection_url: Url = connection_uri
+            .inner()
+            .parse()
+            .map_err(InitializationError::InvalidConnectionUri)?;
+
+        let pool = create_pool(connection_uri.inner(), ssl.inner(), pool_settings)
+            .instrument(info_span!(
+                "Create connection pool",
+                internal.visibility = "user",
+            ))
+            .await?;
+
+        let database_version = {
+            let mut connection = pool
+                .acquire()
+                .await
+                .map_err(InitializationError::UnableToConnect)?;
+            // Extract the database version string.
+            // If the query fails, just return `None` and don't worry about it.
+            let string = sqlx::query("SELECT version()")
+                .map(|row: PgRow| row.get::<String, _>(0))
+                .fetch_one(connection.as_mut())
+                .await
+                .ok();
+            // Extract the database version number.
+            let number = connection.server_version_num();
+            DatabaseVersion { string, number }
+        };
+        let database_info = parse_database_info(&connection_url, database_version);
+
+        Ok(Self {
+            pool,
+            database_info,
+            index,
+        })
+    }
+}
+
+/// A pool manager that possibly handles multiple connection pools
+#[derive(Debug)]
+pub enum PoolManager {
+    Static { pool: Arc<PoolContext> },
+}
+
+impl PoolManager {
+    /// Create our PoolManager
+    async fn new(
+        connection_settings: &ConnectionSettings,
+        pool_settings: &PoolSettings,
+    ) -> Result<Self, InitializationError> {
+        match connection_settings {
+            ConnectionSettings::Static {
+                connection_uri,
+                ssl,
+            } => Ok(Self::Static {
+                pool: Arc::new(PoolContext::new(connection_uri, ssl, pool_settings, 0).await?),
+            }),
+        }
+    }
+
+    /// Aquire a connection pool from the connection manager
+    /// The behavior depends on the configuration of dynamic connections
+    ///
+    /// Static mode:
+    /// The default, non-dynamic mode. This is active when the dynamic connection options are not set
+    /// In this mode, always return our one connection pool.
+    ///
+    /// Named mode:
+    /// When the named mode is configured, attempt to extract the connection name from the request arguments.
+    /// If we have a connection pool for the requested connection name, return it.
+    /// Else, check if the configuration includes a connection string for that name.
+    /// If so, create a connection pool using the connection string in configuration, and return it.
+    ///
+    /// If we don't have a connection string for the requested connection name, return an error.
+    ///
+    /// If the request does not include a connection name, check if we have a fallback pool, which we will if fallbackToStatic is set.
+    /// If we do, return the fallback pool. Else, error.
+    ///
+    /// Dynamic mode:
+    /// When dynamic connections are configured, attempt to extract the connection string from the request arguments.
+    /// If we have a connection pool for the requested connection string, return it.
+    /// Else, create a connection pool using the connection string provided in the request, and return it.
+    ///
+    /// If the request does not include a connection string, check if we have a fallback pool, which we will if fallbackToStatic is set.
+    /// If we do, return the fallback pool. Else, error.
+    pub fn acquire(&self) -> Arc<PoolContext> {
+        match self {
+            Self::Static { pool } => pool.clone(),
+        }
+    }
+
+    /// Update the pool options metrics for all pools
+    pub fn set_pool_options_metrics_all(&self, metrics: &metrics::Metrics) {
+        match self {
+            Self::Static { pool } => {
+                metrics.set_pool_options_metrics(pool.pool.options(), pool.index, "default");
+            }
+        }
+    }
+
+    /// Update the pool metrics for all pools
+    pub fn update_pool_metrics_all(&self, metrics: &metrics::Metrics) {
+        match self {
+            Self::Static { pool } => {
+                metrics.update_pool_metrics(&pool.pool, pool.index, "default");
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PoolAquisitionError {}
+
+#[derive(Debug, thiserror::Error)]
+pub enum LockError {
+    #[error("Lock poisoned")]
+    Poisoned,
+}
+
+impl<T> From<std::sync::PoisonError<T>> for LockError {
+    fn from(_: std::sync::PoisonError<T>) -> Self {
+        LockError::Poisoned
+    }
+}
+
 /// Create a connection pool and wrap it inside a connector State.
 pub async fn create_state(
-    connection_uri: &str,
-    environment: &impl Environment,
+    connection_settings: &ConnectionSettings,
     pool_settings: &PoolSettings,
     metrics_registry: &mut prometheus::Registry,
     version_tag: ndc_postgres_configuration::VersionTag,
 ) -> Result<State, InitializationError> {
-    let connection_url: Url = connection_uri
-        .parse()
-        .map_err(InitializationError::InvalidConnectionUri)?;
-    let pool = create_pool(connection_uri, environment, pool_settings)
-        .instrument(info_span!(
-            "Create connection pool",
-            internal.visibility = "user",
-        ))
-        .await?;
-
-    let database_version = {
-        let mut connection = pool
-            .acquire()
-            .await
-            .map_err(InitializationError::UnableToConnect)?;
-        // Extract the database version string.
-        // If the query fails, just return `None` and don't worry about it.
-        let string = sqlx::query("SELECT version()")
-            .map(|row: PgRow| row.get::<String, _>(0))
-            .fetch_one(connection.as_mut())
-            .await
-            .ok();
-        // Extract the database version number.
-        let number = connection.server_version_num();
-        DatabaseVersion { string, number }
-    };
-    let database_info = parse_database_info(&connection_url, database_version);
+    let pool_manager = PoolManager::new(connection_settings, pool_settings).await?;
 
     let (query_metrics, configuration_metrics) = async {
         let query_metrics_inner = metrics::Metrics::initialize(metrics_registry)
             .map_err(InitializationError::MetricsError)?;
-        query_metrics_inner.set_pool_options_metrics(pool.options());
+        pool_manager.set_pool_options_metrics_all(&query_metrics_inner);
 
         let configuration_metrics_inner =
             ndc_postgres_configuration::Metrics::initialize(metrics_registry)
                 .map_err(InitializationError::MetricsError)?;
 
-        Ok((query_metrics_inner, configuration_metrics_inner))
+        Ok::<_, InitializationError>((query_metrics_inner, configuration_metrics_inner))
     }
     .instrument(info_span!("Setup metrics"))
     .await?;
@@ -78,8 +190,7 @@ pub async fn create_state(
     configuration_metrics.set_configuration_version(version_tag);
 
     Ok(State {
-        pool,
-        database_info,
+        pool_manager,
         query_metrics,
         configuration_metrics,
     })
@@ -89,10 +200,10 @@ pub async fn create_state(
 /// - <https://docs.rs/sqlx/latest/sqlx/pool/struct.PoolOptions.html>
 async fn create_pool(
     connection_url: &str,
-    environment: impl Environment,
+    ssl: &SslInfo,
     pool_settings: &PoolSettings,
 ) -> Result<PgPool, InitializationError> {
-    let connect_options = get_connect_options(&ConnectionUri::from(connection_url), environment)
+    let connect_options = get_connect_options(connection_url, ssl)
         .map_err(InitializationError::InvalidConnectOptions)?;
 
     let pool_options = match pool_settings.check_connection_after_idle {
@@ -179,6 +290,8 @@ pub enum InitializationError {
     UnableToConnect(sqlx::Error),
     #[error("error initializing metrics: {0}")]
     MetricsError(prometheus::Error),
+    #[error("Failed to acquire lock: {0}")]
+    LockError(#[from] LockError),
 }
 
 #[cfg(test)]

--- a/crates/query-engine/execution/src/metrics.rs
+++ b/crates/query-engine/execution/src/metrics.rs
@@ -1,8 +1,7 @@
 //! Metrics setup and update for our connector.
 
+use prometheus::{GaugeVec, Histogram, HistogramTimer, IntCounter, IntGaugeVec, Registry};
 use std::time::Duration;
-
-use prometheus::{Gauge, Histogram, HistogramTimer, IntCounter, IntGauge, Registry};
 
 /// The collection of all metrics exposed through the `/metrics` endpoint.
 #[derive(Debug, Clone)]
@@ -17,14 +16,14 @@ pub struct Metrics {
     mutation_plan_time: Histogram,
     mutation_execution_time: Histogram,
     connection_acquisition_wait_time: Histogram,
-    pool_size: IntGauge,
-    pool_idle_count: IntGauge,
-    pool_active_count: IntGauge,
-    pool_max_connections: IntGauge,
-    pool_min_connections: IntGauge,
-    pool_acquire_timeout: Gauge,
-    pool_max_lifetime: Gauge,
-    pool_idle_timeout: Gauge,
+    pool_size: IntGaugeVec,
+    pool_idle_count: IntGaugeVec,
+    pool_active_count: IntGaugeVec,
+    pool_max_connections: IntGaugeVec,
+    pool_min_connections: IntGaugeVec,
+    pool_acquire_timeout: GaugeVec,
+    pool_max_lifetime: GaugeVec,
+    pool_idle_timeout: GaugeVec,
     pub error_metrics: ErrorMetrics,
 }
 
@@ -207,41 +206,68 @@ impl Metrics {
     // Set the metrics populated from the pool options.
     //
     // This only needs to be called once, as the options don't change.
-    pub fn set_pool_options_metrics(&self, pool_options: &sqlx::pool::PoolOptions<sqlx::Postgres>) {
+    pub fn set_pool_options_metrics(
+        &self,
+        pool_options: &sqlx::pool::PoolOptions<sqlx::Postgres>,
+        poolindex: usize,
+        poolname: &str,
+    ) {
+        let poolindex = poolindex.to_string();
+
+        let labels = &[poolindex.as_str(), poolname];
+
         let max_connections: i64 = pool_options.get_max_connections().into();
-        self.pool_max_connections.set(max_connections);
+        self.pool_max_connections
+            .with_label_values(labels)
+            .set(max_connections);
 
         let min_connections: i64 = pool_options.get_min_connections().into();
-        self.pool_min_connections.set(min_connections);
+        self.pool_min_connections
+            .with_label_values(labels)
+            .set(min_connections);
 
         let acquire_timeout: f64 = pool_options.get_acquire_timeout().as_secs_f64();
-        self.pool_acquire_timeout.set(acquire_timeout);
+        self.pool_acquire_timeout
+            .with_label_values(labels)
+            .set(acquire_timeout);
 
         // if nothing is set, return 0
         let idle_timeout: f64 = pool_options
             .get_idle_timeout()
             .unwrap_or(Duration::ZERO)
             .as_secs_f64();
-        self.pool_idle_timeout.set(idle_timeout);
+        self.pool_idle_timeout
+            .with_label_values(labels)
+            .set(idle_timeout);
 
         // if nothing is set, return 0
         let max_lifetime: f64 = pool_options
             .get_max_lifetime()
             .unwrap_or(Duration::ZERO)
             .as_secs_f64();
-        self.pool_max_lifetime.set(max_lifetime);
+        self.pool_max_lifetime
+            .with_label_values(labels)
+            .set(max_lifetime);
     }
 
     // Update all metrics fed from the database pool.
-    pub fn update_pool_metrics(&self, pool: &sqlx::PgPool) {
+    pub fn update_pool_metrics(&self, pool: &sqlx::PgPool, poolindex: usize, poolname: &str) {
+        let poolindex = poolindex.to_string();
+
+        let labels = &[poolindex.as_str(), poolname];
+
         let pool_size: i64 = pool.size().into();
-        self.pool_size.set(pool_size);
+        self.pool_size.with_label_values(labels).set(pool_size);
 
         let pool_idle: i64 = pool.num_idle().try_into().unwrap();
-        self.pool_idle_count.set(pool_idle);
+        self.pool_idle_count
+            .with_label_values(labels)
+            .set(pool_idle);
 
         let pool_active: i64 = pool_size - pool_idle;
-        self.pool_active_count.set(pool_active);
+        self.pool_active_count
+            .with_label_values(labels)
+            .set(pool_active);
     }
 }
 
@@ -256,23 +282,29 @@ fn add_int_counter_metric(
     register_collector(metrics_registry, int_counter)
 }
 
-/// Create a new int gauge metric and register it with the provided Prometheus Registry
+/// Create a new int gauge vector metric and register it with the provided Prometheus Registry
 fn add_int_gauge_metric(
     metrics_registry: &mut Registry,
     metric_name: &str,
     metric_description: &str,
-) -> Result<IntGauge, prometheus::Error> {
-    let int_gauge = IntGauge::with_opts(prometheus::Opts::new(metric_name, metric_description))?;
+) -> Result<IntGaugeVec, prometheus::Error> {
+    let int_gauge = IntGaugeVec::new(
+        prometheus::Opts::new(metric_name, metric_description),
+        &["poolindex", "poolname"],
+    )?;
     register_collector(metrics_registry, int_gauge)
 }
 
-/// Create a new gauge metric and register it with the provided Prometheus Registry
+/// Create a new gauge vector metric and register it with the provided Prometheus Registry
 fn add_gauge_metric(
     metrics_registry: &mut Registry,
     metric_name: &str,
     metric_description: &str,
-) -> Result<Gauge, prometheus::Error> {
-    let gauge = Gauge::with_opts(prometheus::Opts::new(metric_name, metric_description))?;
+) -> Result<GaugeVec, prometheus::Error> {
+    let gauge = GaugeVec::new(
+        prometheus::Opts::new(metric_name, metric_description),
+        &["poolindex", "poolname"],
+    )?;
     register_collector(metrics_registry, gauge)
 }
 

--- a/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/citus/snapshots/databases_tests__citus__schema_tests__schema_test__get_schema.snap
@@ -5826,5 +5826,6 @@ expression: result
         "count_scalar_type": "int8"
       }
     }
-  }
+  },
+  "request_arguments": null
 }

--- a/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/cockroach/snapshots/databases_tests__cockroach__schema_tests__schema_test__get_schema.snap
@@ -5344,5 +5344,6 @@ expression: result
         "count_scalar_type": "int8"
       }
     }
-  }
+  },
+  "request_arguments": null
 }

--- a/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
+++ b/crates/tests/databases-tests/src/postgres/snapshots/databases_tests__postgres__schema_tests__schema_test__get_schema.snap
@@ -12138,5 +12138,6 @@ expression: result
         "count_scalar_type": "int8"
       }
     }
-  }
+  },
+  "request_arguments": null
 }


### PR DESCRIPTION
This PR refactors state in preparation for dynamic connection pools. A brief list of changes follows:

- update ndc-models dependency to 0.2.4
- update ndc-sdk depndency to 0.7.0
- configuration.rs:  update runtime Configuration struct: replace connection_uri string with a ConnectionSettings enum, which will have a variant per connection pooling mode. For now it only has static, which is default and is the same as the existing behavior.
- normalize accessing the environment during startup:
  - previous behavior had us accessing the environment in two places:
    - when creating runtime configuration from parsed configuration, we would potentially read the env to get a connection string to store in configuration
    - when creating a connection pool while creating state, we would potentially read the env to get ssl information for pool creation
  - this becomes an issue for the upcoming feature allowing creating connection pools after startup.
  - therefore, we change the runtime configuration to include all information we may read from the env. Specifically ssl information is added there
  - as a result we change how pools are created, they now expect the ssl information instead of the environment (connect.rs)"
- we introduce the Redacted struct. This manually implements Display and Debug to show `[REDACTED]` for both. This is a safety feature in case our state gets printed somewhere. In theory this should never be relevant but no harm implemeting this.
- introduce PoolManager enum and PoolContext struct.
  - PoolManager is an abstraction that will handle the various connection modes. For now it onlys has the Static mode which is identical to current behavior. It is stored in the State.
  - a PoolContext can be aquired from the PoolManager. This contains a connection pool, and DatabaseInfo for the connection pool. (host, port, username to be put in traces)
  - the pool manager also has abstractions for updating metrics for (potentially multiple) connection pools
- refactor pool metrics to be labeled
  - given we can now have multiple connection pools, pools metrics are now labeled so we can track metrics for each individual connection pool

