### PR TITLE
Revert CI product to match previous behavior

### DIFF
--- a/.github/workflows/ship.yaml
+++ b/.github/workflows/ship.yaml
@@ -270,6 +270,7 @@ jobs:
           draft: false
           bodyFile: release/notes.md
           artifacts: release/artifacts/*
+
   create-ndc-hub-pr:
     name: Create NDC-Hub Release PR
     needs:
@@ -291,10 +292,20 @@ jobs:
           path: ndc-hub
           token: ${{ secrets.HASURA_BOT_TOKEN }}
 
+      - name: check out cli-plugins-index
+        uses: actions/checkout@v4
+        with:
+          repository: hasura/cli-plugins-index
+          path: cli-plugins-index
+          token: ${{ secrets.HASURA_BOT_TOKEN }}
+
       - uses: actions/download-artifact@v4
         with:
           path: release/artifacts
           merge-multiple: true
+
+      - name: create cli-plugins-index PR
+        run: ./ndc-postgres/ci/create-cli-plugins-index-pr.sh "${GITHUB_REF_NAME}" ndc-postgres cli-plugins-index
 
       - name: create ndc-hub PR
         run: ./ndc-postgres/ci/create-hub-release-pr.sh "${GITHUB_REF_NAME}" "ndc-postgres" "ndc-hub"

--- a/ci/connector-package-definition.sh
+++ b/ci/connector-package-definition.sh
@@ -24,16 +24,11 @@ chmod +x ./${RELEASE_DIR}/artifacts/ndc-postgres-cli-*
 
 # export env vars for templating
 export RELEASE_VERSION="$RELEASE_VERSION"
-export LINUX_AMD64_SHA256=$(sha256sum ${RELEASE_DIR}/artifacts/ndc-postgres-cli-x86_64-unknown-linux-gnu      | cut -f1 -d' ')
-export MACOS_AMD64_SHA256=$(sha256sum ${RELEASE_DIR}/artifacts/ndc-postgres-cli-x86_64-apple-darwin           | cut -f1 -d' ')
-export WINDOWS_AMD64_SHA256=$(sha256sum ${RELEASE_DIR}/artifacts/ndc-postgres-cli-x86_64-pc-windows-msvc.exe  | cut -f1 -d' ')
-export LINUX_ARM64_SHA256=$(sha256sum ${RELEASE_DIR}/artifacts/ndc-postgres-cli-aarch64-unknown-linux-gnu     | cut -f1 -d' ')
-export MACOS_ARM64_SHA256=$(sha256sum ${RELEASE_DIR}/artifacts/ndc-postgres-cli-aarch64-apple-darwin          | cut -f1 -d' ')
 
 # add the connector metadata from template
 mkdir -p ${RELEASE_DIR}/package/.hasura-connector
 # Use a limited set of variables to substitute with envsubst
-envsubst '${RELEASE_VERSION}${LINUX_AMD64_SHA256}${MACOS_AMD64_SHA256}${WINDOWS_AMD64_SHA256}${LINUX_ARM64_SHA256}${MACOS_ARM64_SHA256}' < ci/templates/connector-metadata.yaml > ${RELEASE_DIR}/package/.hasura-connector/connector-metadata.yaml
+envsubst '${RELEASE_VERSION}' < ci/templates/connector-metadata.yaml > ${RELEASE_DIR}/package/.hasura-connector/connector-metadata.yaml
 
 # create a tarball of the package definition
-tar vczf ${RELEASE_DIR}/artifacts/connector-definition.tgz -C ${RELEASE_DIR}/package .
+tar vczf ${RELEASE_DIR}/artifacts/package.tar.gz -C ${RELEASE_DIR}/package .

--- a/ci/create-cli-plugins-index-pr.sh
+++ b/ci/create-cli-plugins-index-pr.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -evo pipefail
+trap 'echo "Error occurred at line $LINENO: $BASH_COMMAND";' ERR
+
+# Parse command line arguments
+RELEASE_VERSION="${1:-}"
+NDC_POSTGRES_DIR="${2:-ndc-postgres}"
+CLI_PLUGINS_INDEX_DIR="${3:-cli-plugins-index}"
+
+# Check if required parameters are provided
+if [ -z "$RELEASE_VERSION" ]; then
+  echo "Usage: $0 <release_version> [ndc_postgres_dir] [cli_plugins_index_dir]"
+  echo "  release_version: The version number (e.g., v1.2.3)"
+  echo "  ndc_postgres_dir: Path to ndc-postgres directory (default: ndc-postgres)"
+  echo "  cli_plugins_index_dir: Path to cli-plugins-index directory (default: cli-plugins-index)"
+  exit 1
+fi
+
+ROOT="$(pwd)"
+
+# Branch name for the PR
+BRANCH_NAME="ndc-postgres/release-$RELEASE_VERSION"
+
+# Get the commit hash from the ndc-postgres repository
+RELEASE_HASH="$(cd $NDC_POSTGRES_DIR && git rev-parse HEAD)"
+
+# Calculate SHA256 hashes from the artifacts
+export RELEASE_VERSION="$RELEASE_VERSION"
+export LINUX_AMD64_SHA256=$(sha256sum ${ROOT}/release/artifacts/ndc-postgres-cli-x86_64-unknown-linux-gnu      | cut -f1 -d' ')
+export MACOS_AMD64_SHA256=$(sha256sum ${ROOT}/release/artifacts/ndc-postgres-cli-x86_64-apple-darwin           | cut -f1 -d' ')
+export WINDOWS_AMD64_SHA256=$(sha256sum ${ROOT}/release/artifacts/ndc-postgres-cli-x86_64-pc-windows-msvc.exe  | cut -f1 -d' ')
+export LINUX_ARM64_SHA256=$(sha256sum ${ROOT}/release/artifacts/ndc-postgres-cli-aarch64-unknown-linux-gnu     | cut -f1 -d' ')
+export MACOS_ARM64_SHA256=$(sha256sum ${ROOT}/release/artifacts/ndc-postgres-cli-aarch64-apple-darwin          | cut -f1 -d' ')
+
+# Change working directory to the target folder
+cd $CLI_PLUGINS_INDEX_DIR
+
+git config --global user.name "hasura-bot"
+git config --global user.email "accounts@hasura.io"
+
+# Create a new feature branch for the changes.
+git checkout -b $BRANCH_NAME
+
+# Create directory for the new version
+mkdir -p "plugins/ndc-postgres/$RELEASE_VERSION"
+
+# Generate the manifest file using the template and envsubst
+envsubst '${RELEASE_VERSION}${LINUX_AMD64_SHA256}${MACOS_AMD64_SHA256}${WINDOWS_AMD64_SHA256}${LINUX_ARM64_SHA256}${MACOS_ARM64_SHA256}' < "${ROOT}/${NDC_POSTGRES_DIR}/ci/templates/manifest.yaml" > "${ROOT}/${CLI_PLUGINS_INDEX_DIR}/plugins/ndc-postgres/$RELEASE_VERSION/manifest.yaml"
+
+git add .
+git commit -m "Release Postgres $RELEASE_VERSION"
+git push origin $BRANCH_NAME --force
+
+# create a pull-requests containing the updates.
+gh pr create \
+  --body "Commit in ndc-postgres: https://github.com/hasura/ndc-postgres/commit/$RELEASE_HASH" \
+  --title "Release Postgres $RELEASE_VERSION" \
+  --head "$BRANCH_NAME" \
+  --base "master"

--- a/ci/templates/connector-metadata.yaml
+++ b/ci/templates/connector-metadata.yaml
@@ -19,28 +19,9 @@ supportedEnvironmentVariables:
 commands:
   update: hasura-ndc-postgres update
 cliPlugin:
-  type: BinaryInline
-  platforms:
-    - selector: darwin-arm64
-      uri: "https://github.com/hasura/ndc-postgres/releases/download/${RELEASE_VERSION}/ndc-postgres-cli-aarch64-apple-darwin"
-      sha256: "${MACOS_ARM64_SHA256}"
-      bin: "hasura-ndc-postgres"
-    - selector: linux-arm64
-      uri: "https://github.com/hasura/ndc-postgres/releases/download/${RELEASE_VERSION}/ndc-postgres-cli-aarch64-unknown-linux-gnu"
-      sha256: "${LINUX_ARM64_SHA256}"
-      bin: "hasura-ndc-postgres"
-    - selector: darwin-amd64
-      uri: "https://github.com/hasura/ndc-postgres/releases/download/${RELEASE_VERSION}/ndc-postgres-cli-x86_64-apple-darwin"
-      sha256: "${MACOS_AMD64_SHA256}"
-      bin: "hasura-ndc-postgres"
-    - selector: windows-amd64
-      uri: "https://github.com/hasura/ndc-postgres/releases/download/${RELEASE_VERSION}/ndc-postgres-cli-x86_64-pc-windows-msvc.exe"
-      sha256: "${WINDOWS_AMD64_SHA256}"
-      bin: "hasura-ndc-postgres.exe"
-    - selector: linux-amd64
-      uri: "https://github.com/hasura/ndc-postgres/releases/download/${RELEASE_VERSION}/ndc-postgres-cli-x86_64-unknown-linux-gnu"
-      sha256: "${LINUX_AMD64_SHA256}"
-      bin: "hasura-ndc-postgres"
+  type: Binary
+  name: ndc-postgres
+  version: ${RELEASE_VERSION}
 dockerComposeWatch:
   - path: ./
     target: /etc/connector

--- a/ci/templates/connector-packaging.json
+++ b/ci/templates/connector-packaging.json
@@ -1,6 +1,6 @@
 {
   "version": "$RELEASE_VERSION",
-  "uri": "https://github.com/hasura/ndc-postgres/releases/download/$RELEASE_VERSION/connector-definition.tgz",
+  "uri": "https://github.com/hasura/ndc-postgres/releases/download/$RELEASE_VERSION/package.tar.gz",
   "checksum": {
     "type": "sha256",
     "value": "$CONNECTOR_DEFINITION_HASH"

--- a/ci/templates/manifest.yaml
+++ b/ci/templates/manifest.yaml
@@ -1,0 +1,40 @@
+name: ndc-postgres
+version: ${RELEASE_VERSION}
+shortDescription: CLI plugin for Hasura ndc-postgres
+homepage: https://hasura.io/connectors/postgres
+platforms:
+  - selector: darwin-arm64
+    uri: https://github.com/hasura/ndc-postgres/releases/download/${RELEASE_VERSION}/ndc-postgres-cli-aarch64-apple-darwin
+    sha256: ${MACOS_ARM64_SHA256}
+    bin: hasura-ndc-postgres
+    files:
+      - from: ./ndc-postgres-cli-aarch64-apple-darwin
+        to: hasura-ndc-postgres
+  - selector: linux-arm64
+    uri: https://github.com/hasura/ndc-postgres/releases/download/${RELEASE_VERSION}/ndc-postgres-cli-aarch64-unknown-linux-gnu
+    sha256: ${LINUX_ARM64_SHA256}
+    bin: hasura-ndc-postgres
+    files:
+      - from: ./ndc-postgres-cli-aarch64-unknown-linux-gnu
+        to: hasura-ndc-postgres
+  - selector: darwin-amd64
+    uri: https://github.com/hasura/ndc-postgres/releases/download/${RELEASE_VERSION}/ndc-postgres-cli-x86_64-apple-darwin
+    sha256: ${MACOS_AMD64_SHA256}
+    bin: hasura-ndc-postgres
+    files:
+      - from: ./ndc-postgres-cli-x86_64-apple-darwin
+        to: hasura-ndc-postgres
+  - selector: windows-amd64
+    uri: https://github.com/hasura/ndc-postgres/releases/download/${RELEASE_VERSION}/ndc-postgres-cli-x86_64-pc-windows-msvc.exe
+    sha256: ${WINDOWS_AMD64_SHA256}
+    bin: hasura-ndc-postgres.exe
+    files:
+      - from: ./ndc-postgres-cli-x86_64-pc-windows-msvc.exe
+        to: hasura-ndc-postgres.exe
+  - selector: linux-amd64
+    uri: https://github.com/hasura/ndc-postgres/releases/download/${RELEASE_VERSION}/ndc-postgres-cli-x86_64-unknown-linux-gnu
+    sha256: ${LINUX_AMD64_SHA256}
+    bin: hasura-ndc-postgres
+    files:
+      - from: ./ndc-postgres-cli-x86_64-unknown-linux-gnu
+        to: hasura-ndc-postgres


### PR DESCRIPTION
we've overhauled CI to automate the release process.

Along the way, I decided to inline the manifest to the connector definition, because using cli-plugins-index for that purpose is now deprecated.

This PR changes the overhauled CI to produce the exact same output as we did before, specifically:
- the cli plugin information is no longer in the connector metadata
- the connector definition archive name reverts to `package.tar.gz`
- we add another script to generate a PR on the cli plugins index repo