### PR TITLE
fix extension of cli plugin url: we use gnu! Not musl!

### DIFF
--- a/ci/connector-package-definition.sh
+++ b/ci/connector-package-definition.sh
@@ -24,10 +24,10 @@ chmod +x ./${RELEASE_DIR}/artifacts/ndc-postgres-cli-*
 
 # export env vars for templating
 export RELEASE_VERSION="$RELEASE_VERSION"
-export LINUX_AMD64_SHA256=$(sha256sum ${RELEASE_DIR}/artifacts/ndc-postgres-cli-x86_64-unknown-linux-musl     | cut -f1 -d' ')
+export LINUX_AMD64_SHA256=$(sha256sum ${RELEASE_DIR}/artifacts/ndc-postgres-cli-x86_64-unknown-linux-gnu      | cut -f1 -d' ')
 export MACOS_AMD64_SHA256=$(sha256sum ${RELEASE_DIR}/artifacts/ndc-postgres-cli-x86_64-apple-darwin           | cut -f1 -d' ')
 export WINDOWS_AMD64_SHA256=$(sha256sum ${RELEASE_DIR}/artifacts/ndc-postgres-cli-x86_64-pc-windows-msvc.exe  | cut -f1 -d' ')
-export LINUX_ARM64_SHA256=$(sha256sum ${RELEASE_DIR}/artifacts/ndc-postgres-cli-aarch64-unknown-linux-musl    | cut -f1 -d' ')
+export LINUX_ARM64_SHA256=$(sha256sum ${RELEASE_DIR}/artifacts/ndc-postgres-cli-aarch64-unknown-linux-gnu     | cut -f1 -d' ')
 export MACOS_ARM64_SHA256=$(sha256sum ${RELEASE_DIR}/artifacts/ndc-postgres-cli-aarch64-apple-darwin          | cut -f1 -d' ')
 
 # add the connector metadata from template

--- a/ci/templates/connector-metadata.yaml
+++ b/ci/templates/connector-metadata.yaml
@@ -26,7 +26,7 @@ cliPlugin:
       sha256: "${MACOS_ARM64_SHA256}"
       bin: "hasura-ndc-postgres"
     - selector: linux-arm64
-      uri: "https://github.com/hasura/ndc-postgres/releases/download/${RELEASE_VERSION}/ndc-postgres-cli-aarch64-unknown-linux-musl"
+      uri: "https://github.com/hasura/ndc-postgres/releases/download/${RELEASE_VERSION}/ndc-postgres-cli-aarch64-unknown-linux-gnu"
       sha256: "${LINUX_ARM64_SHA256}"
       bin: "hasura-ndc-postgres"
     - selector: darwin-amd64
@@ -38,7 +38,7 @@ cliPlugin:
       sha256: "${WINDOWS_AMD64_SHA256}"
       bin: "hasura-ndc-postgres.exe"
     - selector: linux-amd64
-      uri: "https://github.com/hasura/ndc-postgres/releas es/download/${RELEASE_VERSION}/ndc-postgres-cli-x86_64-unknown-linux-musl"
+      uri: "https://github.com/hasura/ndc-postgres/releases/download/${RELEASE_VERSION}/ndc-postgres-cli-x86_64-unknown-linux-gnu"
       sha256: "${LINUX_AMD64_SHA256}"
       bin: "hasura-ndc-postgres"
 dockerComposeWatch:

--- a/ci/templates/connector-packaging.json
+++ b/ci/templates/connector-packaging.json
@@ -7,5 +7,8 @@
   },
   "source": {
     "hash": "$RELEASE_HASH"
+  },
+  "test": {
+    "test_config_path": "../../tests/test-config.json"
   }
 }


### PR DESCRIPTION
Fix two bugs in ci:
- was missing reference to connector tests in connector packaging
- url for linux distributions was wrong! We use gnu not musl
- that bug also affected ability to get sha sum