### PR TITLE
update aliased connectors in hub PR

### DIFF
--- a/ci/create-hub-release-pr.sh
+++ b/ci/create-hub-release-pr.sh
@@ -45,6 +45,25 @@ jq --arg RELEASE_VERSION "$RELEASE_VERSION" --arg RELEASE_HASH "$RELEASE_HASH" '
 
 mv metadata.tmp.json "${ROOT}/${NDC_HUB_DIR}/registry/hasura/postgres/metadata.json"
 
+# Update each ndc-postgres aliased connector variant
+for variant in \
+    'aurora' \
+    'citus' \
+    'cockroach' \
+    'neon' \
+    'postgres-alloydb' \
+    'postgres-azure' \
+    'postgres-cosmos' \
+    'postgres-gcp' \
+    'postgres-timescaledb' ; do
+
+jq --arg RELEASE_VERSION "$RELEASE_VERSION" '.overview.latest_version = $RELEASE_VERSION' "${ROOT}/${NDC_HUB_DIR}/registry/hasura/postgres/aliased_connectors/${variant}/metadata.json" |
+jq --arg RELEASE_VERSION "$RELEASE_VERSION" --arg RELEASE_HASH "$RELEASE_HASH" '.source_code.version |= [{tag: $RELEASE_VERSION, hash: $RELEASE_HASH, is_verified: true}] + .' > metadata.tmp.json
+
+mv metadata.tmp.json "${ROOT}/${NDC_HUB_DIR}/registry/hasura/postgres/aliased_connectors/${variant}/metadata.json"
+
+done
+
 git add .
 git commit -m "Release Postgres $RELEASE_VERSION"
 git push origin $BRANCH_NAME --force


### PR DESCRIPTION
When creating the hub pr, we update the metadata.json file for postgres.

Turns out, postgres is aliased to a bunch of other names, and these all have their own metadata file.

This PR updates the script that creates the hub PR, to also update these additional metadata files