### PR TITLE
Upload ci artifact so it can be used in next step

### DIFF
--- a/.github/workflows/ship.yaml
+++ b/.github/workflows/ship.yaml
@@ -258,6 +258,12 @@ jobs:
       - name: generate a connector package definition
         run: ./ci/connector-package-definition.sh "${GITHUB_REF_NAME}"
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: connector-definition.tgz
+          path: ./release/artifacts/connector-definition.tgz
+          compression-level: 0 # Already compressed
+
       - name: create a release
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
We had a bug where the reate-ndc-hub-pr: job would failt to find the connector-definition.tgz artifact, because we never uploaded it.

This PR adds that step.