### PR TITLE
Revert release 2.2.0, add changelog note about requiring introspection after update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "databases-tests"
-version = "2.2.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-postgres"
-version = "2.2.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1818,7 +1818,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-postgres-cli"
-version = "2.2.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "build-data",
@@ -1833,7 +1833,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-postgres-configuration"
-version = "2.2.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2092,7 +2092,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openapi-generator"
-version = "2.2.0"
+version = "2.1.1"
 dependencies = [
  "ndc-postgres-configuration",
  "serde_json",
@@ -2450,7 +2450,7 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "query-engine-execution"
-version = "2.2.0"
+version = "2.1.1"
 dependencies = [
  "bytes",
  "ndc-models 0.2.4",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "query-engine-metadata"
-version = "2.2.0"
+version = "2.1.1"
 dependencies = [
  "ndc-models 0.2.4",
  "smol_str",
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "query-engine-sql"
-version = "2.2.0"
+version = "2.1.1"
 dependencies = [
  "ndc-models 0.2.4",
  "schemars",
@@ -2483,7 +2483,7 @@ dependencies = [
 
 [[package]]
 name = "query-engine-translation"
-version = "2.2.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "tests-common"
-version = "2.2.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 
-package.version = "2.2.0"
+package.version = "2.1.1"
 package.edition = "2021"
 package.license = "Apache-2.0"
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,14 +4,6 @@
 
 ### Added
 
-### Changed
-
-### Fixed
-
-## [v2.2.0] - 2025-07-02
-
-### Added
-
 - Added support for dynamic database connections, allowing:
   - Named connections: Configure multiple connection URIs that can be selected at request time using the `connection_name` argument
   - Dynamic connections: Accept arbitrary connection strings at request time using the `connection_string` argument
@@ -19,6 +11,8 @@
   - For Named connections: Option to eagerly pre-create all connection pools at startup instead of creating them on-demand
 
 ### Changed
+
+- Updated to ndc models v2. Updating to this connector version will require re-introspection as the ndc schema and capabilities will be different
 
 ### Fixed
 
@@ -412,8 +406,7 @@ Initial release.
 
 <!-- end -->
 
-[Unreleased]: https://github.com/hasura/ndc-postgres/compare/v2.2.0...HEAD
-[v2.2.0]: https://github.com/hasura/ndc-postgres/releases/tag/v2.2.0
+[Unreleased]: https://github.com/hasura/ndc-postgres/compare/v2.1.1...HEAD
 [v2.1.1]: https://github.com/hasura/ndc-postgres/releases/tag/v2.1.1
 [v2.1.0]: https://github.com/hasura/ndc-postgres/releases/tag/v2.1.0
 [v2.0.0]: https://github.com/hasura/ndc-postgres/releases/tag/v2.0.0


### PR DESCRIPTION
Revert the release of v2.2.0, as we've decided we want to do a major version bump instead.