### PR TITLE
for some reason envsubst uses longform options with a single dash. Why?

### DIFF
--- a/ci/connector-package-definition.sh
+++ b/ci/connector-package-definition.sh
@@ -33,7 +33,7 @@ export MACOS_ARM64_SHA256=$(sha256sum ${RELEASE_DIR}/artifacts/ndc-postgres-cli-
 # add the connector metadata from template
 mkdir -p ${RELEASE_DIR}/package/.hasura-connector
 # Use a limited set of variables to substitute with envsubst
-envsubst --no-unset --no-empty '${RELEASE_VERSION}${LINUX_AMD64_SHA256}${MACOS_AMD64_SHA256}${WINDOWS_AMD64_SHA256}${LINUX_ARM64_SHA256}${MACOS_ARM64_SHA256}' < ci/templates/connector-metadata.yaml > ${RELEASE_DIR}/package/.hasura-connector/connector-metadata.yaml
+envsubst -no-unset -no-empty '${RELEASE_VERSION}${LINUX_AMD64_SHA256}${MACOS_AMD64_SHA256}${WINDOWS_AMD64_SHA256}${LINUX_ARM64_SHA256}${MACOS_ARM64_SHA256}' < ci/templates/connector-metadata.yaml > ${RELEASE_DIR}/package/.hasura-connector/connector-metadata.yaml
 
 # create a tarball of the package definition
 tar vczf ${RELEASE_DIR}/artifacts/connector-definition.tgz -C ${RELEASE_DIR}/package .

--- a/ci/create-hub-release-pr.sh
+++ b/ci/create-hub-release-pr.sh
@@ -37,7 +37,7 @@ git checkout -b $BRANCH_NAME
 
 # create new connector definition
 mkdir -p "${ROOT}/${NDC_HUB_DIR}/registry/hasura/postgres/releases/$RELEASE_VERSION"
-envsubst --no-unset --no-empty '${RELEASE_VERSION}${RELEASE_HASH}${CONNECTOR_DEFINITION_HASH}' < "${ROOT}/${NDC_POSTGRES_DIR}/ci/templates/connector-packaging.json" > "${ROOT}/${NDC_HUB_DIR}/registry/hasura/postgres/releases/$RELEASE_VERSION/connector-packaging.json"
+envsubst -no-unset -no-empty '${RELEASE_VERSION}${RELEASE_HASH}${CONNECTOR_DEFINITION_HASH}' < "${ROOT}/${NDC_POSTGRES_DIR}/ci/templates/connector-packaging.json" > "${ROOT}/${NDC_HUB_DIR}/registry/hasura/postgres/releases/$RELEASE_VERSION/connector-packaging.json"
 
 # modify metadata file to add new entry
 jq --arg RELEASE_VERSION "$RELEASE_VERSION" '.overview.latest_version = $RELEASE_VERSION' "${ROOT}/${NDC_HUB_DIR}/registry/hasura/postgres/metadata.json" |


### PR DESCRIPTION
I introduced a bug when adding the `--no-unset` and `--no-empty` envsubst options. Turns out, they are called `-no-unset` and `-no-empty`  